### PR TITLE
feat: 统一调试配置机制到 debug.config.jsonc

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,15 +1,11 @@
-# 诊断日志开关与定位指南
+# 诊断日志开关与定位指南（已统一到 debug.config.jsonc）
 
-为便于定位白屏/加载失败等问题，我们提供“可开可关”的诊断日志。
+自 vNext 起，所有诊断/调试开关已收敛到 `%APPDATA%/codexflow/debug.config.jsonc`：
 
-## 开关
+- 主进程/渲染诊断：`global.diagLog: true`
+- 启动强制打开 DevTools：`global.openDevtools: true`
 
-- 主进程：设置环境变量开启（默认关闭）
-  - Windows PowerShell: `$env:CODEX_DIAG_LOG='1'; npm run dev`
-  - CMD: `set CODEX_DIAG_LOG=1 && npm run dev`
-- 渲染进程：本地存储开关（默认关闭）
-  - 在 DevTools 中执行：`localStorage.setItem('CF_DIAG_LOG','1')`
-  - 关闭：`localStorage.removeItem('CF_DIAG_LOG')`
+保存后主进程会热加载并广播，少数标注“需重启”的项在下次启动生效。
 
 ## 日志位置
 
@@ -20,5 +16,5 @@
   - `[WC.console] ...`（渲染端 console 输出）
   - `[renderer:error]` / `[renderer:unhandledrejection]`
 
-> 生产打包默认关闭详细日志；必要时设置主进程环境变量启用。
+> 生产打包默认关闭详细日志；可在 debug.config.jsonc 打开。
 

--- a/electron/codex/bridge.ts
+++ b/electron/codex/bridge.ts
@@ -8,6 +8,7 @@ import readline from "node:readline";
 import { spawn, execFileSync, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { perfLogger } from "../log";
+import { getDebugConfig } from "../debugConfig";
 import { winToWsl } from "../wsl";
 
 type PendingRequest = {
@@ -150,10 +151,12 @@ function findCodexViaWhereExe(mode: "native" | "wsl"): string | null {
       }
     }
   } catch (err) {
-    // where.exe 失败或解析失败，静默降级到插件目录查找
-    if (process.env.CODEX_DIAG_LOG === "1") {
-      perfLogger.log(`[codex] where.exe lookup failed: ${String(err)}`);
-    }
+    // where.exe 失败或解析失败，静默降级到插件目录查找（仅在主进程调试开启时记录）
+    try {
+      if (getDebugConfig()?.global?.diagLog) {
+        perfLogger.log(`[codex] where.exe lookup failed: ${String(err)}`);
+      }
+    } catch {}
   }
   
   return null;

