### PR TITLE
feat: 新增 Agent 完成后自动刷新 Codex 用量

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,6 +38,7 @@ import {
 } from "lucide-react";
 import AboutSupport from "@/components/about-support";
 import CodexUsageSummary from "@/components/topbar/codex-status";
+import { emitCodexRateRefresh } from "@/lib/codex-status";
 import { checkForUpdate, type UpdateCheckErrorType } from "@/lib/about";
 import { createTerminalAdapter, type TerminalAdapterAPI } from "@/adapters/TerminalAdapter";
 import TerminalManager from "@/lib/TerminalManager";
@@ -1084,6 +1085,8 @@ export default function CodexFlowManagerUI() {
     }
     showCompletionNotification(tabId, preview);
     void playCompletionChime();
+    // 无论通知开关如何，均请求刷新 Codex 用量（由顶部栏组件自行做 1 分钟冷却）
+    try { emitCodexRateRefresh('agent-complete'); } catch {}
   }
 
   function processPtyNotificationChunk(ptyId: string, chunk: string) {

--- a/web/src/lib/codex-status.ts
+++ b/web/src/lib/codex-status.ts
@@ -244,3 +244,14 @@ export function translateRateLimitError(raw: unknown, t: TFunction): string {
     fallbackDefault: "无法获取速率限制",
   });
 }
+
+// 触发 Codex 用量刷新（渲染进程全局事件）
+// 说明：终端任务完成后会派发本事件；顶部栏用量组件监听并在 1 分钟冷却后触发刷新。
+export const CODEX_RATE_REFRESH_EVENT = "codex:rate-refresh-request";
+export type CodexRateRefreshDetail = { source?: string };
+export function emitCodexRateRefresh(source?: string): void {
+  try {
+    const detail: CodexRateRefreshDetail | undefined = source ? { source } : undefined;
+    window.dispatchEvent(new CustomEvent<CodexRateRefreshDetail>(CODEX_RATE_REFRESH_EVENT as any, { detail } as any));
+  } catch {}
+}


### PR DESCRIPTION
- 在 App.tsx 的 Agent 任务完成回调中触发用量刷新事件
- 在顶部栏 CodexUsageSummary 组件中监听刷新事件，带 1 分钟冷却
- 新增 codex-status.ts 工具函数 emitCodexRateRefresh 用于派发事件
- 无论通知开关状态如何，均会请求刷新（组件自行做冷却控制）

这样用户在 Agent 完成任务后能及时看到最新的 Codex 用量消耗情况。