### PR TITLE
﻿feat: 优化历史详情复制能力

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,6 +43,7 @@ import { checkForUpdate, type UpdateCheckErrorType } from "@/lib/about";
 import { createTerminalAdapter, type TerminalAdapterAPI } from "@/adapters/TerminalAdapter";
 import TerminalManager from "@/lib/TerminalManager";
 import { oscBufferDefaults, trimOscBuffer } from "@/lib/oscNotificationBuffer";
+import { copyTextCrossPlatform } from "@/lib/clipboard";
 import { toWSLForInsert } from "@/lib/wsl";
 import SettingsDialog from "@/features/settings/settings-dialog";
 
@@ -3508,6 +3509,7 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
 }
 
 function ContentRenderer({ items, kprefix }: { items: MessageContent[]; kprefix?: string }) {
+  const { t } = useTranslation(["history"]);
   if (!Array.isArray(items) || items.length === 0) return null;
   return (
     <div className="space-y-2">
@@ -3518,7 +3520,12 @@ function ContentRenderer({ items, kprefix }: { items: MessageContent[]; kprefix?
           // 展开显示 user_instructions（移除折叠）
           return (
             <div key={`${kprefix || 'itm'}-uinst-${i}`} className="rounded border border-slate-200 bg-slate-50 p-2 text-xs">
-              <div className="text-slate-600 font-medium">user_instructions</div>
+              <div className="flex items-center justify-between text-slate-600 font-medium">
+                <div>user_instructions</div>
+                <Button size="icon" variant="ghost" title={t('history:copyBlock') as string} aria-label={t('history:copyBlock') as string} onClick={async () => { await copyTextCrossPlatform(text, { preferBrowser: true }); }}>
+                  <CopyIcon className="h-4 w-4" />
+                </Button>
+              </div>
               <pre className="mt-2 overflow-x-auto whitespace-pre-wrap"><code>{text}</code></pre>
             </div>
           );
@@ -3528,7 +3535,12 @@ function ContentRenderer({ items, kprefix }: { items: MessageContent[]; kprefix?
           // 展开显示 environment_context（移除折叠）
           return (
             <div key={`${kprefix || 'itm'}-env-${i}`} className="rounded border border-slate-200 bg-slate-50 p-2 text-xs">
-              <div className="text-slate-600 font-medium">environment_context</div>
+              <div className="flex items-center justify-between text-slate-600 font-medium">
+                <div>environment_context</div>
+                <Button size="icon" variant="ghost" title={t('history:copyBlock') as string} aria-label={t('history:copyBlock') as string} onClick={async () => { await copyTextCrossPlatform(text, { preferBrowser: true }); }}>
+                  <CopyIcon className="h-4 w-4" />
+                </Button>
+              </div>
               <pre className="mt-2 overflow-x-auto whitespace-pre-wrap"><code>{text}</code></pre>
             </div>
           );
@@ -3537,23 +3549,38 @@ function ContentRenderer({ items, kprefix }: { items: MessageContent[]; kprefix?
           // 展开显示 instructions（移除折叠）
           return (
             <div key={`${kprefix || 'itm'}-instr-${i}`} className="rounded border border-slate-200 bg-slate-50 p-2 text-xs">
-              <div className="text-slate-600 font-medium">instructions</div>
+              <div className="flex items-center justify-between text-slate-600 font-medium">
+                <div>instructions</div>
+                <Button size="icon" variant="ghost" title={t('history:copyBlock') as string} aria-label={t('history:copyBlock') as string} onClick={async () => { await copyTextCrossPlatform(text, { preferBrowser: true }); }}>
+                  <CopyIcon className="h-4 w-4" />
+                </Button>
+              </div>
               <pre className="mt-2 overflow-x-auto whitespace-pre-wrap"><code>{text}</code></pre>
             </div>
           );
         }
         if (ty === 'code') {
           return (
-            <pre key={`${kprefix || 'itm'}-code-${i}`} className="overflow-x-auto rounded bg-slate-900 p-3 text-xs text-slate-100">
-              <code>{text}</code>
-            </pre>
+            <div key={`${kprefix || 'itm'}-code-${i}`} className="relative">
+              <Button size="icon" variant="secondary" className="absolute right-2 top-2" title={t('history:copyBlock') as string} aria-label={t('history:copyBlock') as string} onClick={async () => { await copyTextCrossPlatform(text, { preferBrowser: true }); }}>
+                <CopyIcon className="h-4 w-4" />
+              </Button>
+              <pre className="overflow-x-auto rounded bg-slate-900 p-3 text-xs text-slate-100">
+                <code>{text}</code>
+              </pre>
+            </div>
           );
         }
         if (ty === 'function_call') {
           // 展开显示 function_call
           return (
             <div key={`${kprefix || 'itm'}-fnc-${i}`} className="rounded border border-slate-200 bg-slate-50 p-2 text-xs">
-              <div className="text-slate-600 font-medium">function_call</div>
+              <div className="flex items-center justify-between text-slate-600 font-medium">
+                <div>function_call</div>
+                <Button size="icon" variant="ghost" title={t('history:copyBlock') as string} aria-label={t('history:copyBlock') as string} onClick={async () => { await copyTextCrossPlatform(text, { preferBrowser: true }); }}>
+                  <CopyIcon className="h-4 w-4" />
+                </Button>
+              </div>
               <pre className="mt-2 overflow-x-auto whitespace-pre-wrap"><code>{text}</code></pre>
             </div>
           );
@@ -3562,14 +3589,22 @@ function ContentRenderer({ items, kprefix }: { items: MessageContent[]; kprefix?
           // 展开显示 function_output
           return (
             <div key={`${kprefix || 'itm'}-fno-${i}`} className="rounded border border-slate-200 bg-slate-50 p-2 text-xs">
-              <div className="text-slate-600 font-medium">function_output</div>
+              <div className="flex items-center justify-between text-slate-600 font-medium">
+                <div>function_output</div>
+                <Button size="icon" variant="ghost" title={t('history:copyBlock') as string} aria-label={t('history:copyBlock') as string} onClick={async () => { await copyTextCrossPlatform(text, { preferBrowser: true }); }}>
+                  <CopyIcon className="h-4 w-4" />
+                </Button>
+              </div>
               <pre className="mt-2 overflow-x-auto whitespace-pre-wrap"><code>{text}</code></pre>
             </div>
           );
         }
         if (ty === 'summary') {
           return (
-            <div key={`${kprefix || 'itm'}-sum-${i}`} className="rounded border bg-white p-2 text-xs text-slate-700">
+            <div key={`${kprefix || 'itm'}-sum-${i}`} className="relative rounded border bg-white p-2 text-xs text-slate-700">
+              <Button size="icon" variant="ghost" className="absolute right-2 top-2" title={t('history:copyBlock') as string} aria-label={t('history:copyBlock') as string} onClick={async () => { await copyTextCrossPlatform(text, { preferBrowser: true }); }}>
+                <CopyIcon className="h-4 w-4" />
+              </Button>
               {text}
             </div>
           );
@@ -3578,7 +3613,12 @@ function ContentRenderer({ items, kprefix }: { items: MessageContent[]; kprefix?
           // 展开显示 git
           return (
             <div key={`${kprefix || 'itm'}-git-${i}`} className="rounded border border-slate-200 bg-slate-50 p-2 text-xs">
-              <div className="text-slate-600 font-medium">git</div>
+              <div className="flex items-center justify-between text-slate-600 font-medium">
+                <div>git</div>
+                <Button size="icon" variant="ghost" title={t('history:copyBlock') as string} aria-label={t('history:copyBlock') as string} onClick={async () => { await copyTextCrossPlatform(text, { preferBrowser: true }); }}>
+                  <CopyIcon className="h-4 w-4" />
+                </Button>
+              </div>
               <pre className="mt-2 overflow-x-auto whitespace-pre-wrap"><code>{text}</code></pre>
             </div>
           );
@@ -3586,7 +3626,12 @@ function ContentRenderer({ items, kprefix }: { items: MessageContent[]; kprefix?
         if (ty === 'input_text') {
           return (
             <div key={`${kprefix || 'itm'}-in-${i}`} className="rounded border bg-white p-3 text-sm leading-6">
-              <div className="mb-1 text-xs uppercase tracking-wide text-slate-500">input</div>
+              <div className="mb-1 flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
+                <span>input</span>
+                <Button size="icon" variant="ghost" title={t('history:copyBlock') as string} aria-label={t('history:copyBlock') as string} onClick={async () => { await copyTextCrossPlatform(text, { preferBrowser: true }); }}>
+                  <CopyIcon className="h-4 w-4" />
+                </Button>
+              </div>
               <div className="whitespace-pre-wrap break-words">{text}</div>
             </div>
           );
@@ -3594,7 +3639,12 @@ function ContentRenderer({ items, kprefix }: { items: MessageContent[]; kprefix?
         if (ty === 'output_text') {
           return (
             <div key={`${kprefix || 'itm'}-out-${i}`} className="rounded border bg-white p-3 text-sm leading-6">
-              <div className="mb-1 text-xs uppercase tracking-wide text-slate-500">output</div>
+              <div className="mb-1 flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
+                <span>output</span>
+                <Button size="icon" variant="ghost" title={t('history:copyBlock') as string} aria-label={t('history:copyBlock') as string} onClick={async () => { await copyTextCrossPlatform(text, { preferBrowser: true }); }}>
+                  <CopyIcon className="h-4 w-4" />
+                </Button>
+              </div>
               <div className="whitespace-pre-wrap break-words">{text}</div>
             </div>
           );
@@ -3603,7 +3653,12 @@ function ContentRenderer({ items, kprefix }: { items: MessageContent[]; kprefix?
           // 展开显示 state
           return (
             <div key={`${kprefix || 'itm'}-state-${i}`} className="rounded border border-slate-200 bg-slate-50 p-2 text-xs">
-              <div className="text-slate-600 font-medium">state</div>
+              <div className="flex items-center justify-between text-slate-600 font-medium">
+                <div>state</div>
+                <Button size="icon" variant="ghost" title={t('history:copyBlock') as string} aria-label={t('history:copyBlock') as string} onClick={async () => { await copyTextCrossPlatform(text, { preferBrowser: true }); }}>
+                  <CopyIcon className="h-4 w-4" />
+                </Button>
+              </div>
               <pre className="mt-2 overflow-x-auto whitespace-pre-wrap">
                 <code>{text}</code>
               </pre>
@@ -3614,16 +3669,24 @@ function ContentRenderer({ items, kprefix }: { items: MessageContent[]; kprefix?
           // 展开显示 session_meta
           return (
             <div key={`${kprefix || 'itm'}-meta-${i}`} className="rounded border border-slate-200 bg-slate-50 p-2 text-xs">
-              <div className="text-slate-600 font-medium">session_meta</div>
+              <div className="flex items-center justify-between text-slate-600 font-medium">
+                <div>session_meta</div>
+                <Button size="icon" variant="ghost" title={t('history:copyBlock') as string} aria-label={t('history:copyBlock') as string} onClick={async () => { await copyTextCrossPlatform(text, { preferBrowser: true }); }}>
+                  <CopyIcon className="h-4 w-4" />
+                </Button>
+              </div>
               <pre className="mt-2 overflow-x-auto whitespace-pre-wrap"><code>{text}</code></pre>
             </div>
           );
         }
         // default: treat as plain text, including input_text/output_text etc.
         return (
-          <p key={`${kprefix || 'itm'}-txt-${i}`} className="whitespace-pre-wrap break-words text-sm leading-6">
-            {text}
-          </p>
+          <div key={`${kprefix || 'itm'}-txt-${i}`} className="relative">
+            <Button size="icon" variant="ghost" className="absolute right-0 -top-1" title={t('history:copyBlock') as string} aria-label={t('history:copyBlock') as string} onClick={async () => { await copyTextCrossPlatform(text, { preferBrowser: true }); }}>
+              <CopyIcon className="h-4 w-4" />
+            </Button>
+            <p className="whitespace-pre-wrap break-words text-sm leading-6">{text}</p>
+          </div>
         );
       })}
     </div>

--- a/web/src/lib/clipboard.ts
+++ b/web/src/lib/clipboard.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+// 跨平台复制：优先尝试主进程 IPC，可按需切换为浏览器优先
+export type CopyTextOptions = {
+  preferBrowser?: boolean;
+  disableFallback?: boolean;
+};
+
+// 跨平台读取：默认优先使用浏览器剪贴板
+export type ReadTextOptions = {
+  preferBrowser?: boolean;
+  disableFallback?: boolean;
+};
+
+function getHostUtils(): any {
+  try {
+    return (window as any)?.host?.utils;
+  } catch {
+    return undefined;
+  }
+}
+
+async function tryHostCopy(text: string): Promise<boolean> {
+  const utils = getHostUtils();
+  if (!utils || typeof utils.copyText !== "function") return false;
+  try {
+    const result = await utils.copyText(text);
+    if (result && typeof result === "object" && Object.prototype.hasOwnProperty.call(result, "ok")) {
+      return !!result.ok;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function tryBrowserCopy(text: string): Promise<boolean> {
+  try {
+    if (navigator?.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {}
+  return false;
+}
+
+async function tryHostRead(): Promise<{ success: boolean; text: string }> {
+  const utils = getHostUtils();
+  if (!utils || typeof utils.readText !== "function") {
+    return { success: false, text: "" };
+  }
+  try {
+    const result = await utils.readText();
+    if (result && typeof result === "object" && !!result.ok) {
+      return { success: true, text: String(result.text ?? "") };
+    }
+  } catch {}
+  return { success: false, text: "" };
+}
+
+async function tryBrowserRead(): Promise<{ success: boolean; text: string }> {
+  try {
+    if (navigator?.clipboard?.readText) {
+      const text = await navigator.clipboard.readText();
+      return { success: true, text: String(text ?? "") };
+    }
+  } catch {}
+  return { success: false, text: "" };
+}
+
+export async function copyTextCrossPlatform(text: string, options?: CopyTextOptions): Promise<boolean> {
+  const normalized = String(text ?? "");
+  if (!normalized) return false;
+  const preferBrowser = !!options?.preferBrowser;
+  const steps = preferBrowser
+    ? [() => tryBrowserCopy(normalized), () => tryHostCopy(normalized)]
+    : [() => tryHostCopy(normalized), () => tryBrowserCopy(normalized)];
+  for (let i = 0; i < steps.length; i++) {
+    if (i > 0 && options?.disableFallback) break;
+    const step = steps[i];
+    try {
+      if (await step()) return true;
+    } catch {}
+  }
+  return false;
+}
+
+export async function readTextCrossPlatform(options?: ReadTextOptions): Promise<string> {
+  const preferBrowser = options?.preferBrowser !== undefined ? !!options.preferBrowser : true;
+  const steps = preferBrowser
+    ? [() => tryBrowserRead(), () => tryHostRead()]
+    : [() => tryHostRead(), () => tryBrowserRead()];
+  for (let i = 0; i < steps.length; i++) {
+    if (i > 0 && options?.disableFallback) break;
+    const step = steps[i];
+    try {
+      const result = await step();
+      if (result.success) {
+        return result.text;
+      }
+    } catch {}
+  }
+  return "";
+}

--- a/web/src/locales/en/history.json
+++ b/web/src/locales/en/history.json
@@ -2,6 +2,7 @@
   "showPanel": "Show History",
   "hidePanel": "Hide History",
   "detailTitle": "History Detail",
+  "copyBlock": "Copy",
   "copyAll": "Copy All",
   "export": "Export",
   "filterTypes": "Filter Types",

--- a/web/src/locales/zh/history.json
+++ b/web/src/locales/zh/history.json
@@ -2,6 +2,7 @@
   "showPanel": "显示历史",
   "hidePanel": "隐藏历史",
   "detailTitle": "历史详情",
+  "copyBlock": "复制",
   "copyAll": "复制全部",
   "export": "导出",
   "filterTypes": "筛选类型",


### PR DESCRIPTION
- 抽取 web/src/lib/clipboard.ts 提供跨平台复制/读取工具，统一兜底策略
- 历史详情内容块复制按钮复用工具函数,确保主进程不可用时仍可复制
- 终端适配器快捷键及上下文菜单复用剪贴板逻辑,保持行为一致
- 新增 history:copyBlock 文案,补全中英文资源