### PR TITLE
feat(web): 确认弹窗展示目标信息

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7554,7 +7554,21 @@ export default function CodexFlowManagerUI() {
         <DialogContent className="max-w-sm">
           <DialogHeader>
             <DialogTitle>{t('settings:cleanupConfirm.title')}</DialogTitle>
-            <DialogDescription>{t('history:confirmPermanentDelete')}</DialogDescription>
+            <DialogDescription>
+              {t('history:confirmPermanentDelete')}
+              {confirmDelete.item && (
+                <div className="mt-3 rounded border border-slate-200 bg-slate-50 p-3 text-xs text-slate-600 dark:border-[var(--cf-border)] dark:bg-[var(--cf-surface-muted)] dark:text-[var(--cf-text-secondary)]">
+                  <div className="font-semibold text-[var(--cf-text-primary)] mb-1 truncate">
+                    {confirmDelete.item.title || t('history:untitledSessionTitle')}
+                  </div>
+                  {confirmDelete.item.preview && (
+                    <div className="line-clamp-3 opacity-80 whitespace-pre-wrap font-mono text-[11px]">
+                      {confirmDelete.item.preview}
+                    </div>
+                  )}
+                </div>
+              )}
+            </DialogDescription>
           </DialogHeader>
           <div className="flex justify-end gap-2 pt-2">
             <Button variant="outline" onClick={() => setConfirmDelete((m) => ({ ...m, open: false }))}>{t('common:cancel')}</Button>
@@ -9472,9 +9486,19 @@ export default function CodexFlowManagerUI() {
           <DialogHeader>
             <DialogTitle>{t('projects:hideTemporaryTitle')}</DialogTitle>
             <DialogDescription>
-              {hideProjectConfirm.project?.name
-                ? t('projects:hideTemporaryDescriptionNamed', { name: hideProjectConfirm.project.name })
-                : t('projects:hideTemporaryDescription')}
+              {t('projects:hideTemporaryDescription')}
+              {hideProjectConfirm.project?.name && (
+                <div className="mt-4 rounded border border-slate-200 bg-slate-50 p-3 text-center dark:border-[var(--cf-border)] dark:bg-[var(--cf-surface-muted)]">
+                  <div className="text-sm font-semibold text-slate-900 dark:text-[var(--cf-text-primary)]">
+                    {hideProjectConfirm.project.name}
+                  </div>
+                  {hideProjectConfirm.project.id && dirTreeStore.labelById[hideProjectConfirm.project.id] && (
+                    <div className="mt-1 text-xs text-slate-500 dark:text-[var(--cf-text-muted)] truncate">
+                      {dirTreeStore.labelById[hideProjectConfirm.project.id]}
+                    </div>
+                  )}
+                </div>
+              )}
             </DialogDescription>
           </DialogHeader>
           <div className="flex justify-end gap-2 pt-2">

--- a/web/src/locales/en/history.json
+++ b/web/src/locales/en/history.json
@@ -22,6 +22,7 @@
   "cannotOpenDefault": "Unable to open with default app",
   "deleteToTrash": "Delete Permanently",
   "confirmPermanentDelete": "Permanently delete this history file? This action cannot be undone.",
+  "untitledSessionTitle": "Untitled",
   "deleteFailed": "Delete failed: {error}",
   "cannotDelete": "Unable to delete: {error}",
   "continueConversation": "Continue Conversation",

--- a/web/src/locales/zh/history.json
+++ b/web/src/locales/zh/history.json
@@ -22,6 +22,7 @@
   "cannotOpenDefault": "无法用默认程序打开",
   "deleteToTrash": "彻底删除",
   "confirmPermanentDelete": "确认要彻底删除该历史文件吗？该操作不可恢复。",
+  "untitledSessionTitle": "未命名",
   "deleteFailed": "删除失败：{error}",
   "cannotDelete": "无法删除：{error}",
   "continueConversation": "继续对话",


### PR DESCRIPTION
- 历史“彻底删除”确认弹窗中展示会话标题与预览片段，降低误删风险。
- “隐藏项目”确认弹窗中展示项目名称与路径标签，减少误操作。
- 新增 i18n 文案：history:untitledSessionTitle（en/zh）。