### PR TITLE
feat: 优化主题预加载，消除首帧闪烁

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,9 +1,79 @@
 <!doctype html>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk) -->
 <html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodexFlow</title>
+    <style>
+      :root {
+        --theme-bg-light: #ffffff;
+        --theme-bg-dark: #22272e;
+        --theme-text-light: #24292f;
+        --theme-text-dark: #adbac7;
+      }
+    </style>
+    <script>
+      (function () {
+        var STORAGE_KEY = "codexflow.themeSetting";
+        var DARK_MEDIA = "(prefers-color-scheme: dark)";
+        var readVar = function (name, fallback) {
+          try {
+            var v = getComputedStyle(document.documentElement).getPropertyValue(name);
+            v = (v || "").trim();
+            return v || fallback;
+          } catch (error) {
+            return fallback;
+          }
+        };
+        var LIGHT_BG = readVar("--theme-bg-light", "#ffffff");
+        var DARK_BG = readVar("--theme-bg-dark", "#22272e");
+        var LIGHT_TEXT = readVar("--theme-text-light", "#24292f");
+        var DARK_TEXT = readVar("--theme-text-dark", "#adbac7");
+
+        var cached = null;
+        try {
+          cached = localStorage.getItem(STORAGE_KEY);
+        } catch (error) {
+          cached = null;
+        }
+
+        var setting = (cached === "light" || cached === "dark" || cached === "system") ? cached : "system";
+        var prefersDark = false;
+        try {
+          prefersDark = !!(window.matchMedia && window.matchMedia(DARK_MEDIA).matches);
+        } catch (error) {
+          prefersDark = false;
+        }
+        var mode = (setting === "light" || setting === "dark") ? setting : (prefersDark ? "dark" : "light");
+
+        var doc = document;
+        var root = doc.documentElement;
+        var isDark = mode === "dark";
+        root.classList.toggle("dark", isDark);
+        root.dataset.theme = mode;
+        root.dataset.themeSetting = setting;
+        try { root.style.colorScheme = mode; } catch (error) {}
+        var bg = isDark ? DARK_BG : LIGHT_BG;
+        var fg = isDark ? DARK_TEXT : LIGHT_TEXT;
+        try { root.style.backgroundColor = bg; } catch (error) {}
+
+        var applyBody = function () {
+          var body = doc.body;
+          if (!body) return;
+          body.classList.toggle("dark", isDark);
+          try { body.style.backgroundColor = bg; } catch (error) {}
+          try { body.style.color = fg; } catch (error) {}
+        };
+
+        if (doc.readyState === "loading") {
+          doc.addEventListener("DOMContentLoaded", applyBody, { once: true });
+        } else {
+          applyBody();
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/lib/TerminalManager.ts
+++ b/web/src/lib/TerminalManager.ts
@@ -581,7 +581,8 @@ export default class TerminalManager {
       try { existingCleanup(); } catch {}
     }
     this.resizeUnsubByTab[tabId] = null;
-    try { this.hostResizeObserverByTab[tabId]?.disconnect(); } catch {}
+    const prevObserver = this.hostResizeObserverByTab[tabId] || null;
+    try { if (prevObserver) prevObserver.disconnect(); } catch {}
     this.hostResizeObserverByTab[tabId] = null;
 
     const persistent = this.ensurePersistentContainer(tabId);
@@ -603,7 +604,12 @@ export default class TerminalManager {
     // (e.g. window restore/maximize or side panel toggles) and trigger terminal resize.
     try {
       // disconnect any existing observer first
-      try { this.hostResizeObserverByTab[tabId]?.disconnect(); } catch {}
+      const oldObserver = this.hostResizeObserverByTab[tabId] ?? null;
+      try {
+        if (oldObserver && typeof (oldObserver as any).disconnect === 'function') {
+          (oldObserver as any).disconnect();
+        }
+      } catch {}
       const ro = new ResizeObserver(() => {
         try {
           const host = this.hostElByTab[tabId];

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,6 +8,10 @@ import App from './App';
 import { I18nextProvider } from 'react-i18next';
 import i18n, { initI18n } from '@/i18n/setup';
 import ErrorBoundary from '@/components/ErrorBoundary';
+import { applyTheme, getCachedThemeSetting } from '@/lib/theme';
+
+const cachedThemeSetting = getCachedThemeSetting();
+applyTheme(cachedThemeSetting ?? 'system');
 
 const root = createRoot(document.getElementById('root')!);
 


### PR DESCRIPTION
- 在 index.html 添加内联主题脚本，实现页面加载前的主题应用
- 新增 getCachedThemeSetting 和 writeThemeSettingCache 函数
- 在 App.tsx 多处调用缓存写入，确保主题偏好持久化
- 修复 TerminalManager 中 ResizeObserver 的清理逻辑

问题：
- 用户在刷新页面或首次加载时，可能看到短暂的白色/黑色闪烁
- 主题设置未在 localStorage 中缓存，每次需要重新推断

改进：
- 通过内联脚本在 HTML 解析阶段即读取缓存并应用主题
- 添加主题缓存读写工具函数，确保用户偏好在会话间保持
- 增强 ResizeObserver 断开连接的防御性检查