### PR TITLE
perf: 项目列表在完整扫描前显示已缓存的项目

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1249,6 +1249,16 @@ ipcMain.handle('fileIndex.activeRoots', async (event, { roots }: { roots: string
 });
 
 // Projects API
+/** 快速读取项目缓存列表（不触发扫描） */
+ipcMain.handle('projects.list', async () => {
+  try {
+    const res = projects.listProjectsFromStore();
+    return { ok: true, projects: res };
+  } catch (e: any) {
+    return { ok: false, error: String(e) };
+  }
+});
+
 ipcMain.handle('projects.scan', async (_e, { roots }: { roots?: string[] }) => {
   try {
     const res = await projects.scanProjectsAsync(roots, true);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -113,6 +113,10 @@ contextBridge.exposeInMainWorld('host', {
     },
   },
   projects: {
+    /** 读取缓存项目列表（不触发扫描） */
+    list: async () => {
+      return await ipcRenderer.invoke('projects.list');
+    },
     scan: async (args: { roots?: string[] } = {}) => {
       return await ipcRenderer.invoke('projects.scan', args);
     },

--- a/electron/projects.fast.ts
+++ b/electron/projects.fast.ts
@@ -85,6 +85,13 @@ function saveStore(list: Project[]) { try { fs.writeFileSync(getStorePath(), JSO
 async function saveStoreAsync(list: Project[]) { try { await fsp.writeFile(getStorePath(), JSON.stringify(list, null, 2), 'utf8'); } catch {} }
 async function pathExists(p: string): Promise<boolean> { try { await fsp.access(p); return true; } catch { return false; } }
 
+/**
+ * 快速读取本地缓存的项目列表（不触发扫描）。
+ */
+export function listProjectsFromStore(): Project[] {
+  return loadStore();
+}
+
 // 防抖：短时间内的并发调用合并为一次
 let __scanPromise: Promise<Project[]> | null = null;
 let __scanStamp = 0;
@@ -465,4 +472,4 @@ export function touchProject(id: string) {
   if (p) { p.lastOpenedAt = Date.now(); saveStore(store); }
 }
 
-export default { scanProjectsAsync, addProjectByWinPath, touchProject };
+export default { scanProjectsAsync, addProjectByWinPath, touchProject, listProjectsFromStore };

--- a/electron/projects/index.ts
+++ b/electron/projects/index.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
 // 统一入口：当前使用 fast 实现，若后续需要切换，仅改此处
-export { scanProjectsAsync, addProjectByWinPath, touchProject } from "../projects.fast";
+export { scanProjectsAsync, addProjectByWinPath, touchProject, listProjectsFromStore } from "../projects.fast";
 import fast from "../projects.fast";
 export const IMPLEMENTATION_NAME = "fast";
 export default fast;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2265,6 +2265,17 @@ export default function CodexFlowManagerUI() {
         if (res && res.ok && res.locale) setLocale(String(res.locale));
       } catch {}
       try {
+        const res: any = await window.host.projects.list();
+        if (res && res.ok && Array.isArray(res.projects)) {
+          setProjects(res.projects);
+          setSelectedProjectId((prev) => (res.projects.some((p: any) => p.id === prev) ? prev : ""));
+        } else {
+          console.warn('projects.list returned', res);
+        }
+      } catch (e) {
+        console.warn('projects.list failed', e);
+      }
+      try {
         const res: any = await window.host.projects.scan();
         if (res && res.ok && Array.isArray(res.projects)) {
           setProjects(res.projects);

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -108,6 +108,8 @@ export interface PtyAPI {
 }
 
 export interface ProjectsAPI {
+  /** 读取缓存项目列表（不触发扫描） */
+  list(): Promise<{ ok: boolean; projects?: Project[]; error?: string }>;
   scan(args?: { roots?: string[] }): Promise<{ ok: boolean; projects?: Project[]; error?: string }>;
   add(args: { winPath: string }): Promise<{ ok: boolean; project?: Project | null; error?: string }>;
   touch(id: string): void;


### PR DESCRIPTION
通过新的 projects.list IPC 从 projects.json 读取已缓存的项目，并在启动时先行渲染；随后再执行完整扫描以确保准确性。