### PR TITLE
feat(history): 右上角新增历史面板悬浮开关按钮

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -65,6 +65,7 @@ import { isGeminiProvider, writeBracketedPaste, writeBracketedPasteAndEnter } fr
 import { oscBufferDefaults, trimOscBuffer } from "@/lib/oscNotificationBuffer";
 import { resolveDirRowDropPosition } from "@/lib/dir-tree-dnd";
 import HistoryCopyButton from "@/components/history/history-copy-button";
+import HistoryPanelToggleButton from "@/components/history/history-panel-toggle-button";
 import { toWSLForInsert } from "@/lib/wsl";
 import { extractGeminiProjectHashFromPath, deriveGeminiProjectHashCandidatesFromPath } from "@/lib/gemini-hash";
 import { normalizeProvidersSettings } from "@/lib/providers/normalize";
@@ -6714,14 +6715,11 @@ export default function CodexFlowManagerUI() {
 		          themeMode={themeMode}
 		        />
 	      </div>
-	      <div className="flex items-center gap-2">
+	      <div className={`flex items-center gap-2 ${showHistoryPanel ? "" : "pr-[44px]"}`}>
         {/* 目录缺失提示：若选中项目的 Windows 路径不存在则提示 */}
         {selectedProject?.winPath && (
           <span className="hidden" data-proj-path={selectedProject.winPath}></span>
         )}
-        <Button size="sm" variant="secondary" className="whitespace-nowrap" onClick={() => setShowHistoryPanel((v) => !v)}>
-          <HistoryIcon className="mr-2 h-4 w-4" /> {showHistoryPanel ? t('history:hidePanel') : t('history:showPanel')}
-        </Button>
         <Button size="sm" variant="secondary" className="whitespace-nowrap" onClick={() => setSettingsOpen(true)}>
           <SettingsIcon className="mr-2 h-4 w-4" /> {t('settings:title')}
         </Button>
@@ -7342,7 +7340,7 @@ export default function CodexFlowManagerUI() {
   const HistorySidebar = (
     <div className="grid h-full min-w-[240px] grid-rows-[auto_auto_auto_1fr] min-h-0 border-l bg-white/70 backdrop-blur-sm dark:border-slate-800 dark:bg-slate-900/60">
       {/* Header with enhanced modern styling */}
-      <div className="flex items-center justify-between px-3 py-3 border-b border-slate-100 dark:border-slate-700/50">
+      <div className="flex items-center justify-between px-3 pt-3 pb-5 border-b border-slate-100 dark:border-slate-700/50">
         <div className="flex items-center gap-2 font-medium shrink-0">
           <HistoryIcon className="h-4 w-4" /> {t('history:panelTitle')}
         </div>
@@ -7675,6 +7673,14 @@ export default function CodexFlowManagerUI() {
           )}
         </div>
         {showHistoryPanel && HistorySidebar}
+      </div>
+
+      <div className="fixed right-4 top-3 z-40">
+        <HistoryPanelToggleButton
+          expanded={showHistoryPanel}
+          label={String(showHistoryPanel ? t("history:hidePanel") : t("history:showPanel"))}
+          onToggle={() => setShowHistoryPanel((v) => !v)}
+        />
       </div>
 
       {historyCtxMenu.show && (

--- a/web/src/components/history/history-panel-toggle-button.tsx
+++ b/web/src/components/history/history-panel-toggle-button.tsx
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import React from "react";
+import { History as HistoryIcon, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type HistoryPanelToggleButtonProps = {
+  /** 中文说明：当前历史面板是否处于展开状态 */
+  expanded: boolean;
+  /** 中文说明：按钮提示文案（同时用于 title 与 aria-label） */
+  label: string;
+  /** 中文说明：点击切换历史面板显示/隐藏 */
+  onToggle: () => void;
+  /** 中文说明：额外样式（不包含定位，定位建议由调用方控制） */
+  className?: string;
+};
+
+/**
+ * 中文说明：历史面板开关按钮（纯图标）。
+ * - 折叠状态：仅显示“历史”图标，表达入口语义
+ * - 展开状态：仅显示“收起箭头”图标，表达可收起语义
+ */
+export default function HistoryPanelToggleButton(props: HistoryPanelToggleButtonProps) {
+  const { expanded, label, onToggle, className } = props;
+
+  return (
+    <Button
+      size="icon"
+      variant="secondary"
+      className={cn("h-9 w-9 relative", className)}
+      aria-label={label}
+      title={label}
+      aria-pressed={expanded}
+      onClick={onToggle}
+    >
+      {expanded ? <ChevronRight className="h-4 w-4" /> : <HistoryIcon className="h-4 w-4" />}
+    </Button>
+  );
+}


### PR DESCRIPTION
- 顶部栏移除“显示/隐藏历史”文字按钮，改为固定在右上角的图标开关
- 历史面板展开态使用高亮样式，并补充 aria-pressed/aria-label
- 调整历史侧栏 header 内边距，避免开关遮挡搜索框
- 历史面板隐藏时为 TopBar 右侧预留空间，避免遮挡设置/关于按钮