### PR TITLE
perf: 优化自定义引擎目录保留与历史列表加载

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -134,8 +134,11 @@ contextBridge.exposeInMainWorld('host', {
     scan: async (args: { roots?: string[] } = {}) => {
       return await ipcRenderer.invoke('projects.scan', args);
     },
-    add: async (args: { winPath: string }) => {
+    add: async (args: { winPath: string; dirRecord?: { providerId: string; recordedAt?: number } }) => {
       return await ipcRenderer.invoke('projects.add', args);
+    },
+    removeDirRecord: async (args: { id: string }) => {
+      return await ipcRenderer.invoke('projects.removeDirRecord', args);
     },
     touch: (id: string) => {
       ipcRenderer.send('projects.touch', { id });

--- a/electron/projects/index.ts
+++ b/electron/projects/index.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
 // 统一入口：当前使用 fast 实现，若后续需要切换，仅改此处
-export { scanProjectsAsync, addProjectByWinPath, touchProject, listProjectsFromStore } from "../projects.fast";
+export { scanProjectsAsync, addProjectByWinPath, removeProjectDirRecordById, touchProject, listProjectsFromStore } from "../projects.fast";
 import fast from "../projects.fast";
 export const IMPLEMENTATION_NAME = "fast";
 export default fast;

--- a/web/src/components/topbar/provider-switcher.tsx
+++ b/web/src/components/topbar/provider-switcher.tsx
@@ -4,7 +4,6 @@
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import type { AppSettings, ProviderItem } from "@/types/host";
 import { getBuiltInProviders } from "@/lib/providers/builtins";
@@ -13,7 +12,6 @@ import type { ThemeMode } from "@/lib/theme";
 import { CodexUsageHoverCard } from "@/components/topbar/codex-status";
 import { ClaudeUsageHoverCard } from "@/components/topbar/claude-status";
 import { GeminiUsageHoverCard } from "@/components/topbar/gemini-status";
-import { MoreHorizontal } from "lucide-react";
 
 type TerminalMode = NonNullable<AppSettings["terminal"]>;
 
@@ -28,7 +26,7 @@ export type ProviderSwitcherProps = {
 };
 
 /**
- * 顶部栏引擎切换器：固定展示 Codex/Claude/Gemini 三个图标，额外引擎通过“更多”菜单选择。
+ * 顶部栏引擎切换器：内置引擎与自定义引擎同排展示（自定义无用量面板）。
  */
 export const ProviderSwitcher: React.FC<ProviderSwitcherProps> = ({ activeId, providers, onChange, terminalMode, distro, themeMode, className }) => {
   const { t } = useTranslation(["providers", "common"]);
@@ -48,7 +46,7 @@ export const ProviderSwitcher: React.FC<ProviderSwitcherProps> = ({ activeId, pr
     return getBuiltInProviders().map((meta) => resolveProvider(byId.get(meta.id) ?? { id: meta.id }, { themeMode }));
   }, [byId, themeMode]);
 
-  const extras = useMemo(() => {
+  const customs = useMemo(() => {
     const builtInIds = new Set(getBuiltInProviders().map((x) => x.id));
     const list: Array<{ id: string; label: string; iconSrc: string }> = [];
     for (const it of providers || []) {
@@ -195,25 +193,23 @@ export const ProviderSwitcher: React.FC<ProviderSwitcherProps> = ({ activeId, pr
         );
       })}
 
-      {extras.length > 0 && (
-        <DropdownMenu>
-          <DropdownMenuTrigger>
-            <Button variant="ghost" size="icon" className="h-8 w-8 rounded-md" title={t("providers:more") as string} aria-label={t("providers:more") as string}>
-              <MoreHorizontal className="h-4 w-4" />
+      {customs.map((x) => {
+        const selected = x.id === activeId;
+        return (
+          <div key={x.id} className="flex items-center">
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn("h-8 w-8 rounded-md", selected && "bg-slate-100 dark:bg-slate-800")}
+              title={x.label}
+              aria-label={x.label}
+              onClick={() => onChange(x.id)}
+            >
+              {x.iconSrc ? <img src={x.iconSrc} className="h-4 w-4" alt={x.label} /> : <span className="text-xs">{(x.label || "?")[0]}</span>}
             </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuLabel className="text-xs text-slate-500">{t("providers:customList")}</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            {extras.map((x) => (
-              <DropdownMenuItem key={x.id} onClick={() => onChange(x.id)} className="flex items-center gap-2">
-                {x.iconSrc ? <img src={x.iconSrc} className="h-4 w-4" alt={x.label} /> : null}
-                <span className="truncate">{x.label}</span>
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/web/src/features/settings/settings-dialog.tsx
+++ b/web/src/features/settings/settings-dialog.tsx
@@ -486,6 +486,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const storageLoadedRef = useRef(false);
   const autoProfilesLoadedRef = useRef(false);
+  const initFromValuesOnceRef = useRef(false);
 
   const labelOf = useCallback((lng: string) => {
     const map: Record<string, string> = { zh: "简体中文", en: "English" };
@@ -501,8 +502,20 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
     }
   }, []);
 
+  /**
+   * 仅在“打开设置对话框”的瞬间用外部 values 初始化一次内部状态。
+   *
+   * 注意：父组件每次渲染都会创建新的 values 对象；若将 values 放进依赖数组，会导致对话框打开期间被反复重置，
+   * 从而出现“新增自定义引擎后，选择图标/任意操作导致自定义引擎消失（未保存内容被覆盖）”的现象。
+   */
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      initFromValuesOnceRef.current = false;
+      return;
+    }
+    if (initFromValuesOnceRef.current) return;
+    initFromValuesOnceRef.current = true;
+
     const activeId = String(values.providers?.activeId || "codex").trim() || "codex";
     setProvidersActiveId(activeId);
     setProviderEditingId(activeId);
@@ -528,7 +541,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
     setClaudeCodeReadAgentHistory(!!values.claudeCodeReadAgentHistory);
     setTerminalFontFamily(normalizeTerminalFontFamily(values.terminalFontFamily));
     setTerminalTheme(normalizeTerminalTheme(values.terminalTheme));
-  }, [open, values]);
+  }, [open]);
 
   /**
    * 拉取指定引擎的会话根路径列表（优先使用 settings.sessionRoots；旧版本仅支持 codexRoots）。
@@ -1188,11 +1201,11 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                               }
                             }}
                           />
-                          <Button variant="outline" size="sm" onClick={triggerLightIconPicker}>
+                          <Button type="button" variant="outline" size="sm" onClick={triggerLightIconPicker}>
                             {t("settings:providers.fields.iconUpload")}
                           </Button>
                           {hasLightOverride ? (
-                            <Button variant="outline" size="sm" onClick={() => updateProviderItem(providerEditingId, { iconDataUrl: "" })}>
+                            <Button type="button" variant="outline" size="sm" onClick={() => updateProviderItem(providerEditingId, { iconDataUrl: "" })}>
                               {t("settings:providers.fields.iconClear")}
                             </Button>
                           ) : null}
@@ -1247,11 +1260,11 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                               }
                             }}
                           />
-                          <Button variant="outline" size="sm" onClick={triggerDarkIconPicker}>
+                          <Button type="button" variant="outline" size="sm" onClick={triggerDarkIconPicker}>
                             {t("settings:providers.fields.iconUpload")}
                           </Button>
                           {hasDarkOverride ? (
-                            <Button variant="outline" size="sm" onClick={() => updateProviderItem(providerEditingId, { iconDataUrlDark: "" })}>
+                            <Button type="button" variant="outline" size="sm" onClick={() => updateProviderItem(providerEditingId, { iconDataUrlDark: "" })}>
                               {t("settings:providers.fields.iconClear")}
                             </Button>
                           ) : null}

--- a/web/src/locales/en/projects.json
+++ b/web/src/locales/en/projects.json
@@ -7,6 +7,7 @@
   "ctxOpenExternalConsoleWith": "Open {provider} in external {env} console",
   "ctxHideTemporarily": "Hide project",
   "ctxUnhideProject": "Unhide project",
+  "ctxRemoveDirRecord": "Remove directory record",
   "showHiddenProjects": "Show hidden projects",
   "hideHiddenProjects": "Hide hidden projects",
   "hiddenTag": "Hidden",

--- a/web/src/locales/zh/projects.json
+++ b/web/src/locales/zh/projects.json
@@ -7,6 +7,7 @@
   "ctxOpenExternalConsoleWith": "通过外部{env}控制台打开{provider}",
   "ctxHideTemporarily": "隐藏项目",
   "ctxUnhideProject": "取消隐藏项目",
+  "ctxRemoveDirRecord": "移除目录记录",
   "showHiddenProjects": "显示隐藏项目",
   "hideHiddenProjects": "不显示隐藏项目",
   "hiddenTag": "已隐藏",

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -83,6 +83,10 @@ export type Project = {
   winPath: string;
   wslPath: string;
   hasDotCodex: boolean;
+  /** 是否已确认存在内置三引擎（codex/claude/gemini）的会话记录。 */
+  hasBuiltInSessions?: boolean;
+  /** 自定义引擎无法从会话文件反推 cwd 时，用于“保留该目录”的显式记录。 */
+  dirRecord?: { kind: "custom_provider"; providerId: string; recordedAt: number };
   createdAt: number;
   lastOpenedAt?: number;
 };
@@ -121,7 +125,9 @@ export interface ProjectsAPI {
   /** 读取缓存项目列表（不触发扫描） */
   list(): Promise<{ ok: boolean; projects?: Project[]; error?: string }>;
   scan(args?: { roots?: string[] }): Promise<{ ok: boolean; projects?: Project[]; error?: string }>;
-  add(args: { winPath: string }): Promise<{ ok: boolean; project?: Project | null; error?: string }>;
+  add(args: { winPath: string; dirRecord?: { providerId: string; recordedAt?: number } }): Promise<{ ok: boolean; project?: Project | null; error?: string }>;
+  /** 移除“自定义引擎目录记录”。若项目已确认存在内置会话，仅清空记录；否则从列表移除该项目。 */
+  removeDirRecord(args: { id: string }): Promise<{ ok: boolean; removed: boolean; project?: Project | null; error?: string }>;
   touch(id: string): void;
 }
 


### PR DESCRIPTION
- Projects：为自定义引擎新增“目录记录”(dirRecord)，用于无法从会话反推 cwd 时仍能保留项目目录；并提供移除目录记录的 IPC/API。
- UI：顶部栏自定义引擎与内置引擎同排展示，移除“省略号/更多引擎”下拉逻辑。
- Settings：设置对话框打开期仅初始化一次 Provider 编辑状态，修复“新增自定义引擎后选择图标导致引擎消失（未保存内容被覆盖）”。
- History：索引器过滤为空时不再回退全量扫描，避免选中空目录/打开文件夹时卡顿与日志刷屏。
- WSL：路径转换改用 `wsl.exe -e wslpath` 并加入超时，避免反斜杠被 shell 解析导致 `wslpath: C:Users...` 噪声。