### PR TITLE
fix(history): 修复 Gemini 会话在 Windows 下归属漏匹配

### DIFF
--- a/web/src/lib/gemini-hash.ts
+++ b/web/src/lib/gemini-hash.ts
@@ -31,6 +31,83 @@ export function normalizeGeminiPathForHash(p: string): string {
 }
 
 /**
+ * 将路径规范化为更接近 Windows 侧 projectHash 计算的输入：
+ * - 分隔符统一为反斜杠
+ * - 折叠重复分隔符（保留 UNC 起始双反斜杠）
+ * - 去除尾部分隔符
+ */
+function normalizeGeminiWinPathForHash(p: string): string {
+  try {
+    let s = tidyPathCandidate(p).replace(/\//g, "\\");
+    if (!s) return "";
+    if (s.startsWith("\\\\")) {
+      s = "\\\\" + s.slice(2).replace(/\\{2,}/g, "\\");
+    } else {
+      s = s.replace(/\\{2,}/g, "\\");
+    }
+    s = s.replace(/\\+$/, "");
+    return s;
+  } catch {
+    return tidyPathCandidate(p);
+  }
+}
+
+/**
+ * 根据“项目绝对路径字符串”生成 Gemini projectHash 的输入候选（未做哈希）。
+ *
+ * 兼容点：
+ * - Windows：盘符大小写差异、`/` 与 `\\` 分隔符差异
+ * - UNC：`\\\\server\\share\\...`
+ * - POSIX：仅做 `/` 规范化；若为 `/mnt/<drive>/...` 额外派生盘符路径
+ */
+export function deriveGeminiProjectHashInputCandidatesFromPath(pathCandidate: string): string[] {
+  try {
+    const raw = typeof pathCandidate === "string" ? pathCandidate.trim() : "";
+    if (!raw) return [];
+    const base = tidyPathCandidate(raw);
+    if (!base) return [];
+
+    const forms = new Set<string>();
+    const add = (v: string) => {
+      const t = tidyPathCandidate(v);
+      if (!t) return;
+      forms.add(t);
+    };
+
+    add(base);
+
+    const baseSlash = base.replace(/\\/g, "/");
+    const isDrive = /^[a-zA-Z]:\//.test(baseSlash);
+    const isUNC = base.startsWith("\\\\") || baseSlash.startsWith("//");
+    const isPosix = base.startsWith("/");
+
+    if (isPosix) {
+      add(normalizeGeminiPathForHash(base));
+      const m = base.match(/^\/mnt\/([a-zA-Z])\/(.*)$/);
+      if (m) add(`${m[1].toUpperCase()}:\\${m[2].replace(/\//g, "\\")}`);
+    } else if (isDrive || isUNC) {
+      add(normalizeGeminiPathForHash(base));
+      add(normalizeGeminiWinPathForHash(base));
+    } else {
+      add(normalizeGeminiPathForHash(base));
+      if (base.includes("\\") || /^[a-zA-Z]:/.test(base)) add(normalizeGeminiWinPathForHash(base));
+    }
+
+    for (const v of Array.from(forms)) {
+      const m = v.match(/^([a-zA-Z]):([\\/].*)$/);
+      if (!m) continue;
+      const rest = m[2];
+      add(`${m[1].toUpperCase()}:${rest}`);
+      add(`${m[1].toLowerCase()}:${rest}`);
+    }
+
+    return Array.from(forms);
+  } catch {
+    return [];
+  }
+}
+
+/**
  * 提取 Gemini 会话文件路径中的 projectHash（匹配 ~/.gemini/tmp/<hash>/...）。
  */
 export function extractGeminiProjectHashFromPath(filePath: string): string | null {
@@ -63,3 +140,16 @@ export async function sha256Hex(text: string): Promise<string> {
   }
 }
 
+/**
+ * 在浏览器侧从项目路径推导 Gemini projectHash 候选集合（SHA-256 hex）。
+ */
+export async function deriveGeminiProjectHashCandidatesFromPath(pathCandidate: string): Promise<string[]> {
+  try {
+    const inputs = deriveGeminiProjectHashInputCandidatesFromPath(pathCandidate);
+    if (inputs.length === 0) return [];
+    const hashes = await Promise.all(inputs.map((s) => sha256Hex(s)));
+    return Array.from(new Set(hashes.filter(Boolean)));
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
- 统一 Gemini projectHash 候选生成规则，兼容盘符大小写与 /、\\ 分隔符差异
- history.list 与索引器按候选 hash 过滤/反解 cwd，补齐 /mnt/<drive> <-> X:\\ 互推
- 渲染层同步候选 hash 计算，确保索引事件归属判断一致
- 移除 App.tsx 内遗留 mock 数据与 console.assert 调试段，避免硬编码与噪声