### PR TITLE
fix(terminal): 修复标签切换后滚动条指示错位

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,15 @@
+/// <reference types="vitest" />
+
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "web/src"),
+    },
+  },
+});

--- a/web/src/lib/terminal-manager-scroll.test.ts
+++ b/web/src/lib/terminal-manager-scroll.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const createTerminalAdapterMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/adapters/TerminalAdapter", () => ({
+  createTerminalAdapter: createTerminalAdapterMock,
+}));
+
+import TerminalManager from "./TerminalManager";
+
+describe("TerminalManager（终端滚动快照）", () => {
+  afterEach(() => {
+    try { createTerminalAdapterMock.mockReset(); } catch {}
+  });
+
+  /**
+   * 中文说明：创建最小可用的 hostPty stub，避免单测触碰真实 IPC。
+   */
+  const createHostPtyStub = () => {
+    return {
+      onData: () => () => {},
+      write: () => {},
+      resize: () => {},
+      close: () => {},
+    };
+  };
+
+  it("onTabDeactivated 会保存快照，onTabActivated 会恢复", () => {
+    const snapshot = { viewportY: 42, baseY: 80, isAtBottom: false };
+    const adapter: any = {
+      mount: vi.fn(() => ({ cols: 80, rows: 24 })),
+      write: vi.fn(),
+      paste: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      resize: vi.fn(() => ({ cols: 80, rows: 24 })),
+      getScrollSnapshot: vi.fn(() => snapshot),
+      restoreScrollSnapshot: vi.fn(),
+      focus: vi.fn(),
+      blur: vi.fn(),
+      setAppearance: vi.fn(),
+      dispose: vi.fn(),
+    };
+    createTerminalAdapterMock.mockReturnValue(adapter);
+
+    const tm = new TerminalManager(() => undefined, createHostPtyStub() as any, {});
+    tm.ensurePersistentContainer("tab-a");
+    tm.onTabDeactivated("tab-a");
+    tm.onTabActivated("tab-a");
+
+    expect(adapter.getScrollSnapshot).toHaveBeenCalled();
+    expect(adapter.restoreScrollSnapshot).toHaveBeenCalledWith(snapshot);
+    tm.disposeAll(false);
+  });
+
+  it("没有历史快照时，onTabActivated 仍会触发一次对齐修复", () => {
+    const adapter: any = {
+      mount: vi.fn(() => ({ cols: 80, rows: 24 })),
+      write: vi.fn(),
+      paste: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      resize: vi.fn(() => ({ cols: 80, rows: 24 })),
+      getScrollSnapshot: vi.fn(() => null),
+      restoreScrollSnapshot: vi.fn(),
+      focus: vi.fn(),
+      blur: vi.fn(),
+      setAppearance: vi.fn(),
+      dispose: vi.fn(),
+    };
+    createTerminalAdapterMock.mockReturnValue(adapter);
+
+    const tm = new TerminalManager(() => undefined, createHostPtyStub() as any, {});
+    tm.ensurePersistentContainer("tab-b");
+    tm.onTabActivated("tab-b");
+
+    expect(adapter.restoreScrollSnapshot).toHaveBeenCalledWith(null);
+    tm.disposeAll(false);
+  });
+});


### PR DESCRIPTION
背景：在 tab 切换/隐藏（例如 display:none）后，xterm 偶发出现“内容位置正确，但滚动条滑块位置错误”的不一致，导致用户误判当前滚动位置。

变更：
- TerminalAdapter：新增滚动快照读写能力；以 buffer.active.viewportY/baseY 为基准，将 .xterm-viewport 的 scrollTop 与缓冲区视图对齐，并在 restore 时补一次 rAF 对齐。
- TerminalManager：在 onTabDeactivated 保存快照，在 onTabActivated 恢复；无历史快照时仍触发一次对齐修复。
- 测试：新增终端滚动快照单测；补充 vitest 配置以支持 @ 路径别名。