### PR TITLE
fix(history): 修复清除空历史误包含非空会话

### DIFF
--- a/electron/agentSessions/shared/empty.test.ts
+++ b/electron/agentSessions/shared/empty.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import { describe, it, expect } from "vitest";
+import { hasNonEmptyIOFromMessages } from "./empty";
+
+describe("hasNonEmptyIOFromMessages", () => {
+  it("空数组/空值返回 false", () => {
+    expect(hasNonEmptyIOFromMessages(undefined)).toBe(false);
+    expect(hasNonEmptyIOFromMessages(null)).toBe(false);
+    expect(hasNonEmptyIOFromMessages([] as any)).toBe(false);
+  });
+
+  it("识别 input_text / output_text 为有效输入输出", () => {
+    expect(hasNonEmptyIOFromMessages([
+      { role: "user", content: [{ type: "input_text", text: "hi" }] },
+    ] as any)).toBe(true);
+
+    expect(hasNonEmptyIOFromMessages([
+      { role: "assistant", content: [{ type: "output_text", text: "ok" }] },
+    ] as any)).toBe(true);
+  });
+
+  it("兼容旧格式：user/assistant 的 text 也视为有效", () => {
+    expect(hasNonEmptyIOFromMessages([
+      { role: "user", content: [{ type: "text", text: "legacy user" }] },
+    ] as any)).toBe(true);
+
+    expect(hasNonEmptyIOFromMessages([
+      { role: "assistant", content: [{ type: "text", text: "legacy assistant" }] },
+    ] as any)).toBe(true);
+  });
+
+  it("忽略仅包含空白文本的 content", () => {
+    expect(hasNonEmptyIOFromMessages([
+      { role: "user", content: [{ type: "input_text", text: "   \n\t" }] },
+      { role: "assistant", content: [{ type: "output_text", text: "" }] },
+    ] as any)).toBe(false);
+  });
+
+  it("忽略非 user/assistant 的 text（避免把 meta 当成输入输出）", () => {
+    expect(hasNonEmptyIOFromMessages([
+      { role: "meta", content: [{ type: "text", text: "meta text" }] },
+      { role: "system", content: [{ type: "text", text: "system text" }] },
+    ] as any)).toBe(false);
+  });
+
+  it("忽略 instructions/environment_context 等非输入输出类型", () => {
+    expect(hasNonEmptyIOFromMessages([
+      { role: "user", content: [{ type: "instructions", text: "rules" }] },
+      { role: "user", content: [{ type: "environment_context", text: "<cwd>/x</cwd>" }] },
+      { role: "assistant", content: [{ type: "meta", text: "thinking" }] },
+    ] as any)).toBe(false);
+  });
+});
+

--- a/electron/agentSessions/shared/empty.ts
+++ b/electron/agentSessions/shared/empty.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import type { Message } from "../../history";
+
+/**
+ * 判断会话 messages 中是否存在“有效输入/输出”的非空文本。
+ *
+ * 说明：
+ * - 主通道：input_text / output_text
+ * - 兼容旧格式：user/assistant 的 text 也视为有效（避免把旧日志误判为空历史）
+ * - 其他类型一律不计入（例如 instructions/environment_context/meta/tool 等）
+ */
+export function hasNonEmptyIOFromMessages(messages: Message[] | null | undefined): boolean {
+  try {
+    for (const m of (messages || [])) {
+      const role = String((m as any)?.role || "").toLowerCase();
+      const items = Array.isArray((m as any)?.content) ? (m as any).content : [];
+      for (const it of items) {
+        const ty = String((it as any)?.type || "").toLowerCase();
+        const txt = String((it as any)?.text || "").trim();
+        if (!txt) continue;
+        if (ty === "input_text" || ty === "output_text") return true;
+        if (ty === "text" && (role === "user" || role === "assistant")) return true;
+      }
+    }
+  } catch {}
+  return false;
+}
+


### PR DESCRIPTION
问题：设置面板的“清除空历史”在判定空会话时会把部分非空历史也纳入候选。

修复：
- 空会话判定改为“安全优先”：解析失败/文件不存在不纳入候选，避免误删
- 优先使用索引 preview 快速排除非空会话，减少不必要解析
- 按 provider 选择解析器，并加入大小/行数保护，避免大文件性能与误判风险
- 抽取 hasNonEmptyIOFromMessages，兼容旧格式 user/assistant 的 text

测试：
- 新增 hasNonEmptyIOFromMessages 的单元测试