### PR TITLE
chore: 版本号升级至 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexflow",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexflow",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexflow",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "Electron + React + Vite + node-pty + xterm WSL terminal host (UI only, minimal bridge)",
   "license": "Apache-2.0",


### PR DESCRIPTION
更新 package.json 和 package-lock.json 中的版本号从 0.4.0 升级到 0.5.0