--- a/electron/debugConfig.ts
+++ b/electron/debugConfig.ts
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import fs from "node:fs";
+import path from "node:path";
+import { app } from "electron";
+import { perfLogger } from "./log";
+
+// 统一调试配置：单文件 JSONC（支持注释），集中替代环境变量/localStorage/flag 文件
+
+export type DebugConfig = {
+  version: number;
+  global: {
+    diagLog: boolean;          // 主/渲染进程诊断日志（写入 perf.log）
+    openDevtools: boolean;     // 启动时强制打开 DevTools
+  };
+  renderer: {
+    uiDebug: boolean;          // UI 交互/遮罩诊断
+    notifications: {
+      debug: boolean;          // 通知附加日志
+      menu: "auto" | "forceOn" | "forceOff"; // 右键调试菜单
+    };
+    atSearchDebug: boolean;    // @ 搜索调试
+  };
+  terminal: {
+    frontend: { debug: boolean; disablePin: boolean }; // 渲染层终端日志/禁用钉行
+    pty: { debug: boolean };                            // 主进程 PTY 日志
+  };
+  fileIndex: {
+    debug: boolean;
+    poll: { enable: boolean; intervalMs: number };
+    watch: {
+      disable: boolean;
+      maxFiles: number;
+      maxDirs: number;
+      depth: number | "auto";
+    };
+    rescan: { idleMs: number; intervalMs: number };
+  };
+  history: { debug: boolean; filter: string };
+  indexer: { debug: boolean; filter: string };
+  projects: { debug: boolean };
+  updates: { skipVersion: string };
+  codex: { tuiTrace: boolean };
+};
+
+let cached: DebugConfig | null = null;
+let lastMtime = 0;
+const listeners = new Set<(cfg: DebugConfig) => void>();
+
+function getConfigPath(): string { return path.join(app.getPath("userData"), "debug.config.jsonc"); }
+
+function stripJsonComments(input: string): string {
+  try {
+    const src = String(input || "");
+    let out = "";
+    let inString = false;
+    let quoteChar = "";
+    let escaped = false;
+    let i = 0;
+    while (i < src.length) {
+      const ch = src[i];
+      if (inString) {
+        out += ch;
+        if (escaped) {
+          escaped = false;
+        } else if (ch === "\\") {
+          escaped = true;
+        } else if (ch === quoteChar) {
+          inString = false;
+          quoteChar = "";
+        }
+        i += 1;
+        continue;
+      }
+
+      if (ch === '"' || ch === '\'') {
+        inString = true;
+        quoteChar = ch;
+        out += ch;
+        i += 1;
+        continue;
+      }
+
+      if (ch === '/' && i + 1 < src.length) {
+        const next = src[i + 1];
+        if (next === '/') {
+          // 跳过单行注释
+          i += 2;
+          while (i < src.length && src[i] !== '\n' && src[i] !== '\r') {
+            i += 1;
+          }
+          continue;
+        }
+        if (next === '*') {
+          // 跳过多行注释
+          i += 2;
+          while (i < src.length - 1 && !(src[i] === '*' && src[i + 1] === '/')) {
+            i += 1;
+          }
+          if (i < src.length - 1) {
+            i += 2; // 跳过结束 */
+          }
+          continue;
+        }
+      }
+
+      out += ch;
+      i += 1;
+    }
+    return out;
+  } catch {
+    return input;
+  }
+}
+
+export function getDefaultDebugConfig(): DebugConfig {
+  return {
+    version: 1,
+    global: { diagLog: false, openDevtools: false },
+    renderer: { uiDebug: false, notifications: { debug: false, menu: "auto" }, atSearchDebug: false },
+    terminal: { frontend: { debug: false, disablePin: false }, pty: { debug: false } },
+    fileIndex: {
+      debug: false,
+      poll: { enable: false, intervalMs: 1000 },
+      watch: { disable: false, maxFiles: 100000, maxDirs: 50000, depth: "auto" },
+      rescan: { idleMs: 20000, intervalMs: 30000 }
+    },
+    history: { debug: false, filter: "" },
+    indexer: { debug: false, filter: "" },
+    projects: { debug: false },
+    updates: { skipVersion: "" },
+    codex: { tuiTrace: false }
+  };
+}
+
+function renderJsonc(cfg: DebugConfig): string {
+  // 生成带注释的 JSONC（稳定顺序），作为唯一权威模板
+  const lines: string[] = [];
+  lines.push("{");
+  lines.push("  \"version\": " + Number(cfg.version || 1) + ",");
+  lines.push("  // 全局与日志");
+  lines.push("  \"global\": {");
+  lines.push("    \"diagLog\": " + (cfg.global.diagLog ? "true" : "false") + ", // 主/渲染进程诊断写 perf.log");
+  lines.push("    \"openDevtools\": " + (cfg.global.openDevtools ? "true" : "false") + " // 启动强制打开 DevTools（需重启）");
+  lines.push("  },");
+  lines.push("  // 渲染层");
+  lines.push("  \"renderer\": {");
+  lines.push("    \"uiDebug\": " + (cfg.renderer.uiDebug ? "true" : "false") + ", // UI 交互/遮罩诊断");
+  lines.push("    \"notifications\": {");
+  lines.push("      \"debug\": " + (cfg.renderer.notifications.debug ? "true" : "false") + ", // 通知附加日志");
+  lines.push("      \"menu\": \"" + (cfg.renderer.notifications.menu || "auto") + "\" // auto | forceOn | forceOff");
+  lines.push("    },");
+  lines.push("    \"atSearchDebug\": " + (cfg.renderer.atSearchDebug ? "true" : "false") + " // @ 搜索调试");
+  lines.push("  },");
+  lines.push("  // 终端");
+  lines.push("  \"terminal\": {");
+  lines.push("    \"frontend\": { \"debug\": " + (cfg.terminal.frontend.debug ? "true" : "false") + ", \"disablePin\": " + (cfg.terminal.frontend.disablePin ? "true" : "false") + " },");
+  lines.push("    \"pty\": { \"debug\": " + (cfg.terminal.pty.debug ? "true" : "false") + " }");
+  lines.push("  },");
+  lines.push("  // 文件索引");
+  lines.push("  \"fileIndex\": {");
+  lines.push("    \"debug\": " + (cfg.fileIndex.debug ? "true" : "false") + ",");
+  lines.push("    \"poll\": { \"enable\": " + (cfg.fileIndex.poll.enable ? "true" : "false") + ", \"intervalMs\": " + Number(cfg.fileIndex.poll.intervalMs || 1000) + " },");
+  lines.push("    \"watch\": { \"disable\": " + (cfg.fileIndex.watch.disable ? "true" : "false") + ", \"maxFiles\": " + Number(cfg.fileIndex.watch.maxFiles || 100000) + ", \"maxDirs\": " + Number(cfg.fileIndex.watch.maxDirs || 50000) + ", \"depth\": " + (typeof cfg.fileIndex.watch.depth === "number" ? String(cfg.fileIndex.watch.depth) : '\"auto\"') + " },");
+  lines.push("    \"rescan\": { \"idleMs\": " + Number(cfg.fileIndex.rescan.idleMs || 20000) + ", \"intervalMs\": " + Number(cfg.fileIndex.rescan.intervalMs || 30000) + " }");
+  lines.push("  },");
+  lines.push("  // 历史与索引器");
+  lines.push("  \"history\": { \"debug\": " + (cfg.history.debug ? "true" : "false") + ", \"filter\": \"" + String(cfg.history.filter || "").replace(/\\/g, "\\\\").replace(/\"/g, '\\"') + "\" },");
+  lines.push("  \"indexer\": { \"debug\": " + (cfg.indexer.debug ? "true" : "false") + ", \"filter\": \"" + String(cfg.indexer.filter || "").replace(/\\/g, "\\\\").replace(/\"/g, '\\"') + "\" },");
+  lines.push("  // 项目扫描");
+  lines.push("  \"projects\": { \"debug\": " + (cfg.projects.debug ? "true" : "false") + " },");
+  lines.push("  // 更新控制");
+  lines.push("  \"updates\": { \"skipVersion\": \"" + String(cfg.updates.skipVersion || "").replace(/\\/g, "\\\\").replace(/\"/g, '\\"') + "\" },");
+  lines.push("  // Codex CLI");
+  lines.push("  \"codex\": { \"tuiTrace\": " + (cfg.codex.tuiTrace ? "true" : "false") + " }");
+  lines.push("}");
+  let out = lines.join("\n");
+  if (!out.endsWith("\n")) out += "\n";
+  return out;
+}
+
+function merge(a: DebugConfig, b: Partial<DebugConfig> | null | undefined): DebugConfig {
+  if (!b) return a;
+  const pick = (v: any, def: any) => (typeof v === typeof def ? v : def);
+  const x: DebugConfig = getDefaultDebugConfig();
+  try { x.version = Number((b as any).version ?? a.version ?? 1); } catch { x.version = a.version; }
+  x.global = {
+    diagLog: pick((b as any)?.global?.diagLog, a.global.diagLog),
+    openDevtools: pick((b as any)?.global?.openDevtools, a.global.openDevtools),
+  } as any;
+  x.renderer = {
+    uiDebug: pick((b as any)?.renderer?.uiDebug, a.renderer.uiDebug),
+    notifications: {
+      debug: pick((b as any)?.renderer?.notifications?.debug, a.renderer.notifications.debug),
+      menu: ((): any => {
+        const m = (b as any)?.renderer?.notifications?.menu;
+        return m === "forceOn" || m === "forceOff" || m === "auto" ? m : a.renderer.notifications.menu;
+      })(),
+    },
+    atSearchDebug: pick((b as any)?.renderer?.atSearchDebug, a.renderer.atSearchDebug),
+  } as any;
+  x.terminal = {
+    frontend: {
+      debug: pick((b as any)?.terminal?.frontend?.debug, a.terminal.frontend.debug),
+      disablePin: pick((b as any)?.terminal?.frontend?.disablePin, a.terminal.frontend.disablePin),
+    },
+    pty: { debug: pick((b as any)?.terminal?.pty?.debug, a.terminal.pty.debug) },
+  } as any;
+  x.fileIndex = {
+    debug: pick((b as any)?.fileIndex?.debug, a.fileIndex.debug),
+    poll: {
+      enable: pick((b as any)?.fileIndex?.poll?.enable, a.fileIndex.poll.enable),
+      intervalMs: Number((b as any)?.fileIndex?.poll?.intervalMs ?? a.fileIndex.poll.intervalMs),
+    },
+    watch: {
+      disable: pick((b as any)?.fileIndex?.watch?.disable, a.fileIndex.watch.disable),
+      maxFiles: Number((b as any)?.fileIndex?.watch?.maxFiles ?? a.fileIndex.watch.maxFiles),
+      maxDirs: Number((b as any)?.fileIndex?.watch?.maxDirs ?? a.fileIndex.watch.maxDirs),
+      depth: ((): any => {
+        const v = (b as any)?.fileIndex?.watch?.depth;
+        return typeof v === 'number' ? v : (v === 'auto' ? 'auto' : a.fileIndex.watch.depth);
+      })(),
+    },
+    rescan: {
+      idleMs: Number((b as any)?.fileIndex?.rescan?.idleMs ?? a.fileIndex.rescan.idleMs),
+      intervalMs: Number((b as any)?.fileIndex?.rescan?.intervalMs ?? a.fileIndex.rescan.intervalMs),
+    },
+  } as any;
+  x.history = { debug: pick((b as any)?.history?.debug, a.history.debug), filter: String((b as any)?.history?.filter ?? a.history.filter) };
+  x.indexer = { debug: pick((b as any)?.indexer?.debug, a.indexer.debug), filter: String((b as any)?.indexer?.filter ?? a.indexer.filter) };
+  x.projects = { debug: pick((b as any)?.projects?.debug, a.projects.debug) };
+  x.updates = { skipVersion: String((b as any)?.updates?.skipVersion ?? a.updates.skipVersion) };
+  x.codex = { tuiTrace: pick((b as any)?.codex?.tuiTrace, a.codex.tuiTrace) };
+  return x;
+}
+
+export function readDebugConfig(): DebugConfig {
+  try {
+    const p = getConfigPath();
+    if (!fs.existsSync(p)) {
+      const def = getDefaultDebugConfig();
+      const text = renderJsonc(def);
+      try { fs.mkdirSync(path.dirname(p), { recursive: true }); } catch {}
+      fs.writeFileSync(p, text, "utf8");
+      cached = def;
+      lastMtime = Date.now();
+      return def;
+    }
+    const raw = fs.readFileSync(p, "utf8");
+    const json = JSON.parse(stripJsonComments(raw) || "{}") as Partial<DebugConfig>;
+    const merged = merge(getDefaultDebugConfig(), json);
+    cached = merged;
+    try { lastMtime = fs.statSync(p).mtimeMs || Date.now(); } catch { lastMtime = Date.now(); }
+    return merged;
+  } catch (e) {
+    try { perfLogger.log(`[debug.config] read failed: ${String((e as any)?.message || e)}`); } catch {}
+    const d = getDefaultDebugConfig();
+    cached = d;
+    return d;
+  }
+}
+
+export function getDebugConfig(): DebugConfig {
+  if (!cached) return readDebugConfig();
+  return cached;
+}
+
+export function saveDebugConfig(next: DebugConfig): void {
+  try {
+    const p = getConfigPath();
+    try { fs.mkdirSync(path.dirname(p), { recursive: true }); } catch {}
+    const text = renderJsonc(next);
+    fs.writeFileSync(p, text, "utf8");
+    cached = next;
+    try { lastMtime = fs.statSync(p).mtimeMs || Date.now(); } catch { lastMtime = Date.now(); }
+    notifyChanged();
+  } catch (e) {
+    try { perfLogger.log(`[debug.config] save failed: ${String((e as any)?.message || e)}`); } catch {}
+  }
+}
+
+export function updateDebugConfig(partial: Partial<DebugConfig>): DebugConfig {
+  const cur = getDebugConfig();
+  const next = merge(cur, partial);
+  saveDebugConfig(next);
+  return next;
+}
+
+export function onDebugChanged(handler: (cfg: DebugConfig) => void): () => void {
+  listeners.add(handler);
+  return () => { try { listeners.delete(handler); } catch {} };
+}
+
+function notifyChanged(): void {
+  const cfg = getDebugConfig();
+  for (const fn of Array.from(listeners)) {
+    try { fn(cfg); } catch {}
+  }
+}
+
+export function watchDebugConfig(): void {
+  try {
+    const p = getConfigPath();
+    try { fs.mkdirSync(path.dirname(p), { recursive: true }); } catch {}
+    if (!fs.existsSync(p)) { saveDebugConfig(getDebugConfig()); }
+    fs.watch(p, { persistent: true }, (_eventType) => {
+      try {
+        const st = fs.statSync(p);
+        if (st && st.mtimeMs && st.mtimeMs !== lastMtime) {
+          lastMtime = st.mtimeMs;
+          readDebugConfig();
+          notifyChanged();
+        }
+      } catch {}
+    });
+  } catch {}
+}
+
+export function openDebugConfigPath(): string { return getConfigPath(); }
+
+export function resetDebugConfig(): DebugConfig {
+  const def = getDefaultDebugConfig();
+  saveDebugConfig(def);
+  return def;
+}
+
+

--- a/electron/history.ts
+++ b/electron/history.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import os from 'node:os';
 import readline from 'node:readline';
 import { app } from 'electron';
+import { getDebugConfig } from './debugConfig';
 import crypto from 'node:crypto';
 import wsl, { isUNCPath, uncToWsl, getSessionsRootsFastAsync } from './wsl';
 import { perfLogger } from './log';
@@ -133,7 +134,7 @@ export function detectRuntimeShellFromContent(parsed?: any, text?: string): Runt
 function __userDataPath(): string { try { return app.getPath('userData'); } catch { return process.cwd(); } }
 function __flagPath(): string { return path.join(__userDataPath(), 'history-debug.on'); }
 function __flagExists(): boolean { try { fs.accessSync(__flagPath()); return true; } catch { return false; } }
-function __envFlag(): string { return String(process.env.CODEX_HISTORY_DEBUG || ''); }
+function __envFlag(): string { try { return getDebugConfig().history.debug ? '1' : ''; } catch { return ''; } }
 export function debugInfo() {
   return {
     userDataPath: __userDataPath(),

--- a/electron/projects.fast.ts
+++ b/electron/projects.fast.ts
@@ -8,6 +8,7 @@ import os from "node:os";
 import { app } from "electron";
 import { wslToUNC, isUNCPath, uncToWsl, getCodexRootsFastAsync } from "./wsl";
 import { perfLogger } from "./log";
+import { getDebugConfig } from "./debugConfig";
 
 export type Project = {
   id: string;
@@ -40,9 +41,7 @@ export async function scanProjectsAsync(_roots?: string[], verbose = false): Pro
   const store = loadStore();
   const logPath = path.join(app.getPath('userData'), 'scan-log.txt');
   const dbgPath = path.join(app.getPath('userData'), 'projects-debug.log');
-  const dbgFlagPath = path.join(app.getPath('userData'), 'projects-debug.on');
-  const envDbg = String((process as any).env.CODEX_PROJECTS_DEBUG || '').trim() === '1';
-  const dbgEnabled = () => envDbg || (() => { try { fs.accessSync(dbgFlagPath); return true; } catch { return false; } })();
+  const dbgEnabled = () => { try { return !!getDebugConfig().projects.debug; } catch { return false; } };
   const writeLog = async (msg: string) => { if (!verbose) return; try { await fsp.appendFile(logPath, `${new Date().toISOString()} ${msg}\n`, 'utf8'); } catch {} };
   const writeDbg = async (msg: string) => {
     if (!dbgEnabled()) return;

--- a/electron/projects.ts
+++ b/electron/projects.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 import { promises as fsp } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { getDebugConfig } from './debugConfig';
 import { app } from 'electron';
 import { winToWsl, wslToUNC, isUNCPath, uncToWsl, listDistrosAsync, getDistroHomeAsync, execInWslAsync, readFileInWslAsync, winToWslAsync, getDefaultRootsAsync } from './wsl';
 
@@ -161,9 +162,7 @@ export async function scanProjectsAsync(roots?: string[], verbose = false): Prom
   const store = loadStore();
   const logPath = path.join(app.getPath('userData'), 'scan-log.txt');
   const dbgPath = path.join(app.getPath('userData'), 'projects-debug.log');
-  const dbgFlagPath = path.join(app.getPath('userData'), 'projects-debug.on');
-  const envDbg = String(process.env.CODEX_PROJECTS_DEBUG || '').trim() === '1';
-  const dbgEnabled = () => envDbg || (() => { try { fs.accessSync(dbgFlagPath); return true; } catch { return false; } })();
+  const dbgEnabled = () => { try { return !!getDebugConfig().projects.debug; } catch { return false; } };
   const writeLog = async (msg: string) => {
     if (!verbose) return;
     try { await fsp.appendFile(logPath, `${new Date().toISOString()} ${msg}\n`, 'utf8'); } catch {};

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -8,9 +8,10 @@ import type { IPty } from '@lydell/node-pty';
 import * as pty from '@lydell/node-pty';
 import { BrowserWindow } from 'electron';
 import { perfLogger } from './log.js';
+import { getDebugConfig } from './debugConfig.js';
 
-// 终端日志总开关（主进程）。默认关闭，可通过 env 或 IPC 置位。
-let TERM_DEBUG = String(process.env.CODEX_TERM_DEBUG || '').trim() === '1';
+// 终端日志总开关（主进程）。默认关闭，由统一调试配置控制，也可通过 IPC 置位。
+let TERM_DEBUG = (() => { try { return !!(getDebugConfig().terminal.pty.debug); } catch { return false; } })();
 export function setTermDebug(flag: boolean) { TERM_DEBUG = !!flag; try { perfLogger.log(`[pty] debugTerm=${TERM_DEBUG ? 'on' : 'off'}`); } catch {} }
 const dlog = (msg: string) => { if (TERM_DEBUG) { try { perfLogger.log(msg); } catch {} } };
 

--- a/web/src/adapters/TerminalAdapter.tsx
+++ b/web/src/adapters/TerminalAdapter.tsx
@@ -21,24 +21,11 @@ export type TerminalAdapterAPI = {
 };
 
 export function createTerminalAdapter(): TerminalAdapterAPI {
-  // 调试辅助：在控制台异常时，将关键度量写入主进程 perf.log
-  // 打开方式（渲染进程控制台执行一次）：localStorage.setItem('CF_DEBUG_TERM', '1')
-  // 关闭方式：localStorage.removeItem('CF_DEBUG_TERM')
-  // 默认关闭日志；如需开启：localStorage.setItem('CF_DEBUG_TERM','1')
-  // 调试开关：默认关闭；如需开启，执行：localStorage.setItem('CF_DEBUG_TERM','1')
-  const dbgEnabled = () => {
-    try { return localStorage.getItem('CF_DEBUG_TERM') === '1'; } catch { return false; }
-  };
+  // 调试辅助：统一配置（preload 注入只读缓存）
+  const dbgEnabled = () => { try { return !!(globalThis as any).__cf_term_debug__; } catch { return false; } };
   const dlog = (msg: string) => { if (dbgEnabled()) { try { (window as any).host?.utils?.perfLog?.(msg); } catch {} } };
-  // 默认启用“整行钉死”；如需禁用：localStorage.setItem('CF_DISABLE_PIN','1')
-  const pinDisabled = () => {
-    try {
-      const v = localStorage.getItem('CF_DISABLE_PIN');
-      if (v === '1') return true;
-      if (v === '0') return false;
-    } catch {}
-    return false; // 默认启用 pin
-  };
+  // “整行钉死”从统一配置读取
+  const pinDisabled = () => { try { return !!(globalThis as any).__cf_disable_pin__; } catch { return false; } };
 
   let term: Terminal | null = null;
   let fitAddon: FitAddon | null = null;

--- a/web/src/components/at-mention-new/CommandInputWithAt.tsx
+++ b/web/src/components/at-mention-new/CommandInputWithAt.tsx
@@ -287,9 +287,9 @@ export function AtInput({ value, onValueChange, winRoot, projectName, projectPat
       <Input
         ref={ref as any}
         value={value}
-        onChange={onLocalChange}
-        onKeyDown={(e: any) => { try { externalOnKeyDown && externalOnKeyDown(e); } catch {} onKeyDown(e); }}
-        onPaste={onPaste}
+        onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => onLocalChange(e as any)}
+        onKeyDown={(e: React.KeyboardEvent<any>) => { try { externalOnKeyDown && externalOnKeyDown(e); } catch {} onKeyDown(e); }}
+        onPaste={(e: React.ClipboardEvent<any>) => onPaste(e as any)}
         onDragOver={(e) => { try { e.preventDefault(); e.dataTransfer!.dropEffect = 'copy'; } catch {} }}
         onDrop={(e) => {
           try {

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -8,12 +8,12 @@ import { cn } from '@/lib/utils';
 const Ctx = React.createContext<{
   open: boolean;
   setOpen: (v: boolean) => void;
-  triggerRef: React.RefObject<HTMLElement>;
+  triggerRef: React.MutableRefObject<HTMLElement | null>;
 } | null>(null);
 
 export function DropdownMenu({ children }: { children: React.ReactNode }) {
   const [open, setOpen] = React.useState(false);
-  const triggerRef = React.useRef<HTMLElement>(null);
+  const triggerRef = React.useRef<HTMLElement | null>(null);
   return <Ctx.Provider value={{ open, setOpen, triggerRef }}>{children}</Ctx.Provider>;
 }
 

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -6,15 +6,15 @@ import { cn } from '@/lib/utils';
 
 // 支持可选的 multiline 行为：当 multiline 为 true 时渲染为 textarea 并默认将高度提升三倍；
 // 否则保持原生 input 行为并恢复为原始高度（h-10）。这样可以避免全局替换导致的垂直居中问题。
-export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement>, React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   /** 是否渲染为多行输入（textarea） */
   multiline?: boolean;
 }
 
-export const Input = React.forwardRef<HTMLTextAreaElement | HTMLInputElement, InputProps>(({ className, multiline, ...props }, ref) => {
+export const Input = React.forwardRef<HTMLTextAreaElement | HTMLInputElement, InputProps>(((props, ref) => {
+  const { className, multiline, onPointerDown: externalOnPointerDown, ...restProps } = props as any;
   const base = 'flex w-full rounded-md border border-slate-200 bg-white px-3 text-sm ring-offset-white placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950/10';
   // 统一处理 Pointer Capture：将拖拽事件锁定在输入框内，避免拖拽误选外部文字
-  const { onPointerDown: externalOnPointerDown, ...restProps } = props as any;
 
   if (multiline) {
     // textarea 默认文字从左上开始，设置为不可调整大小以保持布局一致
@@ -36,6 +36,6 @@ export const Input = React.forwardRef<HTMLTextAreaElement | HTMLInputElement, In
       {...(restProps as React.InputHTMLAttributes<HTMLInputElement>)}
     />
   );
-});
+}));
 Input.displayName = 'Input';
 

--- a/web/src/i18n/setup.ts
+++ b/web/src/i18n/setup.ts
@@ -31,7 +31,8 @@ async function detectInitialLanguage(): Promise<string> {
 }
 
 // 通过 Vite 的 import.meta.glob 预注册所有本地 JSON 资源，避免运行时路径无法解析
-const LOCALE_MODULES: Record<string, () => Promise<any>> = import.meta.glob("../locales/**/*.json");
+// Vite 专用：通过 import.meta.glob 预注册本地 JSON 模块（非 Vite 环境下类型不包含 glob，需断言 any）
+const LOCALE_MODULES: Record<string, () => Promise<any>> = (import.meta as any).glob("../locales/**/*.json");
 
 function detectedCompiledLanguages(): string[] {
   const set = new Set<string>();

--- a/web/src/lib/TerminalManager.ts
+++ b/web/src/lib/TerminalManager.ts
@@ -27,10 +27,8 @@ export interface HostPtyAPI {
  * 设计目标：将和具体 host/pty 实现解耦，便于在未来提取成独立包或在不同宿主上复用。
  */
 export default class TerminalManager {
-  // 调试辅助：默认关闭；如需开启：localStorage.setItem('CF_DEBUG_TERM','1')
-  private dbgEnabled(): boolean {
-    try { return localStorage.getItem('CF_DEBUG_TERM') === '1'; } catch { return false; }
-  }
+  // 调试辅助：统一配置
+  private dbgEnabled(): boolean { try { return !!(globalThis as any).__cf_term_debug__; } catch { return false; } }
   private dlog(msg: string): void { if (this.dbgEnabled()) { try { (window as any).host?.utils?.perfLog?.(`[tm] ${msg}`); } catch {} } }
   private adapters: Record<string, TerminalAdapterAPI | null> = {};
   private containers: Record<string, HTMLDivElement | null> = {};

--- a/web/src/lib/about.ts
+++ b/web/src/lib/about.ts
@@ -366,8 +366,11 @@ export async function fetchRemoteAbout(opts?: { force?: boolean; timeoutMs?: num
     const fallback = normalizeAboutData(LOCAL_DEFAULT_ABOUT, donationSignatureValid);
     const normalized = normalizeFetchError(err);
     logUpdateEvent("fetchRemoteAbout.fallback", { force: !!opts?.force, timeoutMs, errorType: normalized.type, errorMessage: normalized.message, url: DEFAULT_REMOTE_URL });
-    return { data: fallback, from: "local", error: normalizeFetchError(err) };
+    return { data: fallback, from: "local", error: normalized };
   }
+  // 理论上不会到达此处；为满足类型检查提供兜底返回
+  const fallback = normalizeAboutData(LOCAL_DEFAULT_ABOUT, donationSignatureValid);
+  return { data: fallback, from: "local" };
 }
 
 export type UpdateCheckStatus = "update" | "no-update" | "failed";

--- a/web/src/lib/atSearch.ts
+++ b/web/src/lib/atSearch.ts
@@ -26,9 +26,9 @@ const loadingByRoot = new Map<string, Promise<FileCandidate[]>>();
 const cacheIndexByRoot = new Map<string, Map<string, FileCandidate>>(); // key: D:/F:+rel
 let subscribed = false; // 渲染进程仅订阅一次主进程的索引变更事件
 
-// 前端调试日志：在 localStorage 设置 CODEX_AT_DEBUG=1 可启用；若可用则写入 perf.log
+// 前端调试日志：读取统一调试配置（preload 注入只读缓存）
 function dbgEnabled(): boolean {
-  try { return String(localStorage.getItem('CODEX_AT_DEBUG') || '').trim() === '1'; } catch { return false; }
+  try { return !!(globalThis as any).__cf_at_debug__; } catch { return false; }
 }
 function perfLog(msg: string) {
   if (!dbgEnabled()) return;

--- a/web/src/locales/en/settings.json
+++ b/web/src/locales/en/settings.json
@@ -55,7 +55,7 @@
   "codexCmdHelp": "Customize the command CodexFlow runs when launching from the terminal.",
   "codexTrace": {
     "label": "Codex TUI debugging",
-    "help": "Control whether CodexFlow adds trace logging flags when launching Codex (applies to new terminals).",
+    "help": "Control whether CodexFlow adds trace logging flags when launching Codex (applies to new terminals). The switch is managed by debug.config.jsonc.",
     "toggle": "Enable codex_tui trace logging",
     "note": "Supported in both WSL and PowerShell sessions; turn this off if you prefer quieter logs."
   },
@@ -166,6 +166,12 @@
     "warningDesc": "This will permanently delete {count} history files and cannot be undone. Continue?",
     "warningConfirm": "Delete anyway",
     "batchDeleteFailed": "Batch delete failed"
+  },
+  "debug": {
+    "label": "Debug configuration",
+    "help": "Manage all debug flags in a single JSONC file.",
+    "open": "Open debug.config.jsonc",
+    "reset": "Restore defaults"
   },
   "footer": {
     "note": "Changes apply after you save. Some items may require restarting CodexFlow."

--- a/web/src/locales/zh/settings.json
+++ b/web/src/locales/zh/settings.json
@@ -55,7 +55,7 @@
   "codexCmdHelp": "自定义从终端启动 CodexFlow 时执行的命令。",
   "codexTrace": {
     "label": "Codex TUI 调试",
-    "help": "控制 CodexFlow 启动 Codex 时是否自动附加 trace 日志参数（作用于新打开的终端）。",
+    "help": "控制 CodexFlow 启动 Codex 时是否自动附加 trace 日志参数（作用于新打开的终端）。该开关归属 debug.config.jsonc。",
     "toggle": "启用 codex_tui trace 日志",
     "note": "WSL 与 PowerShell 均支持，如不需要详细日志可关闭。"
   },
@@ -166,6 +166,12 @@
     "warningDesc": "此操作会永久删除 {count} 个历史记录文件，且不可恢复。是否继续？",
     "warningConfirm": "仍要删除",
     "batchDeleteFailed": "批量删除失败"
+  },
+  "debug": {
+    "label": "调试配置",
+    "help": "在单一 JSONC 文件中集中管理全部调试开关。",
+    "open": "打开 debug.config.jsonc",
+    "reset": "恢复默认"
   },
   "footer": {
     "note": "保存后生效；部分设置可能需要重启 CodexFlow。"

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -14,7 +14,7 @@ const root = createRoot(document.getElementById('root')!);
 // 初始化 i18n 后再渲染，避免首次闪烁，并把关键阶段写入主进程日志
 (async () => {
   let DIAG = false;
-  try { DIAG = localStorage.getItem('CF_DIAG_LOG') === '1'; } catch {}
+  try { DIAG = !!(globalThis as any).__cf_ui_debug_cache__ || !!((await (window as any)?.host?.debug?.get?.())?.global?.diagLog); } catch {}
   if (DIAG) { try { await (window as any)?.host?.utils?.perfLog?.('renderer:boot start'); } catch {} }
   try { await initI18n(); } catch (e) { if (DIAG) { try { await (window as any)?.host?.utils?.perfLog?.('renderer:initI18n error ' + String((e as any)?.stack || e)); } catch {} } }
   if (DIAG) { try { await (window as any)?.host?.utils?.perfLog?.('renderer:render start'); } catch {} }

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -25,8 +25,6 @@ export type AppSettings = {
     proxyUrl?: string;
     noProxy?: string;
   };
-  /** Codex TUI 调试日志开关 */
-  codexTraceEnabled?: boolean;
 };
 
 export type Project = {
@@ -211,6 +209,12 @@ declare global {
       i18n: I18nAPI;
       codex: CodexAPI;
       notifications: NotificationsAPI;
+      debug?: {
+        get(): Promise<any>;
+        update(partial: any): Promise<any>;
+        reset?(): Promise<any>;
+        onChanged?(handler: () => void): () => void;
+      };
     };
   }
 }


### PR DESCRIPTION
重构所有调试开关到单一 JSONC 配置文件，替代分散的环境变量、localStorage 和标志文件。

主要改动：
- 新增 electron/debugConfig.ts 模块，提供统一配置管理、热重载和类型安全
- 重构主进程 6 个模块（main、fileIndex、history、indexer、projects、pty）切换到统一配置
- 预加载脚本添加 debug API 桥接和全局缓存同步机制
- 设置模块迁移 codexTraceEnabled 字段到 debug.config.jsonc（自动迁移）
- 渲染进程诊断日志从 localStorage 切换到统一配置
- 设置对话框新增"调试配置"卡片，提供打开/重置功能
- 更新中英文本地化资源和诊断文档

配置文件位置：%APPDATA%/codexflow/debug.config.jsonc
支持热重载、注释、类型提示，覆盖全局、渲染、终端、文件索引、历史、项目等所有调试场景。