### PR TITLE
fix(shell): 修复Claude启动命令行多行文本截断，PowerShell 参数含非 ASCII 时改用 Base64 还原

### DIFF
--- a/web/src/lib/shell.test.ts
+++ b/web/src/lib/shell.test.ts
@@ -13,5 +13,19 @@ describe("shell 工具：PowerShell 参数安全拼接", () => {
     const cmd = buildPowerShellCall(["tool", "a b", "x'y"]);
     expect(cmd).toBe("& 'tool' 'a b' 'x''y'");
   });
+
+  it("包含非 ASCII 字符的参数会被编码为 Base64 表达式（提升 Windows PTY 兼容性）", () => {
+    const prompt = "请重新设计历史面板的‘显示/隐藏’机制。我希望移除原本独立的‘隐藏历史’按钮。";
+    const cmd = buildPowerShellCall(["claude", "--dangerously-skip-permissions", prompt]);
+    expect(cmd).toContain("[System.Text.Encoding]::UTF8.GetString");
+    expect(cmd).toContain("[System.Convert]::FromBase64String");
+    expect(cmd).not.toContain(prompt);
+    expect(cmd).not.toMatch(/[^\x20-\x7E]/);
+
+    const m = cmd.match(/FromBase64String\('([^']*)'\)/);
+    expect(m).not.toBeNull();
+    const decoded = Buffer.from(m?.[1] || "", "base64").toString("utf8");
+    expect(decoded).toBe(prompt);
+  });
 });
 


### PR DESCRIPTION
Windows 的 ConPTY/CodePage 在 PTY 输入侧对部分 Unicode 字符兼容性不一致， 导致包含中文等非 ASCII 的参数在写入/解析时可能出现截断或丢字。

- powerShellArgToken：对包含换行或非 ASCII/不可打印 ASCII 的参数使用 UTF-8 Base64 表达式还原
- buildPowerShellCall：命令 token 统一走 powerShellArgToken，避免路径/命令本身含非 ASCII 时出错
- 单测：补充用例验证输出仅 ASCII，且 Base64 可正确还原原始参数