### PR TITLE
feat: 新增终端字体选择与自定义功能

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -250,6 +250,16 @@ contextBridge.exposeInMainWorld('host', {
     , chooseFolder: async () => {
       return await ipcRenderer.invoke('utils.chooseFolder');
     }
+    , listFonts: async (): Promise<string[]> => {
+      try { const res = await ipcRenderer.invoke('utils.listFonts'); if (res && res.ok && Array.isArray(res.fonts)) return res.fonts as string[]; return []; } catch { return []; }
+    }
+    , listFontsDetailed: async (): Promise<Array<{ name: string; file?: string; monospace: boolean }>> => {
+      try {
+        const res = await ipcRenderer.invoke('utils.listFontsDetailed');
+        if (res && res.ok && Array.isArray(res.fonts)) return res.fonts as Array<{ name: string; file?: string; monospace: boolean }>;
+        return [];
+      } catch { return []; }
+    }
   }
   , images: {
     saveDataURL: async (args: { dataURL: string; projectWinRoot?: string; projectName?: string; ext?: string; prefix?: string }) => {

--- a/electron/settings.ts
+++ b/electron/settings.ts
@@ -48,6 +48,8 @@ export type AppSettings = {
   notifications?: NotificationSettings;
   /** 网络代理设置（供主进程与渲染层共享） */
   network?: NetworkSettings;
+  /** 终端字体栈（CSS font-family 字符串） */
+  terminalFontFamily?: string;
 };
 
 function getStorePath() {

--- a/electron/types/opentype-js.d.ts
+++ b/electron/types/opentype-js.d.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+declare module 'opentype.js' {
+  type BufferLike = ArrayBuffer | ArrayBufferView;
+  export interface OpenTypeFont { tables?: any; }
+  const opentype: {
+    parse: (buffer: BufferLike) => OpenTypeFont;
+  };
+  export default opentype;
+}
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
       "dependencies": {
         "@lydell/node-pty": "^1.1.0",
         "chokidar": "^3.6.0",
+        "iconv-lite": "^0.6.3",
+        "opentype.js": "^1.3.4",
         "undici": "^6.18.2"
       },
       "devDependencies": {
@@ -4712,7 +4714,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -5514,6 +5515,21 @@
         "wrappy": "1"
       }
     },
+    "node_modules/opentype.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-1.3.4.tgz",
+      "integrity": "sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==",
+      "dependencies": {
+        "string.prototype.codepointat": "^0.2.1",
+        "tiny-inflate": "^1.0.3"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
@@ -6193,8 +6209,7 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sanitize-filename": {
       "version": "1.6.3",
@@ -6459,6 +6474,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -6747,6 +6767,11 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
   "dependencies": {
     "@lydell/node-pty": "^1.1.0",
     "chokidar": "^3.6.0",
-    "undici": "^6.18.2"
+    "iconv-lite": "^0.6.3",
+    "undici": "^6.18.2",
+    "opentype.js": "^1.3.4"
   },
   "devDependencies": {
     "@tailwindcss/line-clamp": "^0.4.4",

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
 import * as React from 'react';
+import { createPortal } from 'react-dom';
 import { cn } from '@/lib/utils';
 
 type Ctx = {
@@ -10,6 +11,8 @@ type Ctx = {
   open: boolean;
   setOpen: (v: boolean) => void;
   items: React.MutableRefObject<Map<string, string>>;
+  /** 触发元素引用，用于定位下拉层（固定定位到视口） */
+  triggerRef: React.MutableRefObject<HTMLButtonElement | null>;
 };
 
 const SelectCtx = React.createContext<Ctx | null>(null);
@@ -17,15 +20,87 @@ const SelectCtx = React.createContext<Ctx | null>(null);
 export function Select({ value, onValueChange, children }: { value?: string; onValueChange?: (v: string) => void; children: React.ReactNode }) {
   const [open, setOpen] = React.useState(false);
   const items = React.useRef(new Map<string, string>());
+  const triggerRef = React.useRef<HTMLButtonElement | null>(null);
   return (
-    <SelectCtx.Provider value={{ value, setValue: onValueChange, open, setOpen, items }}>{children}</SelectCtx.Provider>
+    <SelectCtx.Provider value={{ value, setValue: onValueChange, open, setOpen, items, triggerRef }}>{children}</SelectCtx.Provider>
   );
 }
 
-export function SelectTrigger({ children, className, disabled }: React.HTMLAttributes<HTMLButtonElement> & { disabled?: boolean }) {
+export function SelectTrigger({
+  children,
+  className,
+  disabled,
+  onClick,
+  type = 'button',
+  ...rest
+}: React.ButtonHTMLAttributes<HTMLButtonElement> & { disabled?: boolean }) {
   const ctx = React.useContext(SelectCtx)!;
+  const ref = React.useRef<HTMLButtonElement | null>(null);
+  const { onKeyDown: onKeyDownProp, ...buttonProps } = rest;
+  // 同步触发元素引用到上下文，供下拉层定位使用
+  React.useEffect(() => {
+    ctx.triggerRef.current = ref.current;
+  }, [ctx]);
   return (
-    <button className={cn('flex h-10 w-full items-center justify-between rounded-md border border-slate-200 bg-white px-3 text-sm', className, disabled && 'opacity-60 cursor-not-allowed')} disabled={!!disabled} onClick={() => !disabled && ctx.setOpen(!ctx.open)}>
+    <button
+      ref={ref}
+      type={type}
+      className={cn('flex h-10 w-full items-center justify-between rounded-md border border-slate-200 bg-white px-3 text-sm', className, disabled && 'opacity-60 cursor-not-allowed')}
+      disabled={!!disabled}
+      onClick={(event) => {
+        if (disabled) {
+          event.preventDefault();
+          return;
+        }
+        onClick?.(event);
+        if (!event.defaultPrevented) {
+          ctx.setOpen(!ctx.open);
+        }
+      }}
+      onKeyDown={(event) => {
+        onKeyDownProp?.(event);
+        if (event.defaultPrevented) {
+          return;
+        }
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+          if (disabled) {
+            event.preventDefault();
+            return;
+          }
+          event.preventDefault();
+          const keys = Array.from(ctx.items.current.keys());
+          if (keys.length === 0) {
+            return;
+          }
+          const currentValue = ctx.value ?? '';
+          const currentKey = typeof currentValue === 'string' ? currentValue : String(currentValue);
+          const currentIndex = currentKey ? keys.findIndex((key) => key === currentKey) : -1;
+          const forward = event.key === 'ArrowDown';
+          let targetIndex = currentIndex;
+          if (forward) {
+            if (currentIndex === -1) {
+              targetIndex = 0;
+            } else if (currentIndex < keys.length - 1) {
+              targetIndex = currentIndex + 1;
+            }
+          } else {
+            if (currentIndex === -1) {
+              targetIndex = keys.length - 1;
+            } else if (currentIndex > 0) {
+              targetIndex = currentIndex - 1;
+            }
+          }
+          if (targetIndex === currentIndex) {
+            return;
+          }
+          const nextKey = keys[targetIndex];
+          if (nextKey !== undefined) {
+            ctx.setValue?.(nextKey);
+          }
+        }
+      }}
+      {...buttonProps}
+    >
       {children}
     </button>
   );
@@ -39,11 +114,95 @@ export function SelectValue({ placeholder }: { placeholder?: string }) {
 
 export function SelectContent({ children }: { children: React.ReactNode }) {
   const ctx = React.useContext(SelectCtx)!;
-  // 为了在未展开时也能完成 value->label 映射，保持内容挂载，仅通过 hidden 切换可见性
-  return (
-    <div className={cn('relative z-10 mt-1 w-full rounded-md border bg-white p-1 shadow', !ctx.open && 'hidden')} aria-hidden={!ctx.open}>
+  const contentRef = React.useRef<HTMLDivElement | null>(null);
+  const [style, setStyle] = React.useState<React.CSSProperties>({});
+
+  // 计算并更新弹层位置（固定定位，避免被 overflow 裁剪）
+  const updatePosition = React.useCallback(() => {
+    if (!ctx.open) return;
+    const trigger = ctx.triggerRef.current;
+    const pop = contentRef.current;
+    if (!trigger || !pop) return;
+    const rect = trigger.getBoundingClientRect();
+    const viewportW = window.innerWidth;
+    const viewportH = window.innerHeight;
+    const gap = 4; // 触发器与弹层间距
+
+    // 初步放在下方
+    let left = Math.max(8, Math.min(rect.left, viewportW - rect.width - 8));
+    let top = rect.bottom + gap;
+    let maxHeight = Math.min(320, viewportH - top - 8);
+
+    // 若底部空间不足，尝试放在上方
+    if (maxHeight < 160) {
+      const estimatedHeight = pop.getBoundingClientRect().height || 240;
+      const aboveTop = rect.top - gap - estimatedHeight;
+      if (aboveTop >= 8) {
+        top = Math.max(8, rect.top - gap - Math.min(estimatedHeight, 320));
+        maxHeight = Math.min(320, rect.top - 8);
+      }
+    }
+
+    setStyle({ position: 'fixed', left, top, width: rect.width, maxHeight });
+  }, [ctx.open]);
+
+  React.useLayoutEffect(() => {
+    if (!ctx.open) return;
+    updatePosition();
+  }, [ctx.open, updatePosition]);
+
+  React.useEffect(() => {
+    if (!ctx.open) return;
+    const onScroll = () => updatePosition();
+    const onResize = () => updatePosition();
+    window.addEventListener('scroll', onScroll, true);
+    window.addEventListener('resize', onResize);
+    return () => {
+      window.removeEventListener('scroll', onScroll, true);
+      window.removeEventListener('resize', onResize);
+    };
+  }, [ctx.open, updatePosition]);
+
+  // 点击外部关闭
+  React.useEffect(() => {
+    if (!ctx.open) return;
+    const onDown = (e: MouseEvent | FocusEvent) => {
+      const pop = contentRef.current;
+      const trigger = ctx.triggerRef.current;
+      if (!pop || !trigger) return;
+      const target = e.target as Node | null;
+      if (!target) return;
+      if (pop.contains(target)) return;
+      if (trigger.contains(target)) return;
+      ctx.setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('focusin', onDown as any);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('focusin', onDown as any);
+    };
+  }, [ctx.open, ctx]);
+
+  // 未展开时：保持内容挂载，用于 value->label 映射
+  if (!ctx.open) {
+    return (
+      <div className="hidden" aria-hidden>
+        {children}
+      </div>
+    );
+  }
+
+  return createPortal(
+    <div
+      ref={contentRef}
+      className={cn('z-[60] rounded-md border bg-white p-1 shadow-lg overflow-auto')}
+      style={style}
+      role="listbox"
+    >
       {children}
-    </div>
+    </div>,
+    document.body
   );
 }
 

--- a/web/src/lib/TERMINAL_MANAGER_README.md
+++ b/web/src/lib/TERMINAL_MANAGER_README.md
@@ -8,7 +8,7 @@ TerminalManager (轻量说明)
 - 同时导出 `HostPtyAPI` 类型用于外部注入宿主 PTY 实现
 
 构造
-- new TerminalManager(getPtyId?: (tabId)=>ptyId, hostPty?: HostPtyAPI)
+- new TerminalManager(getPtyId?: (tabId)=>ptyId, hostPty?: HostPtyAPI, appearance?: { fontFamily?: string })
   - `getPtyId`：根据 tabId 获取当前绑定 PTY id 的回调（通常从上层 state 传入）
   - `hostPty`：实现 PTY I/O 的对象（默认为 window.host.pty）
 
@@ -21,7 +21,7 @@ TerminalManager (轻量说明)
 
 使用示例（简要）
 ```ts
-const tm = new TerminalManager((tabId) => ptyByTabRef.current[tabId]);
+const tm = new TerminalManager((tabId) => ptyByTabRef.current[tabId], undefined, { fontFamily: myFont });
 // 新建 pty 后
 tm.setPty(tabId, ptyId);
 // tab 激活时

--- a/web/src/lib/font-utils.ts
+++ b/web/src/lib/font-utils.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+/**
+ * 字体工具：解析 CSS font-family 列表、检测本地字体是否可用、
+ * 并从字体栈中解析首个可用字体（用于设置页“预览实际使用字体”提示）。
+ */
+
+/**
+ * 解析 font-family 栈为数组，保留原始顺序。
+ * 兼容引号包裹的字体名与带空格的字体名。
+ */
+export function parseFontFamilyList(stack: string | null | undefined): string[] {
+  const s = String(stack || "").trim();
+  if (!s) return [];
+  const result: string[] = [];
+  let curr = "";
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        curr += ch;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch as '"' | "'";
+      continue;
+    }
+    if (ch === ',') {
+      const t = curr.trim();
+      if (t) result.push(t);
+      curr = "";
+      continue;
+    }
+    curr += ch;
+  }
+  const tail = curr.trim();
+  if (tail) result.push(tail);
+  // 去除首尾引号（若仍保留）
+  return result.map((name) => name.replace(/^(["'])(.*)\1$/, "$2").trim());
+}
+
+/**
+ * 判断是否为通用族（generic family）。
+ */
+function isGenericFamily(name: string): boolean {
+  const n = name.trim().toLowerCase();
+  return (
+    n === "monospace" ||
+    n === "serif" ||
+    n === "sans-serif" ||
+    n === "cursive" ||
+    n === "fantasy" ||
+    n === "system-ui" ||
+    n === "ui-monospace" ||
+    n === "ui-sans-serif" ||
+    n === "ui-serif" ||
+    n === "ui-rounded"
+  );
+}
+
+/**
+ * 粗略检测指定字体是否“可用”（系统已安装）。
+ * 实现：比较 base 家族（monospace/serif/sans-serif）在引入目标字体前后的度量差异。
+ */
+export function isFontAvailable(fontName: string): boolean {
+  try {
+    // 优先使用 CSS Font Loading API，精准判定字体是否可用
+    try {
+      const fontSet: any = (document as any).fonts;
+      if (fontSet && typeof fontSet.check === 'function') {
+        if (fontSet.check(`12px "${fontName}"`) || fontSet.check(`12px ${fontName}`)) {
+          return true;
+        }
+      }
+    } catch {}
+
+    const probeText = 'AaBbCcMmWw0123456789@#&*(){}[]';
+    const fontSize = 64; // 放大以提升差异度
+    const bases = ["monospace", "serif", "sans-serif"]; // 至少覆盖三类
+
+    // 预先测量各 base 家族的宽度
+    const baseWidths: Record<string, number> = {};
+    for (const base of bases) {
+      const span = document.createElement('span');
+      span.textContent = probeText;
+      span.style.position = 'absolute';
+      span.style.left = '-9999px';
+      span.style.top = '-9999px';
+      span.style.fontSize = `${fontSize}px`;
+      span.style.lineHeight = '1';
+      span.style.letterSpacing = '0';
+      span.style.whiteSpace = 'nowrap';
+      span.style.fontFamily = base;
+      document.body.appendChild(span);
+      baseWidths[base] = span.getBoundingClientRect().width;
+      document.body.removeChild(span);
+    }
+
+    // 比较引入目标字体后的宽度是否产生变化
+    for (const base of bases) {
+      const span = document.createElement('span');
+      span.textContent = probeText;
+      span.style.position = 'absolute';
+      span.style.left = '-9999px';
+      span.style.top = '-9999px';
+      span.style.fontSize = `${fontSize}px`;
+      span.style.lineHeight = '1';
+      span.style.letterSpacing = '0';
+      span.style.whiteSpace = 'nowrap';
+      span.style.fontFamily = `'${fontName}', ${base}`;
+      document.body.appendChild(span);
+      const w = span.getBoundingClientRect().width;
+      document.body.removeChild(span);
+      if (Math.abs(w - baseWidths[base]) > 0.5) {
+        return true;
+      }
+    }
+  } catch {
+    // 忽略异常：保守判定为不可用
+  }
+  return false;
+}
+
+export type ResolvedFont = {
+  /** 实际使用的首个可用字体名；若仅命中 generic family，则返回该 generic 名 */
+  name: string;
+  /** 是否从首选回退（即解析到的 name 不是列表第一个具体字体） */
+  isFallback: boolean;
+};
+
+/**
+ * 从 CSS 字体栈中解析首个可用的字体名。
+ * 策略：优先命中具体字体；若均不可用，返回遇到的第一个 generic（如 monospace）。
+ */
+export function resolveFirstAvailableFont(stack: string): ResolvedFont {
+  const list = parseFontFamilyList(stack);
+  if (list.length === 0) return { name: 'monospace', isFallback: true };
+  let firstConcrete: string | null = null;
+  for (const name of list) {
+    if (!isGenericFamily(name)) {
+      if (!firstConcrete) firstConcrete = name;
+      if (isFontAvailable(name)) {
+        return { name, isFallback: firstConcrete !== name };
+      }
+    }
+  }
+  // 未命中具体字体，返回首个 generic 或默认 monospace
+  const generic = list.find(isGenericFamily) || 'monospace';
+  return { name: generic, isFallback: true };
+}
+
+/**
+ * 判断字体是否为等宽字体（monospace）。
+ * 方法：比较 "iiiiiiiiii" 与 "WWWWWWWWWW" 渲染宽度是否一致。
+ */
+export function isMonospaceFont(fontName: string): boolean {
+  try {
+    const textNarrow = 'iiiiiiiiii';
+    const textWide = 'WWWWWWWWWW';
+    const container = document.createElement('div');
+    container.style.position = 'absolute';
+    container.style.left = '-9999px';
+    container.style.top = '-9999px';
+    container.style.whiteSpace = 'nowrap';
+    container.style.visibility = 'hidden';
+    document.body.appendChild(container);
+    const mk = (t: string) => {
+      const span = document.createElement('span');
+      span.textContent = t;
+      span.style.fontSize = '64px';
+      span.style.lineHeight = '1';
+      span.style.letterSpacing = '0';
+      span.style.fontFamily = `'${fontName}', monospace`;
+      container.appendChild(span);
+      const w = span.getBoundingClientRect().width;
+      container.removeChild(span);
+      return w;
+    };
+    const w1 = mk(textNarrow);
+    const w2 = mk(textWide);
+    document.body.removeChild(container);
+    return Math.abs(w1 - w2) < 0.5; // 允许极小的浮点误差
+  } catch {
+    return false;
+  }
+}
+
+
+

--- a/web/src/lib/terminal-appearance.ts
+++ b/web/src/lib/terminal-appearance.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import { parseFontFamilyList } from "@/lib/font-utils";
+
+export const DEFAULT_TERMINAL_FONT_FAMILY =
+  'Cascadia Code, Cascadia Mono, Consolas, ui-monospace, SFMono-Regular, Menlo, Monaco, "Liberation Mono", monospace, "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji", "Apple Color Emoji", "Twemoji Mozilla", "Microsoft YaHei UI", "Microsoft YaHei", SimSun, SimHei, "Noto Sans CJK SC", "Source Han Sans SC"';
+
+export type TerminalAppearance = {
+  fontFamily: string;
+};
+
+export function normalizeTerminalFontFamily(raw?: string | null): string {
+  if (typeof raw !== "string") return DEFAULT_TERMINAL_FONT_FAMILY;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : DEFAULT_TERMINAL_FONT_FAMILY;
+}
+
+export function normalizeTerminalAppearance(
+  partial?: Partial<TerminalAppearance>
+): TerminalAppearance {
+  return {
+    fontFamily: normalizeTerminalFontFamily(partial?.fontFamily),
+  };
+}
+
+/**
+ * 构建终端字体栈：将 primary 放在首位，并与默认栈去重合并。
+ * 注意：即使默认栈已包含该字体，也应置首，避免被其它默认项（如 Cascadia Code）“抢占第一”。
+ */
+export function buildTerminalFontStack(primary?: string | null): string {
+  const head = typeof primary === "string" ? primary.trim() : "";
+  if (!head) return DEFAULT_TERMINAL_FONT_FAMILY;
+  const needsQuote = /\s/.test(head) && !/^['"].*['"]$/.test(head);
+  const first = needsQuote ? `'${head}'` : head;
+  const baseList = parseFontFamilyList(DEFAULT_TERMINAL_FONT_FAMILY);
+  const dedup = baseList.filter((n) => n.toLowerCase() !== head.toLowerCase());
+  return [first, ...dedup].join(", ");
+}
+
+

--- a/web/src/locales/en/settings.json
+++ b/web/src/locales/en/settings.json
@@ -53,6 +53,31 @@
   "wslDistroHelp": "Select the default distribution used when opening a WSL terminal.",
   "codexCmd": "CodexFlow launch command",
   "codexCmdHelp": "Customize the command CodexFlow runs when launching from the terminal.",
+  "terminalFont": {
+    "label": "Terminal font",
+    "help": "Choose the monospaced font for the integrated terminal. The preview below updates in real time.",
+    "placeholder": "e.g. Cascadia Code, Consolas, monospace",
+    "note": "If a font is not installed, the terminal falls back to the system default.",
+    "custom": "Custom font stack",
+    "previewTitle": "Preview",
+    "preview": "0123456789 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ !@#$%^&*() <>",
+    "effective": "Effective: {name}",
+    "fallback": "Fallback in use: {name}",
+    "installedLabel": "Installed fonts",
+    "installedPlaceholder": "Pick a font",
+    "installedNone": "No system fonts detected",
+    "recommendedTag": "recommended",
+    "showAll": "Show all fonts",
+    "showAllHint": "If enabled, the list above shows every installed font. Otherwise only monospace fonts appear.",
+    "prev": "Previous font",
+    "next": "Next font",
+    "presets": {
+      "cascadia": "Cascadia Code (recommended)",
+      "jetbrains": "JetBrains Mono",
+      "fira": "Fira Code"
+    }
+  },
+  "loading": "Loading…",
   "codexTrace": {
     "label": "Codex TUI debugging",
     "help": "Control whether CodexFlow adds trace logging flags when launching Codex (applies to new terminals). The switch is managed by debug.config.jsonc.",

--- a/web/src/locales/zh/settings.json
+++ b/web/src/locales/zh/settings.json
@@ -53,6 +53,31 @@
   "wslDistroHelp": "指定打开 WSL 终端时默认使用的发行版。",
   "codexCmd": "CodexFlow 启动命令",
   "codexCmdHelp": "自定义从终端启动 CodexFlow 时执行的命令。",
+  "terminalFont": {
+    "label": "终端字体",
+    "help": "选择终端使用的等宽字体，底部预览区会实时显示当前选中字体的渲染效果。",
+    "placeholder": "例如：Cascadia Code, Consolas, monospace",
+    "note": "如所选字体未安装，终端会自动回退到系统等宽字体。",
+    "custom": "自定义字体栈",
+    "previewTitle": "预览效果",
+    "preview": "0123456789 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ !@#$%^&*() <>",
+    "effective": "实际使用：{name}",
+    "fallback": "未安装所选字体，已回退至：{name}",
+    "installedLabel": "系统已安装字体",
+    "installedPlaceholder": "选择字体",
+    "installedNone": "未检测到系统字体",
+    "recommendedTag": "推荐",
+    "showAll": "显示所有字体",
+    "showAllHint": "启用后，上方列表会展示所有已安装字体；否则仅显示等宽字体。",
+    "prev": "上一字体",
+    "next": "下一字体",
+    "presets": {
+      "cascadia": "Cascadia Code（推荐）",
+      "jetbrains": "JetBrains Mono",
+      "fira": "Fira Code"
+    }
+  },
+  "loading": "加载中…",
   "codexTrace": {
     "label": "Codex TUI 调试",
     "help": "控制 CodexFlow 启动 Codex 时是否自动附加 trace 日志参数（作用于新打开的终端）。该开关归属 debug.config.jsonc。",

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -25,6 +25,8 @@ export type AppSettings = {
     proxyUrl?: string;
     noProxy?: string;
   };
+  /** 终端字体栈 */
+  terminalFontFamily?: string;
 };
 
 export type Project = {
@@ -173,6 +175,10 @@ export interface UtilsAPI {
   chooseFolder(): Promise<{ ok: boolean; path?: string; canceled?: boolean; error?: string }>;
   debugTermGet(): Promise<{ ok: boolean; enabled?: boolean; error?: string }>;
   debugTermSet(enabled: boolean): Promise<{ ok: boolean; error?: string }>;
+  /** 列出系统已安装字体名称（Windows）。其他平台返回空数组。 */
+  listFonts(): Promise<string[]>;
+  /** 列出系统字体详情：包含路径与是否等宽（基于字体表元数据判定）。 */
+  listFontsDetailed(): Promise<Array<{ name: string; file?: string; monospace: boolean }>>;
 }
 
 export interface AppAPI {


### PR DESCRIPTION
- 主进程新增字体枚举能力（listFonts/listFontsDetailed）
  - 解析 Windows 注册表获取系统已安装字体
  - 支持多编码格式（UTF-16LE/UTF-8/GBK），兼容中文字体名
  - 集成 opentype.js 解析字体元数据，精确判定是否等宽
  - 实现缓存机制，避免重复解析影响性能
- 设置页新增终端字体配置面板
  - 等宽字体优先显示，支持"显示所有字体"切换
  - 实时预览字体渲染效果，显示实际使用/回退提示
  - 支持键盘导航（上下箭头快速切换字体）
  - 自动推荐 Cascadia Mono/Cascadia Code
- 重构 Select 组件支持 Portal 渲染
  - 修复在 overflow: hidden 容器中被裁剪的问题
  - 新增键盘导航（ArrowUp/ArrowDown 切换选项）
  - 自动计算弹层位置，避免超出视口
- TerminalManager/TerminalAdapter 支持动态外观更新
  - 新增 setAppearance 方法，支持运行时更新字体
  - 构造函数支持传入初始 appearance 配置
  - 自动触发 reflow 确保布局正确
- 新增字体工具库（font-utils.ts）
  - parseFontFamilyList：解析 CSS font-family 栈
  - isFontAvailable：检测字体是否已安装
  - resolveFirstAvailableFont：从栈中解析首个可用字体
  - isMonospaceFont：判定字体是否等宽
- 新增终端外观管理（terminal-appearance.ts）
  - 定义 TerminalAppearance 类型和默认字体栈
  - buildTerminalFontStack：构建包含回退的字体栈
  - normalizeTerminalFontFamily：规整化字体配置
- 配置持久化支持
  - AppSettings 新增 terminalFontFamily 字段
  - 保存/加载逻辑完整同步到 UI
- 完善多语言支持（中英文）
  - 新增 settings:terminalFont.* 翻译键
  - 包含加载提示、预览说明、键盘提示等
- 新增依赖
  - opentype.js: 字体元数据解析
  - iconv-lite: 多编码支持（处理注册表输出）
- 新增类型声明（electron/types/opentype-js.d.ts）