### PR TITLE
fix(terminal): 用 bootId 防止重启后恢复无效控制台

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -46,6 +46,21 @@ import { readDebugConfig, getDebugConfig, onDebugChanged, watchDebugConfig, upda
 
 // 使用 CommonJS 编译输出时，运行时环境会提供 `__dirname`，直接使用即可
 
+/**
+ * 中文说明：本次主进程启动的唯一标识，用于让渲染层区分：
+ * - 同一主进程生命周期内的渲染 reload/HMR（PTY 仍存活，可安全恢复 tabId->ptyId 绑定）
+ * - 应用重启（PTY 已销毁，若继续恢复会导致“残留无效控制台”）
+ *
+ * 实现方式：写入环境变量，供 preload 同步读取并暴露给渲染层。
+ */
+const CODEXFLOW_APP_BOOT_ID = String(process.env.CODEXFLOW_APP_BOOT_ID || "").trim()
+  || `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+try {
+  if (!String(process.env.CODEXFLOW_APP_BOOT_ID || "").trim()) {
+    process.env.CODEXFLOW_APP_BOOT_ID = CODEXFLOW_APP_BOOT_ID;
+  }
+} catch {}
+
 let mainWindow: BrowserWindow | null = null;
 let DIAG = false;
 let quitConfirmed = false;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -5,8 +5,16 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 type OpenArgs = { terminal?: 'wsl' | 'windows' | 'pwsh'; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string> };
 
+/**
+ * 中文说明：从主进程继承的本次启动 bootId。
+ * - 主进程在启动时写入 `process.env.CODEXFLOW_APP_BOOT_ID`
+ * - preload 在每次 document load/reload 时都会重新执行，因此必须读取一个“跨 reload 稳定”的值
+ */
+const APP_BOOT_ID = String(process.env.CODEXFLOW_APP_BOOT_ID || "");
+
 contextBridge.exposeInMainWorld('host', {
   app: {
+    bootId: APP_BOOT_ID,
     getVersion: async (): Promise<string> => {
       try { const res = await ipcRenderer.invoke('app.getVersion'); return (res && res.ok) ? String(res.version || '') : ''; } catch { return ''; }
     },

--- a/web/src/lib/TERMINAL_MANAGER_README.md
+++ b/web/src/lib/TERMINAL_MANAGER_README.md
@@ -32,7 +32,7 @@ tm.disposeTab(tabId);
 
 补充说明
 - `setPty(..., { hydrateBacklog: true })`：用于“渲染进程 reload/HMR 后重连现有 PTY”场景，会回放主进程保存的尾部输出，避免滚动区看起来为空。
+- 控制台标签页与 tabId->ptyId 绑定的持久化仅用于同一主进程生命周期内的 reload/HMR；跨应用重启时 PTY 已销毁，渲染层会基于 bootId 判定快照失效并自动清除，避免残留无效控制台。
 
 迁移建议
 - 若要提取为独立包：将 `createTerminalAdapter` 抽成 peerDependency（或提供接口注入），并把 HostPtyAPI 作为必需注入项，避免直接依赖 `window.host`。
-

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -355,6 +355,11 @@ export interface ImagesAPI {
 }
 
 export interface AppAPI {
+  /**
+   * 中文说明：本次主进程启动的唯一标识（跨 reload 稳定）。
+   * 用途：渲染层区分“渲染 reload/HMR”与“应用重启”，避免重启后恢复失效的控制台绑定。
+   */
+  bootId: string;
   getVersion(): Promise<string>;
   getPaths(): Promise<{ licensePath?: string; noticePath?: string }>;
   /** 仅 Windows：设置原生标题栏主题（light/dark） */


### PR DESCRIPTION
- 主进程生成并透传 bootId（preload 暴露到 window.host.app.bootId）
- 控制台会话快照持久化 bootId，恢复时校验并在不匹配时自动清理
- README 与类型定义同步更新