### PR TITLE
feat: 重构图片资源管理机制，引入引用计数与去重复用

### DIFF
--- a/web/src/lib/imageResourceRegistry.ts
+++ b/web/src/lib/imageResourceRegistry.ts
@@ -1,0 +1,123 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import type { PastedImage, SavedImage } from "@/lib/clipboardImages";
+
+export type ChipResourceLike = {
+  fingerprint?: string;
+  winPath?: string;
+  wslPath?: string;
+  fileName?: string;
+  fromPaste?: boolean;
+};
+
+type ResourceEntry = {
+  fingerprint?: string;
+  winPath?: string;
+  wslPath?: string;
+  fileName?: string;
+  fromPaste: boolean;
+  refCount: number;
+};
+
+const resourcesByWinPath = new Map<string, ResourceEntry>();
+const resourcesByFingerprint = new Map<string, ResourceEntry>();
+
+function normalizeFingerprint(fp?: string): string {
+  if (!fp) return "";
+  return String(fp).trim();
+}
+
+function getEntry(meta: ChipResourceLike, createIfMissing: boolean): ResourceEntry | null {
+  if (!meta || !meta.fromPaste) return null;
+  const winPath = typeof meta.winPath === "string" ? meta.winPath.trim() : "";
+  const fingerprint = normalizeFingerprint(meta.fingerprint);
+  if (!createIfMissing && !winPath && !fingerprint) return null;
+  let entry: ResourceEntry | undefined;
+  if (winPath) entry = resourcesByWinPath.get(winPath);
+  if (!entry && fingerprint) entry = resourcesByFingerprint.get(fingerprint);
+  if (!entry) {
+    if (!createIfMissing) return null;
+    if (!winPath && !fingerprint) return null;
+    entry = {
+      fingerprint: fingerprint || undefined,
+      winPath: winPath || undefined,
+      wslPath: meta.wslPath ? String(meta.wslPath) : undefined,
+      fileName: meta.fileName ? String(meta.fileName) : undefined,
+      fromPaste: !!meta.fromPaste,
+      refCount: 0,
+    };
+  } else {
+    if (winPath) entry.winPath = winPath;
+    if (fingerprint) entry.fingerprint = fingerprint;
+    if (meta.wslPath && !entry.wslPath) entry.wslPath = String(meta.wslPath);
+    if (meta.fileName && !entry.fileName) entry.fileName = String(meta.fileName);
+    if (meta.fromPaste) entry.fromPaste = true;
+  }
+  if (entry.winPath) resourcesByWinPath.set(entry.winPath, entry);
+  if (entry.fingerprint) resourcesByFingerprint.set(entry.fingerprint, entry);
+  return entry;
+}
+
+export function rememberSavedImages(images: SavedImage[]): void {
+  try {
+    for (const image of images) {
+      if (!image || !image.fromPaste || !image.winPath) continue;
+      getEntry(image, true);
+    }
+  } catch {}
+}
+
+export function reuseSavedImageFromFingerprint(image: PastedImage): SavedImage | null {
+  try {
+    const fingerprint = normalizeFingerprint(image?.fingerprint);
+    if (!fingerprint) return null;
+    const entry = resourcesByFingerprint.get(fingerprint);
+    if (!entry || !entry.winPath) return null;
+    return {
+      ...image,
+      saved: true,
+      fromPaste: true,
+      winPath: entry.winPath,
+      wslPath: entry.wslPath,
+      fileName: entry.fileName,
+    } as SavedImage;
+  } catch {
+    return null;
+  }
+}
+
+export function retainPastedImage(meta: ChipResourceLike): void {
+  try {
+    if (!meta || !meta.fromPaste || !meta.winPath) return;
+    const entry = getEntry(meta, true);
+    if (!entry) return;
+    entry.refCount += 1;
+  } catch {}
+}
+
+export function releasePastedImage(meta: ChipResourceLike): { shouldTrash: boolean; winPath?: string } {
+  try {
+    if (!meta || !meta.fromPaste || !meta.winPath) return { shouldTrash: false };
+    const entry = getEntry(meta, false);
+    if (!entry) return { shouldTrash: false };
+    entry.refCount = Math.max(0, entry.refCount - 1);
+    if (entry.refCount > 0) return { shouldTrash: false };
+    if (entry.winPath) resourcesByWinPath.delete(entry.winPath);
+    if (entry.fingerprint) resourcesByFingerprint.delete(entry.fingerprint);
+    return { shouldTrash: entry.fromPaste && !!entry.winPath, winPath: entry.winPath };
+  } catch {
+    return { shouldTrash: false };
+  }
+}
+
+// 请求主进程删除已失效的粘贴图片，并吞掉潜在异常与拒绝，避免渲染端出现 UnhandledPromiseRejection
+export function requestTrashWinPath(winPath?: string): void {
+  try {
+    if (!winPath) return;
+    const maybePromise: Promise<any> | undefined = (window as any).host?.images?.trash?.({ winPath });
+    if (maybePromise && typeof maybePromise.catch === "function") {
+      maybePromise.catch(() => {});
+    }
+  } catch {}
+}

--- a/web/src/lib/previewUrlRegistry.ts
+++ b/web/src/lib/previewUrlRegistry.ts
@@ -1,0 +1,27 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+const previewUrlRefCounts = new Map<string, number>();
+
+function isBlobUrl(url: string | undefined | null): url is string {
+  return typeof url === "string" && url.startsWith("blob:");
+}
+
+export function retainPreviewUrl(url: string | undefined | null): void {
+  if (!isBlobUrl(url)) return;
+  const prev = previewUrlRefCounts.get(url) || 0;
+  previewUrlRefCounts.set(url, prev + 1);
+}
+
+export function releasePreviewUrl(url: string | undefined | null): void {
+  if (!isBlobUrl(url)) return;
+  const prev = previewUrlRefCounts.get(url);
+  if (prev === undefined) return;
+  if (prev <= 1) {
+    previewUrlRefCounts.delete(url);
+    try { URL.revokeObjectURL(url); } catch {}
+  } else {
+    previewUrlRefCounts.set(url, prev - 1);
+  }
+}
+


### PR DESCRIPTION
技术改进：
- 新增 imageResourceRegistry.ts：统一管理粘贴图片的引用计数，支持基于指纹的去重复用
- 新增 previewUrlRegistry.ts：统一管理 blob URL 的引用计数，防止内存泄漏
- 重构 App.tsx：集成资源注册表，在发送命令后延迟 3 分钟清理，避免命令执行期间文件被提前删除
- 重构 CommandInputWithAt.tsx：使用资源注册表管理粘贴图片生命周期
- 重构 path-chips-input.tsx：移除本地预览 URL 管理逻辑，统一使用全局注册表
- 优化 clipboardImages.ts：集成指纹去重机制，相同图片自动复用已保存文件

功能变化:
- 优化图片粘贴体验：相同图片不会重复保存到磁盘
- 修复全屏输入时图片失效问题
- 改进资源清理时机，避免命令执行期间文件被误删
- 提升内存管理效率，防止 blob URL 泄漏