### PR TITLE
feat: 添加应用退出确认功能

### DIFF
--- a/electron/locales/quitConfirm.ts
+++ b/electron/locales/quitConfirm.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import { app } from "electron";
+import fs from "node:fs";
+import path from "node:path";
+import { normalizeLocale } from "../i18n";
+
+export type QuitConfirmLabels = {
+  title: string;
+  message: string;
+  detail: string;
+  cancel: string;
+  quit: string;
+};
+
+export type QuitConfirmDialogText = {
+  title: string;
+  message: string;
+  detail: string;
+  cancel: string;
+  quit: string;
+};
+
+export const QUIT_CONFIRM_LABELS: Record<string, QuitConfirmLabels> = {
+  en: {
+    title: "Confirm exit",
+    message: "There are still {{count}} terminal session(s) running. Quit anyway?",
+    detail: "Quitting will close all running terminal sessions.",
+    cancel: "Cancel",
+    quit: "Quit",
+  },
+  zh: {
+    title: "确认退出",
+    message: "还有 {{count}} 个终端会话正在运行，确定要退出吗？",
+    detail: "退出将关闭所有仍在运行的终端会话。",
+    cancel: "取消",
+    quit: "退出",
+  },
+};
+
+const VALID_KEYS = new Set<keyof QuitConfirmLabels>(["title", "message", "detail", "cancel", "quit"]);
+
+type PartialLabels = Partial<QuitConfirmLabels>;
+const userOverrideCache = new Map<string, PartialLabels | null>();
+
+/**
+ * 将模板中的 `{{count}}`/`{count}` 替换为数量。
+ */
+export function formatQuitConfirmMessage(template: string, count: number): string {
+  const safeCount = Math.max(0, Number.isFinite(count) ? Math.floor(count) : 0);
+  return String(template || "").replace(/\{\{\s*count\s*\}\}|\{\s*count\s*\}/g, String(safeCount));
+}
+
+function tryReadUserOverrideFile(lc: string): PartialLabels | null {
+  try {
+    const dir = path.join(app.getPath("userData"), "locales", lc);
+    const file = path.join(dir, "quitConfirm.json");
+    if (!fs.existsSync(file)) return null;
+    const text = fs.readFileSync(file, "utf8");
+    const json = JSON.parse(text);
+    const out: PartialLabels = {};
+    if (json && typeof json === "object") {
+      for (const k of Object.keys(json)) {
+        const key = k as keyof QuitConfirmLabels;
+        const val = (json as any)[k];
+        if (VALID_KEYS.has(key) && typeof val === "string" && val.trim().length > 0) {
+          (out as any)[key] = String(val);
+        }
+      }
+    }
+    return Object.keys(out).length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+function getUserOverride(lc: string): PartialLabels | null {
+  if (userOverrideCache.has(lc)) return userOverrideCache.get(lc)!;
+  const ov = tryReadUserOverrideFile(lc);
+  userOverrideCache.set(lc, ov);
+  return ov;
+}
+
+function mergeLabels(base: QuitConfirmLabels, override?: PartialLabels | null): QuitConfirmLabels {
+  if (!override) return base;
+  return {
+    title: override.title ?? base.title,
+    message: override.message ?? base.message,
+    detail: override.detail ?? base.detail,
+    cancel: override.cancel ?? base.cancel,
+    quit: override.quit ?? base.quit,
+  };
+}
+
+/**
+ * 基于应用语言返回“退出确认”文案（支持 userData 覆盖并带 en 回退）。
+ */
+export function getQuitConfirmLabelsForLocale(localeRaw?: string): QuitConfirmLabels {
+  const lc = normalizeLocale(localeRaw);
+  const base = QUIT_CONFIRM_LABELS[lc] || QUIT_CONFIRM_LABELS["en"];
+  const ov = getUserOverride(lc) || (lc !== "en" ? getUserOverride("en") : null);
+  return mergeLabels(base, ov);
+}
+
+/**
+ * 获取适用于对话框展示的最终文案（已将数量注入 message）。
+ */
+export function getQuitConfirmDialogTextForLocale(localeRaw: string | undefined, count: number): QuitConfirmDialogText {
+  const labels = getQuitConfirmLabelsForLocale(localeRaw);
+  return {
+    title: labels.title,
+    message: formatQuitConfirmMessage(labels.message, count),
+    detail: labels.detail,
+    cancel: labels.cancel,
+    quit: labels.quit,
+  };
+}
+
+/**
+ * 清空用户覆盖缓存（例如用户手动更新了 `quitConfirm.json`）。
+ */
+export function clearQuitConfirmLabelsCache(): void {
+  try { userOverrideCache.clear(); } catch {}
+}
+

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -29,6 +29,13 @@ export class PTYManager {
   }
 
   /**
+   * 获取当前仍处于活跃状态的 PTY 会话数量。
+   */
+  getActiveSessionCount(): number {
+    return this.sessions.size;
+  }
+
+  /**
    * 打开一个 PTY 会话。
    * - 允许通过 opts.terminal 覆盖全局 settings.terminal，用于实现 Provider 级别环境隔离。
    */

--- a/electron/quitConfirmBridge.ts
+++ b/electron/quitConfirmBridge.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import { ipcMain, type BrowserWindow } from "electron";
+
+export type QuitConfirmRequestPayload = {
+  token: string;
+  count: number;
+};
+
+type Pending = {
+  resolve: (ok: boolean) => void;
+  timer: NodeJS.Timeout | null;
+};
+
+const pendingByToken = new Map<string, Pending>();
+
+function uidToken(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * 注册“退出确认”渲染进程回包 IPC。
+ */
+export function registerQuitConfirmIPC(): void {
+  try { ipcMain.removeHandler("app.quitConfirm.respond"); } catch {}
+  ipcMain.handle("app.quitConfirm.respond", async (_e, args: { token: string; ok: boolean }) => {
+    try {
+      const token = String(args?.token || "");
+      const ok = !!args?.ok;
+      const p = pendingByToken.get(token);
+      if (!p) return { ok: false, error: "not_found" };
+      pendingByToken.delete(token);
+      try { if (p.timer) clearTimeout(p.timer); } catch {}
+      try { p.resolve(ok); } catch {}
+      return { ok: true };
+    } catch (e: any) {
+      return { ok: false, error: String(e) };
+    }
+  });
+}
+
+/**
+ * 通过渲染进程弹窗请求用户确认（可自定义 UI 样式）。
+ * - 返回 `true/false` 表示用户明确选择
+ * - 返回 `null` 表示渲染进程不可用/超时，应回退到原生确认框
+ */
+export async function requestQuitConfirmFromRenderer(
+  win: BrowserWindow | null,
+  count: number,
+  opts: { timeoutMs?: number } = {},
+): Promise<boolean | null> {
+  try {
+    const target = win && !win.isDestroyed() ? win : null;
+    if (!target) return null;
+    if (!target.webContents || target.webContents.isDestroyed()) return null;
+
+    const token = uidToken();
+    const payload: QuitConfirmRequestPayload = { token, count: Math.max(0, Math.floor(Number(count) || 0)) };
+    const timeoutMs = Math.max(1500, Math.min(120_000, Number(opts.timeoutMs) || 0)) || 30_000;
+
+    const done = await new Promise<boolean | null>((resolve) => {
+      const timer = setTimeout(() => {
+        pendingByToken.delete(token);
+        resolve(null);
+      }, timeoutMs);
+      pendingByToken.set(token, { resolve: (ok) => resolve(ok), timer });
+      try {
+        target.webContents.send("app:quitConfirm", payload);
+      } catch {
+        pendingByToken.delete(token);
+        try { clearTimeout(timer); } catch {}
+        resolve(null);
+      }
+    });
+    return done;
+  } catch {
+    return null;
+  }
+}
+

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -12,6 +12,13 @@
     "language_en": "English",
     "language_zh": "简体中文"
   },
+  "quitConfirm": {
+    "title": "Confirm exit",
+    "badge": "Sessions: {count}",
+    "message": "There are still {count} terminal session(s) running. Quit anyway?",
+    "detail": "Quitting will close all running terminal sessions.",
+    "quit": "Quit"
+  },
   "files": {
     "copyFileNameWithExt": "Copy filename (with extension)",
     "cannotOpenPath": "Unable to open path",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -12,6 +12,13 @@
     "language_en": "English",
     "language_zh": "简体中文"
   },
+  "quitConfirm": {
+    "title": "确认退出",
+    "badge": "会话：{count}",
+    "message": "还有 {count} 个终端会话正在运行，确定要退出吗？",
+    "detail": "退出将关闭所有仍在运行的终端会话。",
+    "quit": "退出"
+  },
   "files": {
     "copyFileNameWithExt": "复制文件名（含后缀）",
     "cannotOpenPath": "无法打开路径",

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -344,6 +344,10 @@ export interface AppAPI {
   getPaths(): Promise<{ licensePath?: string; noticePath?: string }>;
   /** 仅 Windows：设置原生标题栏主题（light/dark） */
   setTitleBarTheme?(theme: { mode: 'light' | 'dark'; source?: ThemeSetting } | 'light' | 'dark'): Promise<{ ok: boolean; error?: string }>;
+  /** 主进程发起的“退出确认”请求（用于渲染进程自定义弹窗样式） */
+  onQuitConfirm?(handler: (payload: { token: string; count: number }) => void): () => void;
+  /** 回复主进程的“退出确认”结果 */
+  respondQuitConfirm?(token: string, ok: boolean): Promise<{ ok: boolean; error?: string }>;
 }
 
 export interface EnvAPI {


### PR DESCRIPTION
- 当存在活跃终端会话时，拦截退出操作并弹出确认框
- 支持渲染进程自定义 UI 确认弹窗 (App.tsx)
- 实现主进程与渲染进程的退出确认 IPC 通信 (quitConfirmBridge.ts)
- 添加退出确认的多语言文案支持 (quitConfirm.ts, common.json)
- 在 PTYManager 中添加会话计数支持
- 增加 Native 对话框作为 UI 无法响应时的回退方案