### PR TITLE
fix: 防止意外刷新导致控制台与标签丢失

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -83,6 +83,12 @@ contextBridge.exposeInMainWorld('host', {
     openWSLConsole: async (args: OpenArgs): Promise<{ id: string }> => {
       return await ipcRenderer.invoke('pty:open', args);
     },
+    /**
+     * 中文说明：读取指定 PTY 的尾部输出缓存（用于渲染进程 reload/HMR 后恢复滚动区）。
+     */
+    backlog: async (id: string, args?: { maxChars?: number }): Promise<{ ok: boolean; data?: string; error?: string }> => {
+      try { return await ipcRenderer.invoke('pty:backlog', { id, maxChars: args?.maxChars }); } catch (e) { return { ok: false, error: String(e) } as any; }
+    },
     write: (id: string, data: string) => {
       ipcRenderer.send('pty:write', { id, data });
     },

--- a/web/src/lib/TERMINAL_MANAGER_README.md
+++ b/web/src/lib/TERMINAL_MANAGER_README.md
@@ -13,8 +13,8 @@ TerminalManager (轻量说明)
   - `hostPty`：实现 PTY I/O 的对象（默认为 window.host.pty）
 
 主要方法
-- ensurePersistentContainer(tabId): HTMLDivElement
-- setPty(tabId, ptyId): void
+- ensurePersistentContainer(tabId, options?): HTMLDivElement
+- setPty(tabId, ptyId, options?): void
 - attachToHost(tabId, hostEl): void
 - disposeTab(tabId, alsoClosePty = true): void
 - disposeAll(alsoClosePty = true): void
@@ -30,7 +30,9 @@ tm.attachToHost(tabId, hostEl);
 tm.disposeTab(tabId);
 ```
 
+补充说明
+- `setPty(..., { hydrateBacklog: true })`：用于“渲染进程 reload/HMR 后重连现有 PTY”场景，会回放主进程保存的尾部输出，避免滚动区看起来为空。
+
 迁移建议
 - 若要提取为独立包：将 `createTerminalAdapter` 抽成 peerDependency（或提供接口注入），并把 HostPtyAPI 作为必需注入项，避免直接依赖 `window.host`。
-
 

--- a/web/src/lib/console-session.ts
+++ b/web/src/lib/console-session.ts
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+/**
+ * 控制台会话（Tabs + PTY 绑定）在渲染层的轻量持久化。
+ *
+ * 目标
+ * - 解决“意外 reload / HMR / 白屏重载后标签页与控制台丢失”的体验问题；
+ * - 仅保存结构信息（tab 列表、活跃 tab、tabId->ptyId 映射），不保存终端输出正文；
+ * - 终端输出正文由主进程 PTY 尾部缓冲提供回放（见 `pty.backlog`）。
+ */
+
+const CONSOLE_SESSION_STORAGE_KEY = "codexflow.consoleSession.v1";
+const CONSOLE_SESSION_VERSION = 1 as const;
+
+export type PersistedConsoleTab = {
+  id: string;
+  name: string;
+  providerId: string;
+  createdAt: number;
+};
+
+export type PersistedConsoleSession = {
+  version: typeof CONSOLE_SESSION_VERSION;
+  savedAt: number;
+  selectedProjectId: string;
+  tabsByProject: Record<string, PersistedConsoleTab[]>;
+  activeTabByProject: Record<string, string | null>;
+  ptyByTab: Record<string, string>;
+};
+
+/**
+ * 中文说明：安全获取 localStorage（部分环境可能抛异常）。
+ */
+function getLocalStorageSafe(): Storage | null {
+  try {
+    if (typeof window === "undefined") return null;
+    return window.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 中文说明：将输入转为非空字符串；否则返回空串。
+ */
+function toNonEmptyString(value: unknown): string {
+  const s = typeof value === "string" ? value.trim() : String(value ?? "").trim();
+  return s;
+}
+
+/**
+ * 中文说明：对 tabsByProject 做最小校验与归一化，避免脏数据导致 UI 崩溃。
+ */
+function normalizeTabsByProject(input: unknown): Record<string, PersistedConsoleTab[]> {
+  const out: Record<string, PersistedConsoleTab[]> = {};
+  if (!input || typeof input !== "object") return out;
+  for (const [projectIdRaw, listRaw] of Object.entries(input as Record<string, unknown>)) {
+    const projectId = toNonEmptyString(projectIdRaw);
+    if (!projectId) continue;
+    if (!Array.isArray(listRaw)) continue;
+    const tabs: PersistedConsoleTab[] = [];
+    for (const item of listRaw) {
+      if (!item || typeof item !== "object") continue;
+      const obj = item as any;
+      const id = toNonEmptyString(obj.id);
+      if (!id) continue;
+      const name = toNonEmptyString(obj.name) || "Console";
+      const providerId = toNonEmptyString(obj.providerId) || "codex";
+      const createdAtNum = Number(obj.createdAt);
+      const createdAt = Number.isFinite(createdAtNum) ? createdAtNum : Date.now();
+      tabs.push({ id, name, providerId, createdAt });
+    }
+    out[projectId] = tabs;
+  }
+  return out;
+}
+
+/**
+ * 中文说明：归一化 Record<string, string|null>（空字符串视为 null）。
+ */
+function normalizeActiveTabByProject(input: unknown): Record<string, string | null> {
+  const out: Record<string, string | null> = {};
+  if (!input || typeof input !== "object") return out;
+  for (const [projectIdRaw, tabIdRaw] of Object.entries(input as Record<string, unknown>)) {
+    const projectId = toNonEmptyString(projectIdRaw);
+    if (!projectId) continue;
+    const tabId = toNonEmptyString(tabIdRaw);
+    out[projectId] = tabId ? tabId : null;
+  }
+  return out;
+}
+
+/**
+ * 中文说明：归一化 Record<string, string>（用于 tabId -> ptyId）。
+ */
+function normalizePtyByTab(input: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!input || typeof input !== "object") return out;
+  for (const [tabIdRaw, ptyIdRaw] of Object.entries(input as Record<string, unknown>)) {
+    const tabId = toNonEmptyString(tabIdRaw);
+    const ptyId = toNonEmptyString(ptyIdRaw);
+    if (!tabId || !ptyId) continue;
+    out[tabId] = ptyId;
+  }
+  return out;
+}
+
+/**
+ * 中文说明：读取控制台会话快照。
+ */
+export function loadConsoleSession(): PersistedConsoleSession | null {
+  const ls = getLocalStorageSafe();
+  if (!ls) return null;
+  try {
+    const raw = ls.getItem(CONSOLE_SESSION_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as any;
+    const version = Number(parsed?.version);
+    if (version !== CONSOLE_SESSION_VERSION) return null;
+    const selectedProjectId = toNonEmptyString(parsed?.selectedProjectId);
+    const tabsByProject = normalizeTabsByProject(parsed?.tabsByProject);
+    const activeTabByProject = normalizeActiveTabByProject(parsed?.activeTabByProject);
+    const ptyByTab = normalizePtyByTab(parsed?.ptyByTab);
+    const savedAtNum = Number(parsed?.savedAt);
+    const savedAt = Number.isFinite(savedAtNum) ? savedAtNum : Date.now();
+    return { version: CONSOLE_SESSION_VERSION, savedAt, selectedProjectId, tabsByProject, activeTabByProject, ptyByTab };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 中文说明：保存控制台会话快照。
+ */
+export function saveConsoleSession(session: PersistedConsoleSession): void {
+  const ls = getLocalStorageSafe();
+  if (!ls) return;
+  try {
+    const payload: PersistedConsoleSession = {
+      version: CONSOLE_SESSION_VERSION,
+      savedAt: Date.now(),
+      selectedProjectId: toNonEmptyString(session?.selectedProjectId),
+      tabsByProject: normalizeTabsByProject(session?.tabsByProject),
+      activeTabByProject: normalizeActiveTabByProject(session?.activeTabByProject),
+      ptyByTab: normalizePtyByTab(session?.ptyByTab),
+    };
+    const text = JSON.stringify(payload);
+    // 轻量保护：避免异常情况下写入过大导致卡顿（上限约 256KB）
+    if (text.length > 256_000) return;
+    ls.setItem(CONSOLE_SESSION_STORAGE_KEY, text);
+  } catch {
+    // noop
+  }
+}
+
+/**
+ * 中文说明：清除控制台会话快照。
+ */
+export function clearConsoleSession(): void {
+  const ls = getLocalStorageSafe();
+  if (!ls) return;
+  try {
+    ls.removeItem(CONSOLE_SESSION_STORAGE_KEY);
+  } catch {
+    // noop
+  }
+}
+

--- a/web/src/lib/preventReloadShortcuts.ts
+++ b/web/src/lib/preventReloadShortcuts.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+/**
+ * 中文说明：阻止意外触发的“页面刷新/强制刷新”快捷键（Ctrl/Cmd+R、F5）。
+ *
+ * 背景
+ * - CodexFlow 的终端（xterm）内 Ctrl+R 是常用快捷键（反向搜索等）。
+ * - 若被浏览器默认行为拦截，会导致渲染进程 reload，表现为“白屏重载、标签页丢失、控制台清空”。
+ *
+ * 设计
+ * - 仅 `preventDefault()`，不 `stopPropagation()`：确保按键事件仍能被 xterm/输入框接收。
+ * - 使用捕获阶段监听，尽量在默认行为执行前拦截。
+ */
+
+/**
+ * 中文说明：安装“阻止刷新快捷键”拦截器。
+ * @returns 卸载函数（调用后移除监听）。
+ */
+export function installPreventReloadShortcuts(): () => void {
+  const handler = (e: KeyboardEvent) => {
+    try {
+      if (!e) return;
+      if (e.defaultPrevented) return;
+      const key = String(e.key || "");
+      const keyLower = key.toLowerCase();
+      const code = String((e as any).code || "");
+
+      const isMod = !!(e.ctrlKey || e.metaKey);
+      // 避免误伤 AltGr（部分键盘布局下等价于 Ctrl+Alt），因此要求不按下 Alt
+      const isReloadCombo = isMod && !e.altKey && keyLower === "r";
+      const isF5 = key === "F5" || code === "F5";
+      const isBrowserReloadKey = keyLower === "browserreload" || keyLower === "reload";
+
+      if (!isReloadCombo && !isF5 && !isBrowserReloadKey) return;
+      // 仅阻止默认刷新；不阻断事件传播，确保终端/输入框仍能收到 Ctrl+R 等组合键
+      e.preventDefault();
+    } catch {
+      // noop
+    }
+  };
+
+  try {
+    window.addEventListener("keydown", handler, true);
+  } catch {
+    // noop
+  }
+
+  return () => {
+    try {
+      window.removeEventListener("keydown", handler, true);
+    } catch {
+      // noop
+    }
+  };
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -9,9 +9,12 @@ import { I18nextProvider } from 'react-i18next';
 import i18n, { initI18n } from '@/i18n/setup';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import { applyTheme, getCachedThemeSetting } from '@/lib/theme';
+import { installPreventReloadShortcuts } from '@/lib/preventReloadShortcuts';
 
 const cachedThemeSetting = getCachedThemeSetting();
 applyTheme(cachedThemeSetting ?? 'system');
+// 关键：阻止 Ctrl/Cmd+R、F5 导致的渲染进程 reload（不影响 xterm 接收按键）
+installPreventReloadShortcuts();
 
 const root = createRoot(document.getElementById('root')!);
 

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -110,6 +110,8 @@ export type HistoryMessage = { role: string; content: MessageContent[] };
 // ---- Host API 声明 ----
 export interface PtyAPI {
   openWSLConsole(args: { terminal?: 'wsl' | 'windows' | 'pwsh'; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string> }): Promise<{ id: string }>;
+  /** 读取 PTY 的尾部输出缓存（用于渲染进程 reload/HMR 后恢复终端滚动区）。 */
+  backlog?: (id: string, args?: { maxChars?: number }) => Promise<{ ok: boolean; data?: string; error?: string }>;
   write(id: string, data: string): void;
   resize(id: string, cols: number, rows: number): void;
   close(id: string): void;


### PR DESCRIPTION
- 渲染层：拦截 Ctrl/Cmd+R、F5，避免触发渲染进程 reload（不影响终端接收按键）
- 渲染层：持久化并恢复控制台标签页与 tabId->ptyId 绑定（localStorage）
- 主进程：为每个 PTY 维护尾部输出缓冲，并提供 pty.backlog IPC 供恢复回放
- TerminalManager：新增 hydrateBacklog 选项与超时保护，恢复场景自动回放并继续桥接
- 文档：补充 TerminalManager API 与回放说明