### PR TITLE
chore: 为历史记录缓存添加版本控制与自动清理机制

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -12,7 +12,7 @@ import { PTYManager, setTermDebug } from "./pty";
 import opentype from 'opentype.js';
 import iconv from 'iconv-lite';
 import projects, { IMPLEMENTATION_NAME as PROJECTS_IMPL } from "./projects/index";
-import history from "./history";
+import history, { purgeHistoryCacheIfOutdated } from "./history";
 import { startHistoryIndexer, getIndexedSummaries, getIndexedDetails, getLastIndexerRoots, stopHistoryIndexer } from "./indexer";
 import { getSessionsRootsFastAsync } from "./wsl";
 import { perfLogger } from "./log";
@@ -688,6 +688,7 @@ if (!gotLock) {
     // 启动时静默检查更新由渲染进程完成（仅提示，不下载）
     try { setTermDebug(!!getDebugConfig().terminal.pty.debug); } catch {}
     // 启动历史索引器：后台并发解析、缓存、监听变更
+    try { purgeHistoryCacheIfOutdated(); } catch {}
     try { await startHistoryIndexer(() => mainWindow); } catch (e) { console.warn('indexer start failed', e); }
     // 启动后立刻触发一次 UI 强制刷新，确保首次 ready 后显示索引内容
     try { mainWindow?.webContents.send('history:index:add', { items: [] }); } catch {}


### PR DESCRIPTION
- history.ts: 引入 PARSER_VERSION v8 与 CACHE_SCHEMA_VERSION 2，增强缓存持久化结构，自动清理过期缓存
- indexer.ts: 升级索引器版本至 v7，添加 purgeLegacyPersistFiles 函数自动清理旧版本持久化文件，优化性能（避免重复 toLowerCase 调用）
- main.ts: 启动时调用 purgeHistoryCacheIfOutdated() 确保缓存版本一致性

此改动解决了版本升级时缓存格式不兼容导致的潜在问题，并自动清理历史遗留文件，减少磁盘占用。