### PR TITLE
feat(ui): 支持悬停快捷键与弹窗键盘操作

### DIFF
--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -8,6 +8,145 @@ import { cn } from '@/lib/utils';
 type Ctx = { open: boolean; setOpen: (v: boolean) => void };
 const DialogContext = React.createContext<Ctx | null>(null);
 
+const DIALOG_CONTENT_SELECTOR = '[data-cf-dialog-content="true"]';
+let dialogGlobalKeydownInstalled = false;
+
+/**
+ * 中文说明：判断 Enter 自动确认是否需要跳过当前事件目标。
+ * - textarea / 可编辑区域：Enter 通常用于换行
+ * - button：让浏览器默认行为接管，避免二次触发
+ */
+function shouldSkipEnterAutoConfirm(target: EventTarget | null): boolean {
+  try {
+    const el = target as any;
+    if (!el) return false;
+    if (el instanceof HTMLTextAreaElement) return true;
+    if (el instanceof HTMLButtonElement) return true;
+    if (typeof el.isContentEditable === "boolean" && el.isContentEditable) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 中文说明：判断按钮是否可被“Enter 自动确认”安全点击。
+ */
+function isClickableButton(btn: HTMLButtonElement | null): btn is HTMLButtonElement {
+  if (!btn) return false;
+  try {
+    if (btn.disabled) return false;
+    if (btn.getAttribute("aria-disabled") === "true") return false;
+    // 尽量避免点到隐藏按钮
+    const style = window.getComputedStyle(btn);
+    if (style.display === "none" || style.visibility === "hidden") return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 中文说明：在弹窗内容区域内寻找“主按钮”。
+ * - 优先：`data-cf-dialog-primary="true"`
+ * - 兜底：最后一个可点击的 button（符合大多数“取消在左/确认在右”的布局习惯）
+ */
+function findDialogPrimaryButton(root: HTMLElement): HTMLButtonElement | null {
+  const primary = root.querySelector<HTMLButtonElement>('button[data-cf-dialog-primary="true"]');
+  if (isClickableButton(primary)) return primary;
+  const buttons = Array.from(root.querySelectorAll<HTMLButtonElement>("button")).filter(isClickableButton);
+  return buttons.length > 0 ? buttons[buttons.length - 1] : null;
+}
+
+/**
+ * 中文说明：在弹窗内容区域内寻找“取消按钮”。
+ * - 优先：`data-cf-dialog-cancel="true"`
+ * - 兜底：根据按钮文本识别（如“取消/关闭/返回”或“Cancel/Close/Back”），避免误点确认按钮
+ */
+function findDialogCancelButton(root: HTMLElement): HTMLButtonElement | null {
+  const cancel = root.querySelector<HTMLButtonElement>('button[data-cf-dialog-cancel="true"]');
+  if (isClickableButton(cancel)) return cancel;
+  const buttons = Array.from(root.querySelectorAll<HTMLButtonElement>("button")).filter(isClickableButton);
+  const normalize = (s: string) => String(s || "").replace(/\s+/g, " ").trim();
+  const matches = (label: string) => {
+    const text = normalize(label);
+    const lower = text.toLowerCase();
+    const hasHintSuffix = (raw: string, base: string) => {
+      const rest = raw.slice(base.length).trim();
+      return rest.length > 0 && (/^[\(\（]/.test(rest));
+    };
+    const cnBases = ["取消", "关闭", "返回"];
+    for (const b of cnBases) {
+      if (text === b) return true;
+      if (text.startsWith(b) && hasHintSuffix(text, b)) return true;
+    }
+    const enBases = ["cancel", "close", "back"];
+    for (const b of enBases) {
+      if (lower === b) return true;
+      if (lower.startsWith(b) && hasHintSuffix(lower, b)) return true;
+    }
+    return false;
+  };
+  for (const btn of buttons) {
+    const label = normalize(btn.textContent || "");
+    if (matches(label)) return btn;
+  }
+  return null;
+}
+
+/**
+ * 中文说明：全局 Dialog 键盘处理。
+ * - 仅在存在打开的 DialogContent 时生效
+ * - Enter：触发“主按钮”（确认）
+ * - Escape：触发“取消按钮”（取消）；若未找到取消按钮则关闭弹窗
+ */
+function handleGlobalDialogKeydown(event: KeyboardEvent) {
+  if (!event || event.defaultPrevented) return;
+
+  try {
+    const list = Array.from(document.querySelectorAll<HTMLElement>(DIALOG_CONTENT_SELECTOR));
+    if (list.length === 0) return;
+    const topmost = list[list.length - 1];
+
+    if (event.key === "Enter") {
+      // 仅处理“纯 Enter”（不含 Ctrl/Alt/Meta/Shift），避免干扰既有快捷键
+      if (event.ctrlKey || event.metaKey || event.altKey) return;
+      if (event.shiftKey) return;
+      if (shouldSkipEnterAutoConfirm(event.target)) return;
+      const btn = findDialogPrimaryButton(topmost);
+      if (!btn) return;
+      event.preventDefault();
+      btn.click();
+      return;
+    }
+
+    if (event.key === "Escape") {
+      const cancel = findDialogCancelButton(topmost);
+      if (cancel) {
+        event.preventDefault();
+        cancel.click();
+        return;
+      }
+      // 兜底：关闭弹窗（等同于点击遮罩）
+      const overlay = topmost.parentElement?.querySelector<HTMLElement>('[data-cf-dialog-overlay="true"]');
+      if (overlay) {
+        event.preventDefault();
+        overlay.click();
+      }
+    }
+  } catch {}
+}
+
+/**
+ * 中文说明：确保全局 Dialog 键盘处理只注册一次。
+ */
+function ensureDialogGlobalKeydownInstalled() {
+  if (dialogGlobalKeydownInstalled) return;
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+  dialogGlobalKeydownInstalled = true;
+  window.addEventListener("keydown", handleGlobalDialogKeydown);
+}
+
 export function Dialog({ open: openProp, onOpenChange, children }: { open?: boolean; onOpenChange?: (v: boolean) => void; children: React.ReactNode }) {
   const [uncontrolled, setUncontrolled] = React.useState(false);
   const open = openProp ?? uncontrolled;
@@ -33,6 +172,10 @@ export function DialogTrigger({ asChild, children }: { asChild?: boolean; childr
 export function DialogContent({ className, children }: React.HTMLAttributes<HTMLDivElement>) {
   const ctx = React.useContext(DialogContext);
   const [isVisible, setIsVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    ensureDialogGlobalKeydownInstalled();
+  }, []);
 
   React.useEffect(() => {
     let raf1: number | null = null;
@@ -71,12 +214,13 @@ export function DialogContent({ className, children }: React.HTMLAttributes<HTML
     <div className={cn(
       'fixed inset-0 z-50 flex items-center justify-center transition-all duration-apple-slow ease-apple',
       isVisible ? 'opacity-100' : 'opacity-0'
-    )}>
+    )} data-cf-dialog-root="true">
       <div 
         className={cn(
           'absolute inset-0 bg-black/40 backdrop-blur-apple transition-all duration-apple-slow ease-apple',
           isVisible ? 'opacity-100' : 'opacity-0'
         )}
+        data-cf-dialog-overlay="true"
         onClick={() => ctx.setOpen(false)} 
       />
       <div 
@@ -85,6 +229,7 @@ export function DialogContent({ className, children }: React.HTMLAttributes<HTML
           isVisible ? 'opacity-100 scale-100' : 'opacity-0 scale-95',
           className
         )}
+        data-cf-dialog-content="true"
       >
         {children}
       </div>


### PR DESCRIPTION
- 项目列表：悬停时 H 隐藏/取消隐藏；D 删除 worktree 或移除目录记录
- 历史列表：悬停时 D 打开“删除到回收站”确认
- Dialog：Enter 自动触发主按钮、Escape 优先触发取消；多层弹窗按最上层处理
- 保护：IME/组合键/输入控件/弹窗打开时不触发悬停快捷键

测试：未运行（WSL 下 vitest 执行权限异常）