### PR TITLE
feat: 支持 @ 引用 Rule 规则

### DIFF
--- a/web/src/components/at-mention-new/AtCommandPalette.tsx
+++ b/web/src/components/at-mention-new/AtCommandPalette.tsx
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { AtCategory, AtCategoryId, AtItem, SearchResult, SearchScope } from "@/types/at";
 import { AT_CATEGORIES, searchAtItems, getCategoryById } from "@/lib/atSearch";
 import { CaretPosition } from "./caret";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import { FolderOpen, Folder, File, Puzzle, Tag, BadgeCheck, ChevronRight, Search as SearchIcon } from "lucide-react";
-import { FileText, FolderOpenDot } from "lucide-react";
+import { FolderOpen, Folder, File, Puzzle, Tag, BadgeCheck, ChevronRight, FileText, FolderOpenDot, ScrollText } from "lucide-react";
 
 // 图标解析：基于字符串名称返回具体图标
 function IconByName({ name, className }: { name?: string; className?: string }) {
@@ -21,6 +19,7 @@ function IconByName({ name, className }: { name?: string; className?: string }) 
     Puzzle: <Puzzle className={className} />,
     Tag: <Tag className={className} />,
     BadgeCheck: <BadgeCheck className={className} />,
+    ScrollText: <ScrollText className={className} />,
     // 新增更具区分度的文件和文件夹图标
     FolderOpenDot: <FolderOpenDot className={className} />,
     FileText: <FileText className={className} />,
@@ -243,4 +242,3 @@ export default function AtCommandPalette(props: AtCommandPaletteProps) {
     </div>
   );
 }
-

--- a/web/src/components/at-mention-new/CommandInputWithAt.tsx
+++ b/web/src/components/at-mention-new/CommandInputWithAt.tsx
@@ -244,10 +244,10 @@ export function AtInput({ value, onValueChange, winRoot, projectName, projectPat
     const caret = (el.selectionStart as number) ?? String(value || "").length;
     const left = value.slice(0, caret);
     const at = left.lastIndexOf("@");
-    // WSL 路径插入：文件/目录返回“`WSL 相对路径`”样式（两侧带反引号，/ 分隔）；规则等其它类别按标题插入
+    // WSL 路径插入：文件、规则返回路径（用反引号包裹）；其它类别按标题插入
     let insertText = item.title;
     try {
-      if (item.categoryId === 'files') {
+      if (item.categoryId === 'files' || item.categoryId === 'rule') {
         const relOrPath = String((item as any).path || (item as any).subtitle || item.title || "");
         const isRel = !/^\//.test(relOrPath) && !/^([a-zA-Z]):\\/.test(relOrPath) && !/^\\\\/.test(relOrPath);
         const wsl = (projectPathStyle === 'absolute' && isRel && winRoot)

--- a/web/src/types/at.ts
+++ b/web/src/types/at.ts
@@ -36,6 +36,8 @@ export interface RuleItem extends AtItemBase {
   categoryId: "rule";
   /** 所属分组（示例：IDC、Lint 等） */
   group?: string;
+  /** 规则文件的相对路径或完整路径（如 .cursor/index.mdc） */
+  path?: string;
 }
 
 export type AtItem = FileItem | RuleItem;


### PR DESCRIPTION
## 概述
- 支持 @ 搜索自动识别 `.cursor/index.mdc`、`.cursor/rules/*.mdc`、`.cursorrules` 等规则文件并展示为 Rules 分类
- 选中规则后插入实际路径并生成 ScrollText 图标的 Chip,统一文件/规则的路径处理
- 调整相关 UI 组件,移除旧的规则 Mock 数据