### PR TITLE
fix: 收敛文件索引活跃根与前端缓存

### DIFF
--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -197,7 +197,7 @@ export interface WslAPI {
 export interface FileIndexAPI {
   ensureIndex(args: { root: string; excludes?: string[] }): Promise<{ ok: boolean; total?: number; updatedAt?: number; error?: string }>;
   getAllCandidates(root: string): Promise<{ ok: boolean; items?: Array<{ rel: string; isDir: boolean }>; error?: string }>;
-  setActiveRoots(roots: string[]): Promise<{ ok: boolean; closed?: number; remain?: number; error?: string }>;
+  setActiveRoots(roots: string[]): Promise<{ ok: boolean; closed?: number; remain?: number; trimmed?: number; error?: string }>;
   onChanged?: (handler: (payload: { root: string; reason?: string; adds?: { rel: string; isDir: boolean }[]; removes?: { rel: string; isDir: boolean }[] }) => void) => () => void;
 }
 


### PR DESCRIPTION
- fileIndex 将活跃根与内存缓存同步裁剪并返回 trimmed 指标，降低大仓常驻
- 主进程合并多窗口活跃根，避免跨窗口互相清空 watcher
- 前端 @ 搜索收紧缓存数量、增加空闲/隐藏清理与自动恢复最近根，防止旧结果回写
- host 类型同步 trimmed 字段