### PR TITLE
feat: 重构多语言文件结构，修复拖拽文件重复问题

### DIFF
--- a/docs/locales-template/en/common.json
+++ b/docs/locales-template/en/common.json
@@ -5,15 +5,18 @@
     "language_en": "English",
     "language_zh": "简体中文"
   },
-  "common": {
-    "ok": "OK",
-    "cancel": "Cancel",
-    "save": "Save",
-    "open": "Open"
-  },
+  "ok": "OK",
+  "cancel": "Cancel",
+  "save": "Save",
+  "open": "Open",
+  "refresh": "Refresh",
   "files": {
     "copyFileNameWithExt": "Copy filename (with extension)",
-    "cannotOpenPath": "Unable to open path"
+    "cannotOpenPath": "Unable to open path",
+    "image": "Image",
+    "path": "Path",
+    "rule": "Rule",
+    "deleteImageAndText": "Delete image and associated text"
   }
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3585,7 +3585,7 @@ export default function CodexFlowManagerUI() {
               </div>
             )}
             <div className="flex justify-end gap-2 pt-4">
-              <Button onClick={() => setBlockingNotice(null)}>{t(['common:ok', 'common:common.ok'])}</Button>
+              <Button onClick={() => setBlockingNotice(null)}>{t('common:ok')}</Button>
             </div>
           </DialogContent>
         </Dialog>

--- a/web/src/components/topbar/codex-status.tsx
+++ b/web/src/components/topbar/codex-status.tsx
@@ -310,7 +310,7 @@ const CodexUsageHoverButton: React.FC<{ className?: string; terminalMode?: "wsl"
               }}
             >
               <RotateCcw className="h-3.5 w-3.5" />
-              {t(["common:refresh", "common:common.refresh"], "刷新")}
+              {t("common:refresh", "刷新")}
             </Button>
           </div>
         </div>
@@ -397,7 +397,7 @@ export const CodexAccountInline: React.FC<{
       <div className="mt-3 flex justify-end">
         <Button size="sm" variant="outline" className="gap-2" onClick={() => reloadAccount()}>
           <RotateCcw className="h-3.5 w-3.5" />
-          {t(["common:refresh", "common:common.refresh"], "刷新")}
+          {t("common:refresh", "刷新")}
         </Button>
       </div>
     </>

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1,23 +1,22 @@
 {
+  "ok": "OK",
   "cancel": "Cancel",
   "save": "Save",
   "open": "Open",
+  "refresh": "Refresh",
   "app": {
     "name": "CodexFlow",
     "language": "Language",
     "language_en": "English",
     "language_zh": "简体中文"
   },
-  "common": {
-    "ok": "OK",
-    "cancel": "Cancel",
-    "save": "Save",
-    "open": "Open",
-    "refresh": "Refresh"
-  },
   "files": {
     "copyFileNameWithExt": "Copy filename (with extension)",
-    "cannotOpenPath": "Unable to open path"
+    "cannotOpenPath": "Unable to open path",
+    "image": "Image",
+    "path": "Path",
+    "rule": "Rule",
+    "deleteImageAndText": "Delete image and associated text"
   },
   "codexUsage": {
     "loading": "Loading usage…",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -1,23 +1,22 @@
 {
+  "ok": "确定",
   "cancel": "取消",
   "save": "保存",
   "open": "打开",
+  "refresh": "刷新",
   "app": {
     "name": "CodexFlow",
     "language": "语言",
     "language_en": "English",
     "language_zh": "简体中文"
   },
-  "common": {
-    "ok": "确定",
-    "cancel": "取消",
-    "save": "保存",
-    "open": "打开",
-    "refresh": "刷新"
-  },
   "files": {
     "copyFileNameWithExt": "复制文件名（含后缀）",
-    "cannotOpenPath": "无法打开路径"
+    "cannotOpenPath": "无法打开路径",
+    "image": "图片",
+    "path": "路径",
+    "rule": "规则",
+    "deleteImageAndText": "删除图片与关联文字"
   },
   "codexUsage": {
     "loading": "正在同步用量…",


### PR DESCRIPTION
- 重构 common.json 语言文件，将 common 对象下内容移至根级别
- 添加新的翻译键：refresh、image、path、rule、deleteImageAndText
- 修复 PathChipsInput 拖拽同一文件时出现重复 chips 的问题
- 添加路径去重逻辑，支持 Windows/WSL 路径规范化比较
- 更新组件翻译键引用格式，从数组形式改为直接键名
- 在 AtInput 组件中添加翻译支持和图片处理改进
- 移除未使用的 useMemo 导入