### PR TITLE
fix(i18n): 修复项目排序按钮提示插值

### DIFF
--- a/web/src/locales/en/projects.json
+++ b/web/src/locales/en/projects.json
@@ -24,5 +24,5 @@
   "sortLabel": "Sort",
   "sortRecent": "Recently used",
   "sortName": "Name (A-Z)",
-  "sortTitle": "Sort: {{label}}"
+  "sortTitle": "Sort: {label}"
 }

--- a/web/src/locales/zh/projects.json
+++ b/web/src/locales/zh/projects.json
@@ -24,5 +24,5 @@
   "sortLabel": "排序",
   "sortRecent": "最近使用优先",
   "sortName": "名称（A-Z）",
-  "sortTitle": "排序：{{label}}"
+  "sortTitle": "排序：{label}"
 }


### PR DESCRIPTION
- i18next 使用 ICU 语法，插值需使用 {label}
- 修复 hover 排序按钮时显示为“排序：{{label}}”的问题