### PR TITLE
feat(codex): 支持账号备份与一键切换

### DIFF
--- a/electron/codex/authBackups.ts
+++ b/electron/codex/authBackups.ts
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import { app } from "electron";
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { CodexAccountInfo, CodexBridgeOptions } from "./bridge";
+import { getDistroCodexUNCAsync } from "../wsl";
+
+export type CodexAccountStatusKey = "signed_in" | "signed_out";
+
+export type CodexAuthBackupItem = {
+  id: string;
+  createdAt: number;
+  updatedAt: number;
+  runtimeKey: string;
+  signature: string;
+  status: CodexAccountStatusKey;
+  accountId: string | null;
+  userId: string | null;
+  email: string | null;
+  plan: string | null;
+  reason: string;
+};
+
+type CodexAuthBackupMeta = CodexAuthBackupItem & {
+  version: 1;
+};
+
+/**
+ * 生成一个稳定的“账号状态”键：仅用于识别与比对，不参与 UI 文案。
+ */
+export function resolveCodexAccountStatusKey(info: CodexAccountInfo | null | undefined): CodexAccountStatusKey {
+  const accountId = String(info?.accountId || "").trim();
+  const userId = String(info?.userId || "").trim();
+  const email = String(info?.email || "").trim();
+  return (accountId || userId || email) ? "signed_in" : "signed_out";
+}
+
+/**
+ * 生成“账号身份签名”：用于识别账号变化与备份去重。
+ * 说明：
+ * - 旧版本仅使用 accountId，部分环境下可能无法区分不同账号；
+ * - 新版本优先使用 userId 作为身份（其次 accountId，再其次 email），确保可同时保留多个账号备份用于切换。
+ */
+export function resolveCodexAccountSignature(info: CodexAccountInfo | null | undefined): {
+  status: CodexAccountStatusKey;
+  accountId: string | null;
+  signature: string;
+} {
+  const status = resolveCodexAccountStatusKey(info);
+  const accountId = status === "signed_in" ? String(info?.accountId || "").trim() || null : null;
+  const userId = status === "signed_in" ? String(info?.userId || "").trim() || null : null;
+  const email = status === "signed_in" ? String(info?.email || "").trim().toLowerCase() || null : null;
+  const identity = userId || accountId || email || "";
+  const signature = `v2|${status}|${identity}`;
+  return { status, accountId, signature };
+}
+
+/**
+ * 校验备份 ID：避免渲染层注入任意路径读写。
+ */
+export function isSafeAuthBackupId(id: string): boolean {
+  const s = String(id || "").trim().toLowerCase();
+  return /^[a-f0-9]{12,64}$/.test(s);
+}
+
+/**
+ * 获取 CodexFlow 用户数据目录（失败则回退到 ~/.codexflow）。
+ */
+function getUserDataDir(): string {
+  try {
+    const p = app.getPath("userData");
+    return p || path.join(os.homedir(), ".codexflow");
+  } catch {
+    return path.join(os.homedir(), ".codexflow");
+  }
+}
+
+/**
+ * 获取 auth.json 备份根目录（全局共享，不随运行环境隔离）。
+ */
+function getBackupDir(_runtimeKey: string): string {
+  return path.join(getUserDataDir(), "codex-auth-backups");
+}
+
+/**
+ * 将签名映射为备份文件 ID（稳定且尽量短）。
+ */
+function backupIdFromSignature(signature: string): string {
+  return createHash("sha256").update(String(signature || ""), "utf8").digest("hex").slice(0, 16);
+}
+
+/**
+ * 仅更新指定签名的备份 meta（不重写 auth 文件），用于补齐套餐/邮箱等字段。
+ * - 若 auth 备份不存在则返回错误（调用方可降级为 full upsert）。
+ */
+export async function upsertCodexAuthBackupMetaOnlyAsync(args: {
+  runtimeKey: string;
+  signature: string;
+  status: CodexAccountStatusKey;
+  accountId: string | null;
+  userId?: string | null;
+  email?: string | null;
+  plan?: string | null;
+  reason?: string;
+  /** 是否更新时间戳（默认 false，避免仅补齐字段就影响排序） */
+  touchUpdatedAt?: boolean;
+}): Promise<{ ok: true; item: CodexAuthBackupItem } | { ok: false; error: string }> {
+  try {
+    const runtimeKey = String(args.runtimeKey || "").trim();
+    if (!runtimeKey) return { ok: false, error: "missing runtimeKey" };
+    const signature = String(args.signature || "").trim();
+    if (!signature) return { ok: false, error: "missing signature" };
+
+    const id = backupIdFromSignature(signature);
+    const { authPath, metaPath } = resolveBackupPaths(runtimeKey, id);
+    if (!fs.existsSync(authPath)) return { ok: false, error: "backup auth not found" };
+
+    const prev = normalizeMeta(await readJsonSafe(metaPath));
+    const now = Date.now();
+    const createdAt = prev?.createdAt ?? now;
+    const updatedAt = args.touchUpdatedAt ? now : (prev?.updatedAt ?? now);
+    const reason = String(args.reason || prev?.reason || "").trim() || "unknown";
+    const status: CodexAccountStatusKey = args.status === "signed_in" ? "signed_in" : "signed_out";
+    const accountId = args.accountId ? String(args.accountId).trim() || null : null;
+    const userId = args.userId != null ? String(args.userId || "").trim() || null : (prev?.userId ?? null);
+    const email = args.email != null ? String(args.email || "").trim() || null : (prev?.email ?? null);
+    const plan = args.plan != null ? String(args.plan || "").trim() || null : (prev?.plan ?? null);
+
+    const next: CodexAuthBackupMeta = {
+      version: 1,
+      id,
+      createdAt,
+      updatedAt,
+      runtimeKey,
+      signature,
+      status,
+      accountId,
+      userId,
+      email,
+      plan,
+      reason,
+    };
+
+    // 若不触碰时间戳且内容无变化，则直接返回，避免无意义写盘
+    if (!args.touchUpdatedAt && prev) {
+      const same =
+        prev.signature === next.signature &&
+        prev.status === next.status &&
+        (prev.accountId ?? null) === (next.accountId ?? null) &&
+        (prev.userId ?? null) === (next.userId ?? null) &&
+        (prev.email ?? null) === (next.email ?? null) &&
+        (prev.plan ?? null) === (next.plan ?? null) &&
+        (prev.reason ?? "") === (next.reason ?? "") &&
+        prev.createdAt === next.createdAt &&
+        prev.updatedAt === next.updatedAt;
+      if (same) return { ok: true, item: prev };
+    }
+
+    await writeFileAtomic(metaPath, Buffer.from(JSON.stringify(next, null, 2), "utf8"));
+    return { ok: true, item: next };
+  } catch (e: any) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+/**
+ * 原子写入：先写入临时文件，再 rename 覆盖目标文件，避免中途写坏。
+ */
+async function writeFileAtomic(targetPath: string, data: Buffer | string): Promise<void> {
+  const p = String(targetPath || "");
+  const dir = path.dirname(p);
+  const tmp = path.join(dir, `${path.basename(p)}.tmp-${randomUUID()}`);
+  await fsp.writeFile(tmp, data);
+  try {
+    await fsp.rename(tmp, p);
+  } catch {
+    try { await fsp.unlink(p); } catch {}
+    await fsp.rename(tmp, p);
+  }
+}
+
+/**
+ * 安全读取 JSON（失败返回 null）。
+ */
+async function readJsonSafe(filePath: string): Promise<any | null> {
+  try {
+    const text = await fsp.readFile(filePath, "utf8");
+    return JSON.parse(text || "null");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 解析并规范化备份 meta（失败返回 null）。
+ */
+function normalizeMeta(raw: any): CodexAuthBackupMeta | null {
+  try {
+    if (!raw || typeof raw !== "object") return null;
+    if (raw.version !== 1) return null;
+    const id = String(raw.id || "").trim().toLowerCase();
+    if (!isSafeAuthBackupId(id)) return null;
+    const createdAt = Number(raw.createdAt);
+    const updatedAt = Number(raw.updatedAt);
+    if (!Number.isFinite(createdAt) || createdAt <= 0) return null;
+    if (!Number.isFinite(updatedAt) || updatedAt <= 0) return null;
+    const runtimeKey = String(raw.runtimeKey || "").trim();
+    const signature = String(raw.signature || "").trim();
+    const status: CodexAccountStatusKey = raw.status === "signed_in" ? "signed_in" : "signed_out";
+    const accountId = raw.accountId != null ? String(raw.accountId || "").trim() || null : null;
+    const userId = raw.userId != null ? String(raw.userId || "").trim() || null : null;
+    const email = raw.email != null ? String(raw.email || "").trim() || null : null;
+    const plan = raw.plan != null ? String(raw.plan || "").trim() || null : null;
+    const reason = String(raw.reason || "").trim() || "unknown";
+    return {
+      version: 1,
+      id,
+      createdAt,
+      updatedAt,
+      runtimeKey,
+      signature,
+      status,
+      accountId,
+      userId,
+      email,
+      plan,
+      reason,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 返回备份文件路径（auth/meta）。
+ */
+function resolveBackupPaths(runtimeKey: string, id: string): { authPath: string; metaPath: string } {
+  const dir = getBackupDir(runtimeKey);
+  const safeId = String(id || "").trim().toLowerCase();
+  return {
+    authPath: path.join(dir, `auth.${safeId}.json`),
+    metaPath: path.join(dir, `meta.${safeId}.json`),
+  };
+}
+
+/**
+ * 解析当前运行环境对应的 `.codex/auth.json` 路径：
+ * - native：使用当前系统用户目录 `~/.codex/auth.json`
+ * - wsl：使用对应发行版 `$HOME/.codex` 的 UNC 路径
+ */
+export async function resolveCodexAuthJsonPathAsync(runtime: { key: string; options: CodexBridgeOptions }): Promise<{ ok: true; authJsonPath: string } | { ok: false; error: string }> {
+  try {
+    const mode = runtime?.options?.mode ?? "native";
+    if (mode === "wsl" && os.platform() === "win32") {
+      const distro = String(runtime?.options?.wslDistro || "").trim();
+      if (!distro) return { ok: false, error: "missing wsl distro" };
+      const codexUNC = await getDistroCodexUNCAsync(distro);
+      if (!codexUNC) return { ok: false, error: "无法定位 WSL 的 $HOME/.codex" };
+      return { ok: true, authJsonPath: path.join(codexUNC, "auth.json") };
+    }
+    return { ok: true, authJsonPath: path.join(os.homedir(), ".codex", "auth.json") };
+  } catch (e: any) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+/**
+ * 枚举全局 auth.json 备份列表（按更新时间倒序）。
+ */
+export async function listCodexAuthBackupsAsync(runtimeKey: string): Promise<CodexAuthBackupItem[]> {
+  const dir = getBackupDir(runtimeKey);
+  try {
+    if (!fs.existsSync(dir)) return [];
+    const entries = await fsp.readdir(dir, { withFileTypes: true });
+    const metas = entries
+      .filter((e) => e.isFile() && /^meta\.[a-f0-9]{12,64}\.json$/i.test(e.name))
+      .map((e) => path.join(dir, e.name));
+
+    const items: CodexAuthBackupItem[] = [];
+    for (const metaPath of metas) {
+      const raw = await readJsonSafe(metaPath);
+      const meta = normalizeMeta(raw);
+      if (!meta) continue;
+      const { authPath } = resolveBackupPaths(runtimeKey, meta.id);
+      if (!fs.existsSync(authPath)) continue;
+      items.push(meta);
+    }
+
+    return items.sort((a, b) => b.updatedAt - a.updatedAt);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * 创建/更新指定签名的 auth.json 备份（同一签名仅保留一个“最新备份”）。
+ */
+export async function upsertCodexAuthBackupAsync(args: {
+  runtimeKey: string;
+  authJsonPath: string;
+  signature: string;
+  status: CodexAccountStatusKey;
+  accountId: string | null;
+  userId?: string | null;
+  email?: string | null;
+  plan?: string | null;
+  reason: string;
+}): Promise<{ ok: true; item: CodexAuthBackupItem } | { ok: false; error: string }> {
+  try {
+    const runtimeKey = String(args.runtimeKey || "").trim();
+    if (!runtimeKey) return { ok: false, error: "missing runtimeKey" };
+    const authJsonPath = String(args.authJsonPath || "").trim();
+    if (!authJsonPath) return { ok: false, error: "missing authJsonPath" };
+    if (!fs.existsSync(authJsonPath)) return { ok: false, error: "auth.json not found" };
+
+    const signature = String(args.signature || "").trim();
+    const id = backupIdFromSignature(signature);
+    const { authPath, metaPath } = resolveBackupPaths(runtimeKey, id);
+    await fsp.mkdir(path.dirname(authPath), { recursive: true });
+
+    const content = await fsp.readFile(authJsonPath);
+    await writeFileAtomic(authPath, content);
+
+    const now = Date.now();
+    const prev = normalizeMeta(await readJsonSafe(metaPath));
+    const createdAt = prev?.createdAt ?? now;
+    const reason = String(args.reason || "").trim() || "unknown";
+    const status: CodexAccountStatusKey = args.status === "signed_in" ? "signed_in" : "signed_out";
+    const accountId = args.accountId ? String(args.accountId).trim() || null : null;
+    const userId = args.userId != null ? String(args.userId || "").trim() || null : null;
+    const email = args.email != null ? String(args.email || "").trim() || null : null;
+    const plan = args.plan != null ? String(args.plan || "").trim() || null : null;
+    const meta: CodexAuthBackupMeta = {
+      version: 1,
+      id,
+      createdAt,
+      updatedAt: now,
+      runtimeKey,
+      signature,
+      status,
+      accountId,
+      userId,
+      email,
+      plan,
+      reason,
+    };
+    await writeFileAtomic(metaPath, Buffer.from(JSON.stringify(meta, null, 2), "utf8"));
+    return { ok: true, item: meta };
+  } catch (e: any) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+/**
+ * 获取单个备份 meta（用于切换后同步更新 settings 等场景）。
+ */
+export async function readCodexAuthBackupMetaAsync(runtimeKey: string, id: string): Promise<CodexAuthBackupItem | null> {
+  try {
+    if (!isSafeAuthBackupId(id)) return null;
+    const { metaPath, authPath } = resolveBackupPaths(runtimeKey, id);
+    if (!fs.existsSync(metaPath) || !fs.existsSync(authPath)) return null;
+    const raw = await readJsonSafe(metaPath);
+    const meta = normalizeMeta(raw);
+    return meta;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 将指定备份覆盖写入到目标 `.codex/auth.json`（原子写入，失败返回错误）。
+ */
+export async function applyCodexAuthBackupAsync(args: {
+  runtimeKey: string;
+  backupId: string;
+  targetAuthJsonPath: string;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const runtimeKey = String(args.runtimeKey || "").trim();
+    const backupId = String(args.backupId || "").trim().toLowerCase();
+    if (!runtimeKey) return { ok: false, error: "missing runtimeKey" };
+    if (!isSafeAuthBackupId(backupId)) return { ok: false, error: "invalid backupId" };
+
+    const { authPath } = resolveBackupPaths(runtimeKey, backupId);
+    if (!fs.existsSync(authPath)) return { ok: false, error: "backup auth not found" };
+
+    const target = String(args.targetAuthJsonPath || "").trim();
+    if (!target) return { ok: false, error: "missing targetAuthJsonPath" };
+
+    const content = await fsp.readFile(authPath);
+    await fsp.mkdir(path.dirname(target), { recursive: true });
+    await writeFileAtomic(target, content);
+    return { ok: true };
+  } catch (e: any) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+/**
+ * 删除指定备份（auth/meta）。若文件不存在则视为成功。
+ */
+export async function deleteCodexAuthBackupAsync(args: {
+  runtimeKey: string;
+  backupId: string;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const runtimeKey = String(args.runtimeKey || "").trim();
+    if (!runtimeKey) return { ok: false, error: "missing runtimeKey" };
+    const backupId = String(args.backupId || "").trim().toLowerCase();
+    if (!isSafeAuthBackupId(backupId)) return { ok: false, error: "invalid backupId" };
+
+    const removeFile = async (p: string): Promise<void> => {
+      try {
+        await fsp.unlink(p);
+      } catch (e: any) {
+        if (e && typeof e === "object" && (e as any).code === "ENOENT") return;
+        throw e;
+      }
+    };
+    const { authPath, metaPath } = resolveBackupPaths(runtimeKey, backupId);
+    await removeFile(authPath);
+    await removeFile(metaPath);
+    return { ok: true };
+  } catch (e: any) {
+    return { ok: false, error: String(e) };
+  }
+}

--- a/electron/codex/bridge.ts
+++ b/electron/codex/bridge.ts
@@ -312,8 +312,12 @@ export class CodexBridge {
     this.wslDistro = options.wslDistro;
   }
 
-  async getAccountInfo(): Promise<CodexAccountInfo> {
-    const token = await this.ensureToken(false);
+  /**
+   * 获取当前 ChatGPT 账号信息。
+   * - `forceRefresh=true` 时强制刷新 token（用于“记录账号”等需要及时感知切换的场景）。
+   */
+  async getAccountInfo(forceRefresh: boolean = false): Promise<CodexAccountInfo> {
+    const token = await this.ensureToken(!!forceRefresh);
     return this.decodeAccount(token);
   }
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -204,6 +204,16 @@ contextBridge.exposeInMainWorld('host', {
     getRateLimit: async () => {
       return await ipcRenderer.invoke('codex.rateLimit');
     }
+    ,
+    listAuthBackups: async () => {
+      return await ipcRenderer.invoke('codex.authBackups.list');
+    },
+    applyAuthBackup: async (args: { id: string }) => {
+      return await ipcRenderer.invoke('codex.authBackups.apply', args);
+    },
+    deleteAuthBackup: async (args: { id: string }) => {
+      return await ipcRenderer.invoke('codex.authBackups.delete', args);
+    }
   }
   , claude: {
     getUsage: async () => {

--- a/electron/wsl.ts
+++ b/electron/wsl.ts
@@ -441,7 +441,7 @@ export async function getDistroCodexUNCAsync(distro: string): Promise<string> {
     const { stdout } = await (function execFilePromiseLocal() {
       return new Promise<{ stdout: Buffer; stderr: Buffer }>((resolve, reject) => {
         try {
-          execFile('wsl.exe', args, { windowsHide: true, maxBuffer: 8 * 1024 * 1024 }, (err, stdout, stderr) => {
+          execFile('wsl.exe', args, { windowsHide: true, timeout: 5000, maxBuffer: 8 * 1024 * 1024 }, (err, stdout, stderr) => {
             if (err) return reject(err);
             resolve({ stdout: Buffer.isBuffer(stdout) ? stdout : Buffer.from(String(stdout || '')), stderr: Buffer.isBuffer(stderr) ? stderr : Buffer.from(String(stderr || '')) });
           });
@@ -470,7 +470,7 @@ export async function getDistroHomeSubPathUNCAsync(distro: string, subPath: stri
     const { stdout } = await (function execFilePromiseLocal() {
       return new Promise<{ stdout: Buffer; stderr: Buffer }>((resolve, reject) => {
         try {
-          execFile("wsl.exe", args, { windowsHide: true, maxBuffer: 8 * 1024 * 1024 }, (err, stdout, stderr) => {
+          execFile("wsl.exe", args, { windowsHide: true, timeout: 5000, maxBuffer: 8 * 1024 * 1024 }, (err, stdout, stderr) => {
             if (err) return reject(err);
             resolve({
               stdout: Buffer.isBuffer(stdout) ? stdout : Buffer.from(String(stdout || "")),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1840,6 +1840,8 @@ export default function CodexFlowManagerUI() {
   const [claudeCodeReadAgentHistory, setClaudeCodeReadAgentHistory] = useState<boolean>(false);
   // 网络代理设置（用于设置对话框初始值与回显）
   const [networkPrefs, setNetworkPrefs] = useState<NetworkPrefs>({ proxyEnabled: true, proxyMode: "system", proxyUrl: "", noProxy: "" });
+  // ChatGPT/Codex：是否启用“记录账号”（用于自动备份与快速切换）
+  const [codexAccountRecordEnabled, setCodexAccountRecordEnabled] = useState<boolean>(false);
   const [sendMode, setSendMode] = useState<'write_only' | 'write_and_enter'>("write_and_enter");
   // 项目内路径样式：absolute=全路径；relative=相对路径（默认全路径）
   const [projectPathStyle, setProjectPathStyle] = useState<'absolute' | 'relative'>('absolute');
@@ -2247,6 +2249,10 @@ export default function CodexFlowManagerUI() {
               proxyUrl: String(net.proxyUrl || ''),
               noProxy: String(net.noProxy || ''),
             });
+          } catch {}
+          // 同步“记录账号”偏好
+          try {
+            setCodexAccountRecordEnabled(!!(s as any)?.codexAccount?.recordEnabled);
           } catch {}
           // historyRoot 自动计算，无需显示设置
         }
@@ -4503,6 +4509,7 @@ export default function CodexFlowManagerUI() {
           theme: themeSetting,
           notifications: notificationPrefs,
           network: networkPrefs,
+          codexAccount: { recordEnabled: codexAccountRecordEnabled },
           terminalFontFamily,
           terminalTheme,
           claudeCodeReadAgentHistory,
@@ -4533,6 +4540,7 @@ export default function CodexFlowManagerUI() {
               theme: nextTheme,
               notifications: nextNotifications,
               network: v.network,
+              codexAccount: v.codexAccount as any,
               terminalFontFamily: nextFontFamily,
               terminalTheme: nextTerminalTheme,
               claudeCode: { readAgentHistory: nextClaudeAgentHistory },
@@ -4562,6 +4570,7 @@ export default function CodexFlowManagerUI() {
           writeThemeSettingCache(nextTheme);
           setNotificationPrefs(nextNotifications);
           setNetworkPrefs(v.network);
+          setCodexAccountRecordEnabled(!!v.codexAccount?.recordEnabled);
           setTerminalFontFamily(nextFontFamily);
           setTerminalTheme(nextTerminalTheme);
           setClaudeCodeReadAgentHistory(nextClaudeAgentHistory);

--- a/web/src/components/topbar/codex-status.tsx
+++ b/web/src/components/topbar/codex-status.tsx
@@ -18,6 +18,7 @@ import {
   translateRateLimitError,
   translateCodexBridgeError,
   CODEX_RATE_REFRESH_EVENT,
+  CODEX_AUTH_CHANGED_EVENT,
 } from "@/lib/codex-status";
 import { useHoverCard } from "@/components/topbar/hover-card";
 
@@ -122,6 +123,20 @@ function useCodexAccountCached(envKey: string): [
     }
   }, [envKey, t]);
 
+  // 监听“账号已切换”事件：清空缓存并立即重新拉取
+  useEffect(() => {
+    const onAuthChanged = () => {
+      try {
+        CODEX_ACCOUNT_CACHE.set(envKey, { attemptedAt: null, data: null, error: null });
+        setAttempted(false);
+        setState({ loading: false, error: null, data: null });
+        fetchAccount();
+      } catch {}
+    };
+    window.addEventListener(CODEX_AUTH_CHANGED_EVENT, onAuthChanged as any);
+    return () => window.removeEventListener(CODEX_AUTH_CHANGED_EVENT, onAuthChanged as any);
+  }, [envKey, fetchAccount]);
+
   return [state, fetchAccount, { attempted }];
 }
 
@@ -167,6 +182,16 @@ function useCodexAccount(
   useEffect(() => {
     if (auto) fetchAccount();
   }, [auto, fetchAccount]);
+
+  // 监听“账号已切换”事件：立即重新拉取账号信息
+  useEffect(() => {
+    const onAuthChanged = () => {
+      try { fetchAccount(); } catch {}
+    };
+    window.addEventListener(CODEX_AUTH_CHANGED_EVENT, onAuthChanged as any);
+    return () => window.removeEventListener(CODEX_AUTH_CHANGED_EVENT, onAuthChanged as any);
+  }, [fetchAccount]);
+
   return [state, fetchAccount];
 }
 
@@ -267,6 +292,20 @@ function useCodexRateCached(envKey: string): [
       setState({ loading: false, error: errorText, data: null });
     }
   }, [envKey, resolveErrorMessage]);
+
+  // 监听“账号已切换”事件：清空缓存并立即重新拉取用量
+  useEffect(() => {
+    const onAuthChanged = () => {
+      try {
+        CODEX_RATE_CACHE.set(envKey, { attemptedAt: null, data: null, error: null });
+        setAttempted(false);
+        setState({ loading: false, error: null, data: null });
+        fetchRate();
+      } catch {}
+    };
+    window.addEventListener(CODEX_AUTH_CHANGED_EVENT, onAuthChanged as any);
+    return () => window.removeEventListener(CODEX_AUTH_CHANGED_EVENT, onAuthChanged as any);
+  }, [envKey, fetchRate]);
 
   return [state, fetchRate, { attempted }];
 }

--- a/web/src/features/settings/codex-auth-switch.tsx
+++ b/web/src/features/settings/codex-auth-switch.tsx
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import type { TFunction } from "i18next";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select";
+import type { CodexAuthBackupItem } from "@/types/host";
+import { emitCodexAuthChanged } from "@/lib/codex-status";
+
+export type CodexAuthSwitchProps = {
+  open: boolean;
+  recordEnabled: boolean;
+  onRecordEnabledChange: (enabled: boolean) => void;
+};
+
+type LoadState = {
+  loading: boolean;
+  error: string | null;
+  items: CodexAuthBackupItem[];
+};
+
+/**
+ * 格式化备份列表展示文案：以“登录状态”为主，展示“账号状态值 + 套餐”。
+ */
+function formatBackupLabel(item: CodexAuthBackupItem, t: TFunction): string {
+  const signedText = t(`settings:codexAccount.switch.status.${item.status}`) as string;
+  const statusValue = (() => {
+    const email = String(item.email || "").trim();
+    if (email) return email;
+    const accountId = String(item.accountId || "").trim();
+    if (accountId) return accountId;
+    const userId = String(item.userId || "").trim();
+    if (userId) return userId;
+    return t("settings:codexAccount.statusUnknown", "未登录") as string;
+  })();
+  const planText = (() => {
+    const plan = String(item.plan || "").trim();
+    if (!plan) return t("settings:codexAccount.plan.unknown", "未知套餐") as string;
+    const key = `settings:codexAccount.plan.${plan}`;
+    const translated = t(key) as string;
+    return translated && translated !== key ? translated : plan;
+  })();
+  return [signedText, statusValue, planText].filter(Boolean).join(" · ");
+}
+
+/**
+ * 设置面板：Codex auth.json 备份列表与一键切换入口。
+ */
+export const CodexAuthSwitch: React.FC<CodexAuthSwitchProps> = ({ open, recordEnabled, onRecordEnabledChange }) => {
+  const { t } = useTranslation(["settings", "common"]);
+  const [state, setState] = useState<LoadState>({ loading: false, error: null, items: [] });
+  const [selectedId, setSelectedId] = useState<string>("");
+  const [switching, setSwitching] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [feedback, setFeedback] = useState<{ ok: boolean; text: string } | null>(null);
+
+  const refreshList = useCallback(async () => {
+    setFeedback(null);
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+    try {
+      // 先触发一次账号刷新，让主进程有机会补齐备份 meta（例如套餐/邮箱在上一轮未拿到的情况）
+      try { await window.host.codex.getAccountInfo(); } catch {}
+      const res = await window.host.codex.listAuthBackups();
+      if (res && res.ok && Array.isArray(res.items)) {
+        const items = res.items as CodexAuthBackupItem[];
+        setState({ loading: false, error: null, items });
+        setSelectedId((cur) => (cur && items.some((x) => x.id === cur) ? cur : (items[0]?.id || "")));
+        return;
+      }
+      setState({
+        loading: false,
+        error: (res && res.error) ? String(res.error) : (t("settings:codexAccount.switch.loadFailed") as string),
+        items: [],
+      });
+    } catch (e) {
+      setState({
+        loading: false,
+        error: String(e || t("settings:codexAccount.switch.loadFailed")),
+        items: [],
+      });
+    }
+  }, [t]);
+
+  useEffect(() => {
+    if (!open) return;
+    refreshList();
+  }, [open, refreshList]);
+
+  const selectedLabel = useMemo(() => {
+    const hit = state.items.find((x) => x.id === selectedId);
+    if (hit) return formatBackupLabel(hit, t);
+    if (state.items.length > 0) return t("settings:codexAccount.switch.selectPlaceholder") as string;
+    return t("settings:codexAccount.switch.empty") as string;
+  }, [selectedId, state.items, t]);
+
+  const canSwitch = !!selectedId && !switching && !deleting && !state.loading && state.items.some((x) => x.id === selectedId);
+  const canDelete = !!selectedId && !deleting && !switching && !state.loading && state.items.some((x) => x.id === selectedId);
+
+  const applySelected = useCallback(async () => {
+    if (!canSwitch) return;
+    setFeedback(null);
+    setSwitching(true);
+    try {
+      const res = await window.host.codex.applyAuthBackup({ id: selectedId });
+      if (res && res.ok) {
+        setFeedback({ ok: true, text: t("settings:codexAccount.switch.switchSuccess") as string });
+        // 通知全局：账号已切换，强制刷新顶部栏用量与设置面板账号状态
+        emitCodexAuthChanged("settings-switch");
+        await refreshList();
+      } else {
+        setFeedback({ ok: false, text: (res && res.error) ? String(res.error) : (t("settings:codexAccount.switch.switchFailed") as string) });
+      }
+    } catch (e) {
+      setFeedback({ ok: false, text: String(e || t("settings:codexAccount.switch.switchFailed")) });
+    } finally {
+      setSwitching(false);
+    }
+  }, [canSwitch, refreshList, selectedId, t]);
+
+  /**
+   * 删除当前选中的备份（同时删除 meta 与 auth 文件）。
+   */
+  const deleteSelected = useCallback(async () => {
+    if (!canDelete) return;
+    const hit = state.items.find((x) => x.id === selectedId);
+    const label = hit ? formatBackupLabel(hit, t) : selectedId;
+    const ok = window.confirm(
+      t("settings:codexAccount.switch.deleteConfirm", { label }) as string
+    );
+    if (!ok) return;
+    setFeedback(null);
+    setDeleting(true);
+    try {
+      const res = await window.host.codex.deleteAuthBackup({ id: selectedId });
+      if (res && res.ok) {
+        setFeedback({ ok: true, text: t("settings:codexAccount.switch.deleteSuccess") as string });
+        await refreshList();
+      } else {
+        setFeedback({ ok: false, text: (res && res.error) ? String(res.error) : (t("settings:codexAccount.switch.deleteFailed") as string) });
+      }
+    } catch (e) {
+      setFeedback({ ok: false, text: String(e || t("settings:codexAccount.switch.deleteFailed")) });
+    } finally {
+      setDeleting(false);
+    }
+  }, [canDelete, refreshList, selectedId, state.items, t]);
+
+  return (
+    <div className="space-y-3">
+      <label className="flex items-start gap-3 rounded-lg border border-slate-200/70 bg-white/60 px-3 py-3 shadow-sm dark:border-[var(--cf-border)] dark:bg-[var(--cf-surface-muted)] dark:text-[var(--cf-text-primary)]">
+        <input
+          type="checkbox"
+          className="mt-1 h-4 w-4 rounded border-slate-300 text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-[var(--cf-border)] dark:bg-[var(--cf-surface)] dark:checked:bg-[var(--cf-accent)] dark:focus-visible:ring-[var(--cf-accent)]/40"
+          checked={recordEnabled}
+          onChange={(e) => onRecordEnabledChange(e.target.checked)}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-slate-800 dark:text-[var(--cf-text-primary)]">
+            {t("settings:codexAccount.record.label")}
+          </div>
+          <p className="text-xs text-slate-500 dark:text-[var(--cf-text-secondary)]">
+            {t("settings:codexAccount.record.desc")}
+          </p>
+        </div>
+      </label>
+
+      <div className="grid gap-2 sm:grid-cols-[1fr_auto_auto_auto] items-center">
+        <Select value={selectedId} onValueChange={(v) => setSelectedId(String(v || ""))}>
+          <SelectTrigger
+            className="h-auto min-h-10 py-2 items-start"
+            disabled={!open || state.loading || state.items.length === 0}
+          >
+            <span className="text-left whitespace-normal break-all leading-snug" title={selectedLabel}>
+              {selectedLabel}
+            </span>
+          </SelectTrigger>
+          <SelectContent>
+            {state.items.map((item) => {
+              const label = formatBackupLabel(item, t);
+              return (
+                <SelectItem key={item.id} value={item.id}>
+                  <span className="whitespace-normal break-all leading-snug" title={label}>
+                    {label}
+                  </span>
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+
+        <Button
+          variant="outline"
+          disabled={!open || state.loading}
+          onClick={() => refreshList()}
+        >
+          {state.loading ? t("settings:loading") : t("settings:codexAccount.switch.refreshList")}
+        </Button>
+
+        <Button
+          variant="secondary"
+          disabled={!canSwitch}
+          onClick={() => applySelected()}
+        >
+          {switching ? t("settings:codexAccount.switch.switching") : t("settings:codexAccount.switch.switch")}
+        </Button>
+
+        <Button
+          variant="danger"
+          disabled={!canDelete}
+          onClick={() => deleteSelected()}
+        >
+          {deleting ? t("settings:codexAccount.switch.deleting") : t("settings:codexAccount.switch.delete")}
+        </Button>
+      </div>
+
+      {state.error ? (
+        <div className="text-xs text-[var(--cf-red)]">{state.error}</div>
+      ) : feedback ? (
+        <div className={`text-xs ${feedback.ok ? "text-slate-600 dark:text-[var(--cf-text-secondary)]" : "text-[var(--cf-red)]"}`}>
+          {feedback.text}
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/web/src/features/settings/settings-dialog.tsx
+++ b/web/src/features/settings/settings-dialog.tsx
@@ -19,6 +19,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn, formatBytes } from "@/lib/utils";
 import { listAvailableLanguages, changeAppLanguage } from "@/i18n/setup";
 import { CodexAccountInline } from "@/components/topbar/codex-status";
+import { CodexAuthSwitch } from "./codex-auth-switch";
 import { Trash2, Power, ChevronUp, ChevronDown, Plus, Image as ImageIcon, Star } from "lucide-react";
 import { getBuiltInProviders, isBuiltInProviderId } from "@/lib/providers/builtins";
 import { resolveProvider } from "@/lib/providers/resolve";
@@ -49,6 +50,9 @@ type NetworkPrefs = {
   proxyUrl: string;
   noProxy: string;
 };
+type CodexAccountPrefs = {
+  recordEnabled: boolean;
+};
 
 const normalizeThemeSetting = (value: any): ThemeSetting => {
   if (value === "light" || value === "dark") return value;
@@ -70,6 +74,7 @@ export type SettingsDialogProps = {
     theme: ThemeSetting;
     notifications: NotificationPrefs;
     network?: NetworkPrefs;
+    codexAccount: CodexAccountPrefs;
     terminalFontFamily: string;
     terminalTheme: TerminalThemeId;
     claudeCodeReadAgentHistory: boolean;
@@ -86,6 +91,7 @@ export type SettingsDialogProps = {
     theme: ThemeSetting;
     notifications: NotificationPrefs;
     network: NetworkPrefs;
+    codexAccount: CodexAccountPrefs;
     terminalFontFamily: string;
     terminalTheme: TerminalThemeId;
     claudeCodeReadAgentHistory: boolean;
@@ -383,6 +389,9 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
     proxyUrl: values.network?.proxyUrl ?? "",
     noProxy: values.network?.noProxy ?? "",
   });
+  const [codexAccount, setCodexAccount] = useState<CodexAccountPrefs>(() => ({
+    recordEnabled: !!values.codexAccount?.recordEnabled,
+  }));
   const [claudeCodeReadAgentHistory, setClaudeCodeReadAgentHistory] = useState<boolean>(!!values.claudeCodeReadAgentHistory);
   const [codexRoots, setCodexRoots] = useState<string[]>([]);
   const [claudeRoots, setClaudeRoots] = useState<string[]>([]);
@@ -481,6 +490,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
       proxyUrl: values.network?.proxyUrl ?? "",
       noProxy: values.network?.noProxy ?? "",
     });
+    setCodexAccount({ recordEnabled: !!values.codexAccount?.recordEnabled });
     setClaudeCodeReadAgentHistory(!!values.claudeCodeReadAgentHistory);
     setTerminalFontFamily(normalizeTerminalFontFamily(values.terminalFontFamily));
     setTerminalTheme(normalizeTerminalTheme(values.terminalTheme));
@@ -1527,6 +1537,12 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                     distro={(providerEnvMap["codex"]?.terminal || "wsl") === "wsl" ? (providerEnvMap["codex"]?.distro || "Ubuntu-24.04") : undefined}
                     expanded
                   />
+                  <Separator className="my-4" />
+                  <CodexAuthSwitch
+                    open={open}
+                    recordEnabled={codexAccount.recordEnabled}
+                    onRecordEnabledChange={(enabled) => setCodexAccount({ recordEnabled: enabled })}
+                  />
                 </CardContent>
               </Card>
             </div>
@@ -1787,6 +1803,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
     pathStyle,
     notifications,
     network,
+    codexAccount,
     sendMode,
     showDarkIconOverride,
     storageInfo,
@@ -1908,6 +1925,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                       theme,
                       notifications,
                       network,
+                      codexAccount,
                       terminalFontFamily: normalizeTerminalFontFamily(terminalFontFamily),
                       terminalTheme,
                       claudeCodeReadAgentHistory,

--- a/web/src/lib/codex-status.ts
+++ b/web/src/lib/codex-status.ts
@@ -245,6 +245,17 @@ export function translateRateLimitError(raw: unknown, t: TFunction): string {
   });
 }
 
+// 触发 Codex “账号已切换/认证已变化”刷新（渲染进程全局事件）
+// 说明：当 auth.json 被切换/覆盖写入后，账号信息与用量都需要立即重新拉取。
+export const CODEX_AUTH_CHANGED_EVENT = "codex:auth-changed";
+export type CodexAuthChangedDetail = { source?: string };
+export function emitCodexAuthChanged(source?: string): void {
+  try {
+    const detail: CodexAuthChangedDetail | undefined = source ? { source } : undefined;
+    window.dispatchEvent(new CustomEvent<CodexAuthChangedDetail>(CODEX_AUTH_CHANGED_EVENT as any, { detail } as any));
+  } catch {}
+}
+
 // 触发 Codex 用量刷新（渲染进程全局事件）
 // 说明：终端任务完成后会派发本事件；顶部栏用量组件监听并在 1 分钟冷却后触发刷新。
 export const CODEX_RATE_REFRESH_EVENT = "codex:rate-refresh-request";

--- a/web/src/locales/en/settings.json
+++ b/web/src/locales/en/settings.json
@@ -207,6 +207,35 @@
       "business": "Business",
       "education": "Education",
       "unknown": "Unknown plan"
+    },
+    "record": {
+      "label": "Record accounts",
+      "desc": "When enabled, CodexFlow backs up auth.json whenever it detects an account change during refresh."
+    },
+    "switch": {
+      "selectPlaceholder": "Select a backup…",
+      "refreshList": "Refresh backups",
+      "switch": "Switch",
+      "switching": "Switching…",
+      "delete": "Delete",
+      "deleting": "Deleting…",
+      "deleteConfirm": "Delete this backup?\n\n{label}",
+      "deleteSuccess": "Backup deleted",
+      "deleteFailed": "Delete failed",
+      "empty": "No backups yet",
+      "status": {
+        "signed_in": "Signed in",
+        "signed_out": "Signed out"
+      },
+      "reason": {
+        "unknown": "Unknown",
+        "autoRecord": "Auto record",
+        "autoRecordInit": "Auto record (first)",
+        "beforeSwitch": "Before switch"
+      },
+      "loadFailed": "Failed to load backups",
+      "switchSuccess": "auth.json updated",
+      "switchFailed": "Switch failed"
     }
   },
   "codexRoots": {

--- a/web/src/locales/zh/settings.json
+++ b/web/src/locales/zh/settings.json
@@ -207,6 +207,35 @@
       "business": "企业",
       "education": "教育",
       "unknown": "未知套餐"
+    },
+    "record": {
+      "label": "记录账号",
+      "desc": "启用后，每次刷新账号信息时若检测到账号变化，会自动备份当前环境的 auth.json。"
+    },
+    "switch": {
+      "selectPlaceholder": "选择一个备份…",
+      "refreshList": "刷新备份",
+      "switch": "切换",
+      "switching": "切换中…",
+      "delete": "删除",
+      "deleting": "删除中…",
+      "deleteConfirm": "确定删除该备份？\n\n{label}",
+      "deleteSuccess": "备份已删除",
+      "deleteFailed": "删除失败",
+      "empty": "暂无备份",
+      "status": {
+        "signed_in": "已登录",
+        "signed_out": "未登录"
+      },
+      "reason": {
+        "unknown": "未知状态",
+        "autoRecord": "自动记录",
+        "autoRecordInit": "首次自动记录",
+        "beforeSwitch": "切换前备份"
+      },
+      "loadFailed": "备份列表获取失败",
+      "switchSuccess": "已覆盖写入 auth.json",
+      "switchFailed": "切换失败"
     }
   },
   "codexRoots": {

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -58,6 +58,11 @@ export type AppSettings = {
     proxyUrl?: string;
     noProxy?: string;
   };
+  /** ChatGPT/Codex 账号相关设置（记录账号、切换备份等） */
+  codexAccount?: {
+    recordEnabled?: boolean;
+    lastSeenSignatureByRuntime?: Record<string, string>;
+  };
   /** 终端字体栈 */
   terminalFontFamily?: string;
 };
@@ -183,6 +188,20 @@ export type CodexRateLimitSnapshot = {
   secondary: CodexRateLimitWindow | null;
 };
 
+export type CodexAuthBackupItem = {
+  id: string;
+  createdAt: number;
+  updatedAt: number;
+  runtimeKey: string;
+  signature: string;
+  status: "signed_in" | "signed_out";
+  accountId: string | null;
+  userId: string | null;
+  email: string | null;
+  plan: string | null;
+  reason: string;
+};
+
 export type ClaudeUsageWindow = {
   remainingPercent: number | null;
   usedPercent: number | null;
@@ -221,6 +240,9 @@ export type GeminiQuotaSnapshot = {
 export interface CodexAPI {
   getAccountInfo(): Promise<{ ok: boolean; info?: CodexAccountInfo; error?: string }>;
   getRateLimit(): Promise<{ ok: boolean; snapshot?: CodexRateLimitSnapshot; error?: string }>;
+  listAuthBackups(): Promise<{ ok: boolean; items?: CodexAuthBackupItem[]; error?: string }>;
+  applyAuthBackup(args: { id: string }): Promise<{ ok: boolean; error?: string }>;
+  deleteAuthBackup(args: { id: string }): Promise<{ ok: boolean; error?: string }>;
 }
 
 export interface ClaudeAPI {


### PR DESCRIPTION
- 设置面板新增“记录账号”开关与备份列表：支持刷新/切换/删除；列表文案以登录状态为主，展示状态值与套餐，并避免中间省略
- 主进程新增 auth.json 备份管理与 IPC：基于 userId/accountId/email 生成稳定签名，支持保留多个账号备份；刷新过程中仅补齐 meta，避免“未知套餐”被过早写入
- 切换备份后派发 codex:auth-changed：顶部栏用量与设置面板账号信息立即重拉；切换后重启 Codex bridge，避免旧 token 缓存影响识别
- 安全：备份写入 app.getPath('userData')/codex-auth-backups（auth.<id>.json + meta.<id>.json），不写入工程目录，降低误提交泄漏风险
- WSL：wsl.exe 调用增加 timeout，避免卡死；移除旧版按 runtimeKey 分目录的备份兼容扫描逻辑