### PR TITLE
feat: 新增官方终端引擎并固定引擎排序

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -62,7 +62,7 @@ import HistoryCopyButton from "@/components/history/history-copy-button";
 import { toWSLForInsert } from "@/lib/wsl";
 import { extractGeminiProjectHashFromPath, deriveGeminiProjectHashCandidatesFromPath } from "@/lib/gemini-hash";
 import { normalizeProvidersSettings } from "@/lib/providers/normalize";
-import { isBuiltInProviderId } from "@/lib/providers/builtins";
+import { isBuiltInSessionProviderId } from "@/lib/providers/builtins";
 import { resolveProvider } from "@/lib/providers/resolve";
 import { injectCodexTraceEnv } from "@/providers/codex/commands";
 import { buildClaudeResumeStartupCmd } from "@/providers/claude/commands";
@@ -2611,7 +2611,7 @@ export default function CodexFlowManagerUI() {
   const recordCustomProviderDirIfNeeded = useCallback(async (project: Project, providerId: string) => {
     try {
       const pid = String(providerId || "").trim();
-      if (!pid || isBuiltInProviderId(pid)) return;
+      if (!pid || isBuiltInSessionProviderId(pid)) return;
       if (project?.hasBuiltInSessions === true) return;
       const existing = (project as any)?.dirRecord;
       if (existing && String(existing.kind || "") === "custom_provider" && String(existing.providerId || "") === pid) return;
@@ -2659,7 +2659,7 @@ export default function CodexFlowManagerUI() {
     }
 
     // 内置三引擎：即便会话记录落盘存在延迟，也先在 UI 侧标记，避免“自定义目录记录可移除”误判。
-    if (isBuiltInProviderId(activeProviderId)) {
+    if (isBuiltInSessionProviderId(activeProviderId)) {
       markProjectHasBuiltInSessions(project.id);
     } else {
       void recordCustomProviderDirIfNeeded(project, activeProviderId);
@@ -2762,7 +2762,7 @@ export default function CodexFlowManagerUI() {
     }
 
     // 内置三引擎：即便会话记录落盘存在延迟，也先在 UI 侧标记，避免“自定义目录记录可移除”误判。
-    if (isBuiltInProviderId(activeProviderId)) {
+    if (isBuiltInSessionProviderId(activeProviderId)) {
       markProjectHasBuiltInSessions(selectedProject.id);
     } else {
       void recordCustomProviderDirIfNeeded(selectedProject, activeProviderId);

--- a/web/src/assets/providers/black-terminal-icon.svg
+++ b/web/src/assets/providers/black-terminal-icon.svg
@@ -1,0 +1,8 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk) -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <title>Terminal</title>
+  <rect x="3" y="4" width="18" height="16" rx="2" />
+  <path d="M7 9l3 3-3 3" />
+  <path d="M11 15h6" />
+</svg>

--- a/web/src/assets/providers/white-terminal-icon.svg
+++ b/web/src/assets/providers/white-terminal-icon.svg
@@ -1,0 +1,8 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk) -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <title>Terminal</title>
+  <rect x="3" y="4" width="18" height="16" rx="2" />
+  <path d="M7 9l3 3-3 3" />
+  <path d="M11 15h6" />
+</svg>

--- a/web/src/lib/providers/builtins.ts
+++ b/web/src/lib/providers/builtins.ts
@@ -5,9 +5,13 @@ import openaiIconUrl from "@/assets/providers/openai.svg";
 import openaiDarkIconUrl from "@/assets/providers/openai-dark.png";
 import claudeIconUrl from "@/assets/providers/claude-color.svg";
 import geminiIconUrl from "@/assets/providers/gemini-color.svg";
+import terminalIconUrl from "@/assets/providers/black-terminal-icon.svg";
+import terminalDarkIconUrl from "@/assets/providers/white-terminal-icon.svg";
 import type { ThemeMode } from "@/lib/theme";
 
-export type BuiltInProviderId = "codex" | "claude" | "gemini";
+export type BuiltInProviderId = "codex" | "claude" | "gemini" | "terminal";
+
+export type BuiltInSessionProviderId = "codex" | "claude" | "gemini";
 
 export type BuiltInProviderMeta = {
   id: BuiltInProviderId;
@@ -37,6 +41,13 @@ export function getDefaultProviderIconUrl(themeMode?: ThemeMode): string {
  * 判断是否为内置 Provider id。
  */
 export function isBuiltInProviderId(id: string): id is BuiltInProviderId {
+  return id === "codex" || id === "claude" || id === "gemini" || id === "terminal";
+}
+
+/**
+ * 判断是否为“会话型内置 Provider”（具备会话扫描/历史索引能力：codex/claude/gemini）。
+ */
+export function isBuiltInSessionProviderId(id: string): id is BuiltInSessionProviderId {
   return id === "codex" || id === "claude" || id === "gemini";
 }
 
@@ -48,5 +59,6 @@ export function getBuiltInProviders(): BuiltInProviderMeta[] {
     { id: "codex", defaultStartupCmd: "codex", iconUrl: openaiIconUrl, iconUrlDark: openaiDarkIconUrl, labelKey: "providers:items.codex" },
     { id: "claude", defaultStartupCmd: "claude", iconUrl: claudeIconUrl, iconUrlDark: claudeIconUrl, labelKey: "providers:items.claude" },
     { id: "gemini", defaultStartupCmd: "gemini", iconUrl: geminiIconUrl, iconUrlDark: geminiIconUrl, labelKey: "providers:items.gemini" },
+    { id: "terminal", defaultStartupCmd: "", iconUrl: terminalIconUrl, iconUrlDark: terminalDarkIconUrl, labelKey: "providers:items.terminal" },
   ];
 }

--- a/web/src/locales/en/providers.json
+++ b/web/src/locales/en/providers.json
@@ -2,7 +2,8 @@
   "items": {
     "codex": "Codex",
     "claude": "Claude",
-    "gemini": "Gemini"
+    "gemini": "Gemini",
+    "terminal": "Terminal"
   },
   "customEngine": "Custom Engine",
   "more": "More engines",

--- a/web/src/locales/en/settings.json
+++ b/web/src/locales/en/settings.json
@@ -7,7 +7,7 @@
     },
     "providers": {
       "title": "Custom Engine",
-      "desc": "Configure Codex / Claude / Gemini, and add custom engines (icon + startup command + isolated environment)."
+      "desc": "Configure Codex / Claude / Gemini / Terminal, and add custom engines (icon + startup command + isolated environment)."
     },
     "notifications": {
       "title": "Notifications",

--- a/web/src/locales/zh/providers.json
+++ b/web/src/locales/zh/providers.json
@@ -2,7 +2,8 @@
   "items": {
     "codex": "Codex",
     "claude": "Claude",
-    "gemini": "Gemini"
+    "gemini": "Gemini",
+    "terminal": "终端"
   },
   "customEngine": "自定义引擎",
   "more": "更多引擎",

--- a/web/src/locales/zh/settings.json
+++ b/web/src/locales/zh/settings.json
@@ -7,7 +7,7 @@
     },
     "providers": {
       "title": "自定义引擎",
-      "desc": "配置 Codex / Claude / Gemini，并可新增自定义引擎（图标 + 启动命令 + 环境隔离）。"
+      "desc": "配置 Codex / Claude / Gemini / 终端，并可新增自定义引擎（图标 + 启动命令 + 环境隔离）。"
     },
     "notifications": {
       "title": "通知提醒",


### PR DESCRIPTION
- 新增官方 Provider `terminal`（无启动命令），提供亮/暗主题图标
- providers 配置归一化：官方引擎固定在前，自定义引擎保持相对顺序并始终在后
- 目录记录逻辑按“会话型内置引擎”区分：仅 codex/claude/gemini 标记内置会话，terminal 按自定义引擎方式保留目录
- 补齐中英文文案：Providers 列表与设置描述加入 Terminal