### PR TITLE
perf(at): 主进程优化 @ 搜索与文件索引，降低大仓库卡顿/白屏

### DIFF
--- a/electron/fileIndexSearch.test.ts
+++ b/electron/fileIndexSearch.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import { describe, expect, it } from "vitest";
+import { searchFileIndexCandidates } from "./fileIndexSearch";
+
+describe("electron/fileIndexSearch", () => {
+  it("空查询：按 dirs -> files 返回种子结果", () => {
+    const res = searchFileIndexCandidates({
+      files: ["b.txt", "c.txt"],
+      dirs: ["a", "z"],
+      query: "",
+      limit: 3,
+    });
+    expect(res.map((x) => `${x.isDir ? "D" : "F"}:${x.rel}`)).toEqual(["D:a", "D:z", "F:b.txt"]);
+  });
+
+  it("前缀命中应优先于仅包含命中", () => {
+    const res = searchFileIndexCandidates({
+      files: ["abc/def.txt", "abc/xxdefyy.txt"],
+      dirs: [],
+      query: "def",
+      limit: 2,
+    });
+    expect(res[0]?.rel).toBe("abc/def.txt");
+  });
+
+  it("ASCII 大小写不敏感", () => {
+    const res = searchFileIndexCandidates({
+      files: ["docs/ReadMe.MD"],
+      dirs: [],
+      query: "readme",
+      limit: 5,
+    });
+    expect(res[0]?.rel).toBe("docs/ReadMe.MD");
+  });
+
+  it("支持轻量子序列匹配（避免必须连续包含）", () => {
+    const res = searchFileIndexCandidates({
+      files: ["config.ts", "compile.ts"],
+      dirs: [],
+      query: "cfg",
+      limit: 5,
+    });
+    // config: c...f...g
+    expect(res.some((x) => x.rel === "config.ts")).toBe(true);
+  });
+
+  it("limit 生效且不会返回超过上限的结果", () => {
+    const files = Array.from({ length: 100 }, (_, i) => `src/file-${i}.ts`);
+    const res = searchFileIndexCandidates({ files, dirs: [], query: "file", limit: 7 });
+    expect(res.length).toBe(7);
+  });
+});
+

--- a/electron/fileIndexSearch.ts
+++ b/electron/fileIndexSearch.ts
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+export type RankedRel = {
+  rel: string;
+  isDir: boolean;
+  score: number;
+};
+
+type QueryInfo = {
+  raw: string;
+  needleCodes: number[];
+  hasSlash: boolean;
+  slashSegs: number[][];
+};
+
+/**
+ * 中文说明：对文件/目录相对路径执行轻量模糊匹配并返回 topN。
+ *
+ * 设计目标：
+ * - 避免 “map 全量评分 + sort 全量排序” 带来的 O(N log N) CPU 与海量临时对象分配；
+ * - 在大仓库（数十万候选）下仍能稳定工作，避免触发渲染进程 reload/白屏。
+ *
+ * @param args.files - 文件相对路径列表（使用 "/" 分隔）
+ * @param args.dirs - 目录相对路径列表（使用 "/" 分隔）
+ * @param args.query - 查询串（允许包含 "\\"，内部会归一化为 "/"）
+ * @param args.limit - 返回上限
+ */
+export function searchFileIndexCandidates(args: {
+  files: string[];
+  dirs: string[];
+  query: string;
+  limit: number;
+}): RankedRel[] {
+  const limit = clampLimit(args.limit);
+  if (limit <= 0) return [];
+  const q = normalizeQuery(args.query);
+  if (!q) {
+    // 空查询：不做全量扫描，直接给一个稳定的“前 N 个”种子结果
+    const out: RankedRel[] = [];
+    for (const d of (Array.isArray(args.dirs) ? args.dirs : [])) {
+      if (out.length >= limit) break;
+      if (!d) continue;
+      out.push({ rel: String(d), isDir: true, score: 0 });
+    }
+    if (out.length < limit) {
+      for (const f of (Array.isArray(args.files) ? args.files : [])) {
+        if (out.length >= limit) break;
+        if (!f) continue;
+        out.push({ rel: String(f), isDir: false, score: 0 });
+      }
+    }
+    return out;
+  }
+
+  const info = buildQueryInfo(q);
+  const top: RankedRel[] = [];
+
+  for (const d of (Array.isArray(args.dirs) ? args.dirs : [])) {
+    if (!d) continue;
+    const rel = String(d);
+    const score = scoreRel(rel, true, info);
+    if (score <= 0) continue;
+    insertTopK(top, { rel, isDir: true, score }, limit);
+  }
+  for (const f of (Array.isArray(args.files) ? args.files : [])) {
+    if (!f) continue;
+    const rel = String(f);
+    const score = scoreRel(rel, false, info);
+    if (score <= 0) continue;
+    insertTopK(top, { rel, isDir: false, score }, limit);
+  }
+  return top;
+}
+
+/**
+ * 中文说明：将 query 归一化为文件索引使用的形式（统一分隔符并 trim）。
+ */
+function normalizeQuery(query: string): string {
+  return String(query || "").trim().replace(/\\/g, "/");
+}
+
+/**
+ * 中文说明：限制 limit，避免被外部误传大值导致扫描开销放大。
+ */
+function clampLimit(limit: number): number {
+  const n = Number(limit);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(50, Math.floor(n)));
+}
+
+/**
+ * 中文说明：构造查询的预处理信息（ASCII 大小写不敏感）。
+ */
+function buildQueryInfo(q: string): QueryInfo {
+  const needleCodes = toNeedleCodes(q);
+  const hasSlash = q.includes("/");
+  const slashSegs = hasSlash
+    ? q.split("/").filter(Boolean).map((seg) => toNeedleCodes(seg))
+    : [];
+  return { raw: q, needleCodes, hasSlash, slashSegs };
+}
+
+/**
+ * 中文说明：将字符串转换为 ASCII 小写码点数组（仅对 A-Z 做折叠）。
+ */
+function toNeedleCodes(s: string): number[] {
+  const out: number[] = [];
+  const str = String(s || "");
+  for (let i = 0; i < str.length; i++) {
+    out.push(toLowerAsciiCode(str.charCodeAt(i)));
+  }
+  return out;
+}
+
+/**
+ * 中文说明：ASCII 大小写折叠（仅处理 A-Z）。
+ */
+function toLowerAsciiCode(code: number): number {
+  if (code >= 65 && code <= 90) return code + 32;
+  return code;
+}
+
+/**
+ * 中文说明：判断 hay 是否以 needle 开头（ASCII 大小写不敏感）。
+ */
+function startsWithIgnoreCaseAscii(hay: string, needle: number[]): boolean {
+  if (!needle || needle.length === 0) return true;
+  const s = String(hay || "");
+  if (s.length < needle.length) return false;
+  for (let i = 0; i < needle.length; i++) {
+    const hc = toLowerAsciiCode(s.charCodeAt(i));
+    if (hc !== needle[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * 中文说明：在 hay 中查找 needle 的首次位置（ASCII 大小写不敏感）。
+ */
+function indexOfIgnoreCaseAscii(hay: string, needle: number[], fromIndex = 0): number {
+  if (!needle || needle.length === 0) return 0;
+  const s = String(hay || "");
+  const n = needle.length;
+  const start = Math.max(0, Math.min(s.length, Math.floor(fromIndex)));
+  if (n > s.length - start) return -1;
+  for (let i = start; i <= s.length - n; i++) {
+    let ok = true;
+    for (let j = 0; j < n; j++) {
+      const hc = toLowerAsciiCode(s.charCodeAt(i + j));
+      if (hc !== needle[j]) { ok = false; break; }
+    }
+    if (ok) return i;
+  }
+  return -1;
+}
+
+/**
+ * 中文说明：获取路径的 basename（以 "/" 为分隔符）。
+ */
+function basename(rel: string): string {
+  const s = String(rel || "");
+  const i = s.lastIndexOf("/");
+  return i >= 0 ? s.slice(i + 1) : s;
+}
+
+/**
+ * 中文说明：子序列匹配得分（ASCII 大小写不敏感）。
+ * - 返回 -1 表示不匹配；
+ * - 返回越大表示越紧凑/越靠前。
+ */
+function scoreSubsequence(hay: string, needle: number[]): number {
+  if (!needle || needle.length === 0) return -1;
+  const s = String(hay || "");
+  let j = 0;
+  let first = -1;
+  let last = -1;
+  for (let i = 0; i < s.length && j < needle.length; i++) {
+    const hc = toLowerAsciiCode(s.charCodeAt(i));
+    if (hc === needle[j]) {
+      if (first < 0) first = i;
+      last = i;
+      j++;
+    }
+  }
+  if (j !== needle.length) return -1;
+  const span = Math.max(1, last - first + 1);
+  const tight = Math.max(0, 200 - span);
+  const startBonus = Math.max(0, 60 - first);
+  return 220 + tight + startBonus;
+}
+
+/**
+ * 中文说明：对单个候选路径评分（越大越靠前）。
+ */
+function scoreRel(rel: string, isDir: boolean, q: QueryInfo): number {
+  const base = basename(rel);
+  let s = 0;
+
+  if (startsWithIgnoreCaseAscii(base, q.needleCodes)) s += 1200;
+  if (startsWithIgnoreCaseAscii(rel, q.needleCodes)) s += 900;
+  if (indexOfIgnoreCaseAscii(rel, q.needleCodes) >= 0) s += 500;
+
+  if (q.hasSlash && q.slashSegs.length > 0) {
+    let start = 0;
+    let ok = 0;
+    for (const seg of q.slashSegs) {
+      const idx = indexOfIgnoreCaseAscii(rel, seg, start);
+      if (idx >= 0) {
+        ok += 1;
+        start = idx + seg.length;
+      } else {
+        break;
+      }
+    }
+    if (ok > 0) s += ok * 180;
+    if (isDir) s += 160;
+  } else {
+    if (!isDir) s += 60;
+    // 轻量模糊：仅在未命中 contains 时尝试子序列匹配，避免对所有候选做额外扫描
+    if (s < 500 && q.needleCodes.length >= 3) {
+      const a = scoreSubsequence(base, q.needleCodes);
+      const b = scoreSubsequence(rel, q.needleCodes);
+      const best = Math.max(a, b);
+      if (best > 0) s += best;
+    }
+  }
+
+  // 更短路径略优（对分数做轻微惩罚）
+  s -= rel.length * 0.3;
+  return s;
+}
+
+/**
+ * 中文说明：插入到 topK 列表（按 score 降序，次级按 rel 长度升序）。
+ */
+function insertTopK(list: RankedRel[], item: RankedRel, limit: number): void {
+  if (limit <= 0) return;
+  if (list.length >= limit) {
+    const worst = list[list.length - 1];
+    if (compareRank(item, worst) >= 0) return;
+  }
+  let i = 0;
+  while (i < list.length && compareRank(list[i], item) <= 0) i++;
+  list.splice(i, 0, item);
+  if (list.length > limit) list.pop();
+}
+
+/**
+ * 中文说明：排序比较器（返回 <0 表示 a 更靠前）。
+ */
+function compareRank(a: RankedRel, b: RankedRel): number {
+  if (a.score !== b.score) return b.score - a.score; // score 降序
+  const la = a.rel.length;
+  const lb = b.rel.length;
+  if (la !== lb) return la - lb; // 更短优先
+  return a.rel.localeCompare(b.rel);
+}
+

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1749,6 +1749,22 @@ ipcMain.handle('fileIndex.candidates', async (_e, { root }: { root: string }) =>
   }
 });
 
+// @ 搜索：主进程侧只返回 topN，避免把全量候选传到渲染进程导致卡顿/崩溃
+ipcMain.handle('fileIndex.searchAt', async (_e, args: { root: string; query: string; scope?: 'all' | 'files' | 'rule'; limit?: number; excludes?: string[] }) => {
+  try {
+    const root = String((args as any)?.root || '').trim();
+    if (!root) return { ok: true, items: [], total: 0, updatedAt: Date.now() };
+    const query = String((args as any)?.query || '');
+    const scope = (args as any)?.scope;
+    const limit = (args as any)?.limit;
+    const excludes = Array.isArray((args as any)?.excludes) ? (args as any).excludes : undefined;
+    const res = await (fileIndex as any).searchAt({ root, query, scope, limit, excludes });
+    return { ok: true, ...res };
+  } catch (e: any) {
+    return { ok: false, error: String(e) };
+  }
+});
+
 ipcMain.handle('fileIndex.activeRoots', async (event, { roots }: { roots: string[] }) => {
   try {
     const list = Array.isArray(roots) ? roots.filter((x) => typeof x === 'string') : [];

--- a/web/src/components/at-mention-new/AtCommandPalette.tsx
+++ b/web/src/components/at-mention-new/AtCommandPalette.tsx
@@ -74,14 +74,17 @@ export default function AtCommandPalette(props: AtCommandPaletteProps) {
   }, [level, scope, query]);
 
   const [results, setResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      if (level !== 'results') { setResults([]); return; }
+      if (level !== 'results') { setResults([]); setLoading(false); return; }
+      if (!cancelled) setLoading(true);
       try {
         const list = await searchAtItems(query, scope, 30);
         if (!cancelled) setResults(list);
       } catch { if (!cancelled) setResults([]); }
+      finally { if (!cancelled) setLoading(false); }
     })();
     return () => { cancelled = true; };
   }, [level, scope, query]);
@@ -214,7 +217,7 @@ export default function AtCommandPalette(props: AtCommandPaletteProps) {
           <ScrollArea className="h-[210px]">
             <div className="py-1">
               {results.length === 0 && (
-                <div className="px-3 py-4 text-sm text-[var(--cf-text-muted)]">{t('at:noResults')}</div>
+                <div className="px-3 py-4 text-sm text-[var(--cf-text-muted)]">{loading ? t('at:loading') : t('at:noResults')}</div>
               )}
               {results.map((r, idx) => {
                 const it = r.item;

--- a/web/src/lib/atSearch.ts
+++ b/web/src/lib/atSearch.ts
@@ -2,9 +2,8 @@
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
 import type { AtCategory, AtCategoryId, AtItem, FileItem, RuleItem, SearchResult, SearchScope } from "@/types/at";
-import type { FileCandidate } from "@/lib/fileIndexClient";
-import { ensureIndex as ensureIdx, getAllCandidates } from "@/lib/fileIndexClient";
 import i18n from "@/i18n/setup";
+import { searchAt, type AtSearchWireItem } from "@/lib/fileIndexClient";
 
 // 分类常量（保持不变）
 export const AT_CATEGORIES: AtCategory[] = [
@@ -12,40 +11,43 @@ export const AT_CATEGORIES: AtCategory[] = [
   { id: "rule", name: "Rules", icon: "ScrollText" },
 ];
 
-const SPECIAL_RULE_FILES: Array<{ rel: string; groupKey: "pinned" | "legacy" }> = [
-  { rel: ".cursor/index.mdc", groupKey: "pinned" },
-  { rel: ".cursorrules", groupKey: "legacy" },
-];
+// 渲染层仅维护“当前项目根”，实际候选与搜索在主进程完成（避免全量候选跨进程搬运）
+let currentRoot: string | null = null;
+let currentExcludes: string[] | undefined;
+let lastActiveRoot: string | null = null;
+let restoreActiveRootPromise: Promise<void> | null = null;
 
-// Worker 管理（懒加载）
-let worker: Worker | null = null;
-let workerLoaded = false;
-let currentRoot: string | null = null; // 当前项目根（Windows/UNC）
-let workerRoot: string | null = null;  // Worker 内当前已加载的根
-let lastActiveRoot: string | null = null; // 最近一次激活的项目根（用于后台清理后的恢复）
-let restoreActiveRootPromise: Promise<void> | null = null; // 控制并发恢复，避免竞争
-const cacheByRoot = new Map<string, FileCandidate[]>();
-const loadingByRoot = new Map<string, Promise<FileCandidate[]>>();
-const cacheIndexByRoot = new Map<string, Map<string, FileCandidate>>(); // key: D:/F:+rel
-let subscribed = false; // 渲染进程仅订阅一次主进程的索引变更事件
+// 空闲与后台释放：与旧实现保持一致（长期运行时减少 watcher/缓存常驻）
+const IDLE_DISPOSE_MS = 3 * 60 * 1000;
+const HIDDEN_DISPOSE_MS = 90 * 1000;
+let idleTimer: number | null = null;
+let hiddenCleanupTimer: number | null = null;
+let cleanupHookInstalled = false;
 
-// Worker 生命周期清理：在窗口卸载时主动终止，避免浏览器保留线程对象导致的极小概率残留
-let workerCleanupInstalled = false;
-function disposeWorker(): void {
-  try {
-    // 先移除回调，打断潜在闭包引用链，便于 GC 回收
-    try { if (worker) (worker as any).onmessage = null; } catch {}
-    try { if (worker) (worker as any).onmessageerror = null; } catch {}
-    try { if (worker) (worker as any).onerror = null; } catch {}
-    try { worker?.terminate(); } catch {}
-  } catch {}
-  worker = null;
-  workerLoaded = false;
-  workerRoot = null;
+/**
+ * 中文说明：读取 @ 搜索调试开关（preload 注入只读缓存）。
+ */
+function dbgEnabled(): boolean {
+  try { return !!(globalThis as any).__cf_at_debug__; } catch { return false; }
 }
-function ensureWorkerCleanupHook(): void {
+
+/**
+ * 中文说明：输出 @ 搜索调试日志（仅在开启调试时生效）。
+ */
+function perfLog(msg: string): void {
+  if (!dbgEnabled()) return;
+  const line = `[atSearch] ${msg}`;
+  try { (window as any).host?.utils?.perfLog?.(line); } catch {}
+  try { console.debug(line); } catch {}
+}
+
+/**
+ * 中文说明：安装空闲/后台清理钩子（仅一次）。
+ */
+function ensureCleanupHook(): void {
   if (typeof window === "undefined") return;
-  if (workerCleanupInstalled) return;
+  if (cleanupHookInstalled) return;
+  cleanupHookInstalled = true;
   try {
     window.addEventListener("beforeunload", () => {
       try { cleanupRendererResources("unload"); } catch {}
@@ -56,130 +58,38 @@ function ensureWorkerCleanupHook(): void {
           scheduleHiddenCleanup();
         } else {
           clearHiddenCleanupTimer();
-          touchAtUsage(); // 回到前台时延长空闲计时，避免频繁重建索引
-          // 若后台清理已释放索引，恢复最近的项目根，避免回到前台后 @ 面板为空
+          touchAtUsage();
           restoreActiveRootIfCleared("visible").catch(() => {});
         }
       } catch {}
     });
-    workerCleanupInstalled = true;
   } catch {}
 }
 
-const MAX_CACHE_ROOTS = 3; // 缓存根目录数量上限，收紧多仓缓存占用
-const KEY_PREFIX_DIR = "D";
-const KEY_PREFIX_FILE = "F";
-const IDLE_DISPOSE_MS = 3 * 60 * 1000; // @ 面板空闲超时回收（ms）
-const HIDDEN_DISPOSE_MS = 90 * 1000; // 页面隐藏后延迟释放资源（ms）
-let idleTimer: number | null = null;
-let hiddenCleanupTimer: number | null = null;
-const loadGenByRoot = new Map<string, number>(); // 用于防止被清理后的旧异步加载回写缓存，并维护代际号
-
-function normalizeRootKey(root: string | null | undefined): string {
-  return String(root || "").toLowerCase();
-}
-
-function isSameRoot(a?: string | null, b?: string | null): boolean {
-  return normalizeRootKey(a) === normalizeRootKey(b);
-}
-
-function buildIndexFor(list: FileCandidate[]): Map<string, FileCandidate> {
-  const idx = new Map<string, FileCandidate>();
-  for (const item of list) {
-    idx.set(`${item.isDir ? KEY_PREFIX_DIR : KEY_PREFIX_FILE}:${item.rel}`, item);
-  }
-  return idx;
-}
-
-function enforceCacheLimit(preserveKey?: string): void {
-  if (cacheByRoot.size <= MAX_CACHE_ROOTS) return;
-  const currentKey = currentRoot ? normalizeRootKey(currentRoot) : null;
-  const keep = new Set<string>();
-  if (preserveKey) keep.add(preserveKey);
-  if (currentKey) keep.add(currentKey);
-  let trimmed = false;
-  for (const key of Array.from(cacheByRoot.keys())) {
-    if (cacheByRoot.size <= MAX_CACHE_ROOTS) break;
-    if (keep.has(key)) continue;
-    invalidateRendererRoot(key);
-    trimmed = true;
-    if (workerRoot && normalizeRootKey(workerRoot) === key) {
-      workerRoot = null;
-      workerLoaded = false;
-    }
-  }
-  // 若发生裁剪，顺带清理已失效根的代际计数，避免 Map 长期增长
-  if (trimmed) pruneLoadGenerations(preserveKey ?? currentRoot);
-}
-
-function bumpLoadGeneration(key: string): number {
-  const next = (loadGenByRoot.get(key) ?? 0) + 1;
-  loadGenByRoot.set(key, next);
-  return next;
-}
-
-function invalidateRendererRoot(key: string): void {
-  cacheByRoot.delete(key);
-  cacheIndexByRoot.delete(key);
-  loadingByRoot.delete(key);
-  bumpLoadGeneration(key);
-}
-
-function trimRendererCaches(keepRoot?: string | null): void {
-  const keepKey = keepRoot ? normalizeRootKey(keepRoot) : null;
-  for (const key of Array.from(cacheByRoot.keys())) {
-    if (keepKey && key === keepKey) continue;
-    invalidateRendererRoot(key);
-  }
-  for (const key of Array.from(loadingByRoot.keys())) {
-    if (keepKey && key === keepKey) continue;
-    invalidateRendererRoot(key);
-  }
-  enforceCacheLimit(keepKey ?? undefined);
-  pruneLoadGenerations(keepRoot);
-}
-
-// 清理已被裁剪的根对应的 load 代际，避免 Map 无限增长
-function pruneLoadGenerations(keepRoot?: string | null): void {
-  const keepKey = keepRoot ? normalizeRootKey(keepRoot) : null;
-  const alive = new Set<string>();
-  if (keepKey) alive.add(keepKey);
-  if (currentRoot) alive.add(normalizeRootKey(currentRoot));
-  if (workerRoot) alive.add(normalizeRootKey(workerRoot));
-  for (const k of cacheByRoot.keys()) alive.add(k);
-  for (const k of loadingByRoot.keys()) alive.add(k);
-  for (const k of Array.from(loadGenByRoot.keys())) {
-    if (!alive.has(k)) loadGenByRoot.delete(k);
-  }
-}
-
+/**
+ * 中文说明：主动释放渲染层与主进程侧的资源占用（清空 activeRoots）。
+ */
 function cleanupRendererResources(reason?: string): void {
   const prevRoot = currentRoot;
-  if (prevRoot) lastActiveRoot = prevRoot; // 记录最近活跃根，便于恢复
-  try { disposeWorker(); } catch {}
-  // 清理所有缓存（包含当前根），避免在主进程 watcher 已关闭时继续复用陈旧列表
-  trimRendererCaches(null);
+  if (prevRoot) lastActiveRoot = prevRoot;
+  currentRoot = null;
+  currentExcludes = undefined;
+  restoreActiveRootPromise = null;
   if (typeof window !== "undefined" && idleTimer !== null) {
     try { window.clearTimeout(idleTimer); } catch {}
   }
   idleTimer = null;
-  if (typeof window !== "undefined" && hiddenCleanupTimer !== null) {
-    try { window.clearTimeout(hiddenCleanupTimer); } catch {}
-  }
-  hiddenCleanupTimer = null;
-  currentRoot = null;
-  workerRoot = null;
-  workerLoaded = false;
-  loadGenByRoot.clear();
-  // 主进程同步收敛：释放 fileIndex watcher 与内存缓存，避免长期驻留
+  clearHiddenCleanupTimer();
   try {
     const p = (window as any).host?.fileIndex?.setActiveRoots?.([]);
-    // 捕获 Promise 拒绝，避免窗口关闭阶段出现未处理异常
     if (p && typeof (p as any).catch === "function") (p as Promise<unknown>).catch(() => {});
   } catch {}
-  perfLog(`cleanup reason='${reason || 'idle'}' root='${prevRoot || ''}' caches=${cacheByRoot.size}`);
+  perfLog(`cleanup reason='${reason || "idle"}' root='${prevRoot || ""}'`);
 }
 
+/**
+ * 中文说明：标记一次 @ 使用，刷新空闲回收计时。
+ */
 function touchAtUsage(): void {
   if (typeof window === "undefined") return;
   try { if (idleTimer !== null) window.clearTimeout(idleTimer); } catch {}
@@ -187,6 +97,9 @@ function touchAtUsage(): void {
   clearHiddenCleanupTimer();
 }
 
+/**
+ * 中文说明：清理后台回收计时器。
+ */
 function clearHiddenCleanupTimer(): void {
   if (typeof window === "undefined") return;
   if (hiddenCleanupTimer !== null) {
@@ -195,6 +108,9 @@ function clearHiddenCleanupTimer(): void {
   hiddenCleanupTimer = null;
 }
 
+/**
+ * 中文说明：页面进入后台后延迟释放资源（避免短暂切屏频繁重建）。
+ */
 function scheduleHiddenCleanup(): void {
   if (typeof window === "undefined" || typeof document === "undefined") return;
   clearHiddenCleanupTimer();
@@ -204,7 +120,9 @@ function scheduleHiddenCleanup(): void {
   } catch {}
 }
 
-// 在被后台/空闲清理后，尝试自动恢复最近一次的项目根，减少首次搜索空结果
+/**
+ * 中文说明：在被空闲/后台清理后，尝试恢复最近一次的项目根，避免首次搜索为空。
+ */
 async function restoreActiveRootIfCleared(reason?: string): Promise<void> {
   if (currentRoot || !lastActiveRoot) return;
   if (restoreActiveRootPromise) {
@@ -216,39 +134,41 @@ async function restoreActiveRootIfCleared(reason?: string): Promise<void> {
     try {
       if (!restoringRoot || currentRoot) return;
       await setActiveFileIndexRoot(restoringRoot);
-      perfLog(`restore.root reason='${reason || ''}' root='${restoringRoot || ''}'`);
+      perfLog(`restore.root reason='${reason || ""}' root='${restoringRoot || ""}'`);
     } catch {}
   })();
   restoreActiveRootPromise = p.finally(() => { restoreActiveRootPromise = null; });
   try { await restoreActiveRootPromise; } catch {}
 }
 
-function storeCacheEntry(rootKey: string, list: FileCandidate[], index?: Map<string, FileCandidate>): Map<string, FileCandidate> {
-  const key = normalizeRootKey(rootKey);
-  const idx = index ?? buildIndexFor(list);
-  if (cacheByRoot.has(key)) cacheByRoot.delete(key);
-  cacheByRoot.set(key, list);
-  if (cacheIndexByRoot.has(key)) cacheIndexByRoot.delete(key);
-  cacheIndexByRoot.set(key, idx);
-  enforceCacheLimit(key);
-  return idx;
-}
-
-// 前端调试日志：读取统一调试配置（preload 注入只读缓存）
-function dbgEnabled(): boolean {
-  try { return !!(globalThis as any).__cf_at_debug__; } catch { return false; }
-}
-function perfLog(msg: string) {
-  if (!dbgEnabled()) return;
-  const line = `[atSearch] ${msg}`;
-  try { (window as any).host?.utils?.perfLog?.(line); } catch {}
-  try { console.debug(line); } catch {}
-}
-
+/**
+ * 中文说明：将路径统一为 "/" 分隔的相对路径展示形式。
+ */
 function toPosixRel(value: string): string {
   return String(value || "").replace(/\\/g, "/");
 }
 
+/**
+ * 中文说明：构造文件/目录条目（id 稳定，避免 React 大量重复卸载/挂载）。
+ */
+function toFileItem(rel: string, isDir: boolean): FileItem {
+  const norm = toPosixRel(rel);
+  const i = norm.lastIndexOf("/");
+  const base = i >= 0 ? norm.slice(i + 1) : norm;
+  return {
+    id: `files:${norm}`,
+    categoryId: "files",
+    title: base || norm,
+    subtitle: norm,
+    path: norm,
+    isDir,
+    icon: isDir ? "FolderOpenDot" : "FileText",
+  };
+}
+
+/**
+ * 中文说明：构造规则条目（主要用于展示与插入路径）。
+ */
 function buildRuleItem(rel: string, group?: string): RuleItem {
   const posix = toPosixRel(rel);
   const idx = posix.lastIndexOf("/");
@@ -266,314 +186,63 @@ function buildRuleItem(rel: string, group?: string): RuleItem {
   };
 }
 
-function buildRuleItemsFromCandidates(list: FileCandidate[]): RuleItem[] {
-  const items: RuleItem[] = [];
-  const byRel = new Map<string, FileCandidate>();
-  for (const cand of list) {
-    if (!cand || cand.isDir) continue;
-    const rel = toPosixRel(cand.rel);
-    if (!rel) continue;
-    byRel.set(rel, cand);
-  }
-
-  for (const spec of SPECIAL_RULE_FILES) {
-    const rel = toPosixRel(spec.rel);
-    if (!rel) continue;
-    if (byRel.has(rel)) {
-      const group = i18n.t(`at:groups.${spec.groupKey}`) as string;
-      items.push(buildRuleItem(rel, group));
-    }
-  }
-
-  const dynamic: string[] = [];
-  for (const rel of byRel.keys()) {
-    if (rel.startsWith(".cursor/rules/") && rel.endsWith(".mdc")) dynamic.push(rel);
-  }
-  dynamic.sort((a, b) => a.localeCompare(b));
-  for (const rel of dynamic) {
-    items.push(buildRuleItem(rel, i18n.t("at:groups.dynamic") as string));
-  }
-  return items;
-}
-
-function ensureWorker(): Worker {
-  if (!worker) {
-    // Vite 友好写法（module worker）
-    worker = new Worker(new URL("./atWorker.ts", import.meta.url), { type: "module" });
-    workerLoaded = false;
-    worker.onmessage = (ev: MessageEvent) => {
-      const data: any = ev.data || {};
-      if (data && data.type === 'loaded') {
-        workerLoaded = true;
-        perfLog(`worker.loaded total=${data.total} root='${workerRoot || ''}'`);
-      }
-    };
-  }
-  // 确保仅安装一次卸载清理钩子
-  ensureWorkerCleanupHook();
-  return worker;
-}
-
-function toFileItem(rel: string, isDir: boolean, idx: number): FileItem {
-  const norm = String(rel || "").replace(/\\/g, "/");
-  const i = norm.lastIndexOf("/");
-  const base = i >= 0 ? norm.slice(i + 1) : norm;
-  return {
-    id: `f-${idx}-${norm}`,
-    categoryId: "files",
-    title: base || norm,
-    subtitle: norm, // 用相对路径展示
-    path: norm,     // 用于携带相对路径（拼接时使用）
-    isDir,
-    icon: isDir ? "FolderOpenDot" : "FileText",
-  };
-}
-
-async function loadCandidatesForRoot(root: string, excludes?: string[]): Promise<FileCandidate[]> {
-  const key = normalizeRootKey(root);
-  if (cacheByRoot.has(key)) return cacheByRoot.get(key)!;
-  if (loadingByRoot.has(key)) return loadingByRoot.get(key)!;
-  const loadGen = bumpLoadGeneration(key); // 每次加载生成新的代际，便于在清理后阻止旧结果回写
-  const p = (async () => {
-    try {
-      const t0 = Date.now();
-      perfLog(`ensureIndex.start root='${root}'`);
-      await ensureIdx(root, excludes);
-      perfLog(`ensureIndex.done root='${root}' dur=${Date.now() - t0}ms`);
-      const t1 = Date.now();
-      const list = await getAllCandidates(root);
-      perfLog(`candidates.loaded root='${root}' count=${list.length} dur=${Date.now() - t1}ms`);
-      const idx = buildIndexFor(list);
-      // 若在加载期间根被清理（如切换项目或 LRU 收缩），则跳过回写
-      if ((loadGenByRoot.get(key) ?? 0) !== loadGen) {
-        perfLog(`candidates.skip root='${root}' reason='invalidated'`);
-        return list;
-      }
-      storeCacheEntry(root, list, idx);
-      return list;
-    } finally {
-      loadingByRoot.delete(key);
-    }
-  })();
-  loadingByRoot.set(key, p);
-  return p;
-}
-
-function postToWorkerForRoot(root: string, list: FileCandidate[]) {
-  ensureWorker();
-  try { worker?.postMessage({ type: 'load', candidates: list }); workerRoot = root; perfLog(`worker.load root='${root}' count=${list.length}`); } catch {}
-}
-
+/**
+ * 中文说明：设置当前项目根，并通知主进程收敛 watcher（只保留该 root）。
+ * @param winRoot - Windows/UNC 项目根
+ * @param excludes - 额外排除（可选）
+ */
 export async function setActiveFileIndexRoot(winRoot: string, excludes?: string[]): Promise<void> {
+  ensureCleanupHook();
   touchAtUsage();
-  const prevRoot = currentRoot;
-  lastActiveRoot = winRoot;
-  currentRoot = winRoot;
-  const switched = !isSameRoot(prevRoot, winRoot);
-  if (switched) {
-    // 切换项目时主动收敛缓存与 Worker，避免旧大仓库数据常驻
-    trimRendererCaches(winRoot);
-    if (!isSameRoot(workerRoot, winRoot)) disposeWorker();
-  }
-  // 切换项目时：通知主进程仅保留当前根的 watcher，避免多项目同时监听带来的负载
-  try { await (window as any).host?.fileIndex?.setActiveRoots?.([winRoot]); } catch {}
-  // 首次调用时订阅主进程的索引变更事件
-  if (!subscribed) {
-    try {
-      const onChanged = (window as any).host?.fileIndex?.onChanged;
-      if (typeof onChanged === 'function') {
-        onChanged(async ({ root, adds, removes }: { root: string; adds?: { rel: string; isDir: boolean }[]; removes?: { rel: string; isDir: boolean }[] }) => {
-          try {
-            if (!root || !currentRoot) return;
-            if (String(root).toLowerCase() !== String(currentRoot).toLowerCase()) return;
-            const rootKey = currentRoot ?? root;
-            const key = normalizeRootKey(rootKey);
-            const hasPatch = (Array.isArray(adds) && adds.length > 0) || (Array.isArray(removes) && removes.length > 0);
-            if (hasPatch) {
-              let list = cacheByRoot.get(key) || [];
-              let idx = cacheIndexByRoot.get(key) || new Map<string, FileCandidate>();
-              if (idx.size === 0 && list.length > 0) idx = buildIndexFor(list);
-              const addsList = Array.isArray(adds) ? adds : [];
-              const removesList = Array.isArray(removes) ? removes : [];
-              let changed = false;
-              // 应用新增
-              for (const a of addsList) {
-                const k = `${a.isDir ? KEY_PREFIX_DIR : KEY_PREFIX_FILE}:${a.rel}`;
-                if (!idx.has(k)) { const it = { rel: a.rel, isDir: !!a.isDir } as FileCandidate; idx.set(k, it); list.push(it); changed = true; }
-              }
-              // 应用删除（批量过滤更快）
-              if (removesList.length > 0 && list.length > 0) {
-                const rm = new Set(removesList.map(r => `${r.isDir ? KEY_PREFIX_DIR : KEY_PREFIX_FILE}:${r.rel}`));
-                if (rm.size > 0) {
-                  const kept: FileCandidate[] = [];
-                  let removedAny = false;
-                  for (const it of list) {
-                    const mk = `${it.isDir ? KEY_PREFIX_DIR : KEY_PREFIX_FILE}:${it.rel}`;
-                    if (rm.has(mk)) { removedAny = true; continue; }
-                    kept.push(it);
-                  }
-                  if (removedAny) {
-                    list = kept;
-                    idx = buildIndexFor(kept);
-                    changed = true;
-                  }
-                }
-              }
-              idx = storeCacheEntry(rootKey, list, idx);
-              if (changed) {
-                ensureWorker();
-                try { worker?.postMessage({ type: 'patch', adds: addsList, removes: removesList }); } catch {}
-                try { await (window as any).host?.utils?.perfLog?.(`[atSearch] patched root='${currentRoot}' adds=${addsList.length} removes=${removesList.length} total=${(cacheByRoot.get(key) || []).length}`); } catch {}
-              }
-            } else {
-              // 兼容兜底：全量刷新（避免极端情况下 patch 丢失）
-              try { await (window as any).host?.utils?.perfLog?.(`[atSearch] onChanged(root-only) root='${root}' current='${currentRoot}'`); } catch {}
-              const list = await getAllCandidates(currentRoot).catch(() => [] as FileCandidate[]);
-              const idx = buildIndexFor(list);
-              storeCacheEntry(rootKey, list, idx);
-              postToWorkerForRoot(currentRoot, list);
-            }
-            const total = (cacheByRoot.get(key) || []).length;
-            perfLog(`renderer.refresh root='${currentRoot}' count=${total}`);
-          } catch {}
-        });
-        try { await (window as any).host?.utils?.perfLog?.(`[atSearch] subscribed.onChanged`); } catch {}
-        subscribed = true;
-      }
-    } catch {}
-  }
-  // 大仓库卡顿优化：不在“选中项目”时预加载所有候选，等首次 @ 查询再懒加载
-  try {
-    const key = String(winRoot || '').toLowerCase();
-    const cached = cacheByRoot.get(key);
-    if (cached && cached.length > 0) {
-      postToWorkerForRoot(winRoot, cached);
-    }
-  } catch {}
+  const root = String(winRoot || "").trim();
+  if (!root) return;
+  currentRoot = root;
+  lastActiveRoot = root;
+  currentExcludes = Array.isArray(excludes) ? excludes.filter((x) => typeof x === "string" && x.trim().length > 0) : undefined;
+  try { await (window as any).host?.fileIndex?.setActiveRoots?.([root]); } catch {}
 }
 
-function normalize(s: string): string { return String(s || "").replace(/\\/g, "/").toLowerCase(); }
-
-function scoreRule(item: RuleItem, query: string): number {
-  const t = normalize(item.title);
-  const g = normalize(item.subtitle || "");
-  const q = normalize(query);
-  let s = 0;
-  if (!q) return 0;
-  if (t.startsWith(q)) s += 800;
-  if (t.includes(q)) s += 300;
-  if (g.startsWith(q)) s += 200;
-  if (g.includes(q)) s += 100;
-  return s;
-}
-
-// 使用 Worker 执行文件匹配；若 Worker 未就绪，回退到主线程简易匹配（保证同步体验）
+/**
+ * 中文说明：执行 @ 搜索并返回 UI 需要的结果结构。
+ *
+ * 根因修复点：
+ * - 不再把“全量候选文件列表”拉到渲染进程（也不再塞进 WebWorker）；
+ * - 仅向主进程请求 topN 结果，避免首次/大仓库下出现内存峰值导致页面刷新。
+ */
 export async function searchAtItems(query: string, scope: SearchScope, limit = 30): Promise<SearchResult[]> {
-  const q = String(query || "").trim();
-  const results: SearchResult[] = [];
   touchAtUsage();
   await restoreActiveRootIfCleared("search");
+  if (!currentRoot) return [];
 
-  // 规则类：从候选文件中过滤 .cursor 相关规则文件
-  const pickRules = async () => {
-    if (scope !== 'all' && scope !== 'rule') return;
-    if (!currentRoot) return;
-    const rootKey = String(currentRoot || '').toLowerCase();
-    let candidates = cacheByRoot.get(rootKey);
-    if (!candidates) {
-      candidates = await loadCandidatesForRoot(currentRoot).catch(() => [] as FileCandidate[]);
+  const res = await searchAt({
+    root: currentRoot,
+    query: String(query || ""),
+    scope,
+    limit,
+    excludes: currentExcludes,
+  }).catch(() => ({ items: [], total: 0, updatedAt: Date.now() }));
+
+  const items = Array.isArray(res.items) ? (res.items as AtSearchWireItem[]) : [];
+  const out: SearchResult[] = [];
+  for (const it of items) {
+    if (!it || !it.rel) continue;
+    if (it.categoryId === "files") {
+      const item: AtItem = toFileItem(it.rel, !!it.isDir);
+      out.push({ item, score: Number(it.score || 0) });
+      continue;
     }
-    const rules = buildRuleItemsFromCandidates(candidates || []);
-    if (rules.length === 0) return;
-    if (!q) {
-      for (const it of rules.slice(0, Math.min(10, Math.max(0, limit - results.length)))) results.push({ item: it, score: 0 });
-      return;
-    }
-    const scored = rules.map((it) => ({ item: it as AtItem, score: scoreRule(it, q) }));
-    scored.sort((a, b) => b.score - a.score);
-    for (const it of scored.slice(0, Math.max(0, limit - results.length))) results.push(it);
-  };
-
-  // 文件类：优先使用 Worker；若未就绪则用本地候选简易匹配
-  const pickFiles = async () => {
-    if (scope !== 'all' && scope !== 'files') return;
-    if (!currentRoot) return;
-    // 确保 Worker 已加载当前根的候选（若未就绪则先加载并推送）
-    if (workerRoot !== currentRoot) {
-      const list = await loadCandidatesForRoot(currentRoot).catch(() => [] as FileCandidate[]);
-      if (workerRoot !== currentRoot) postToWorkerForRoot(currentRoot, list);
-    }
-    const want = Math.min(30, limit);
-    const w = ensureWorker();
-    const t0 = Date.now();
-    // 根据候选规模动态等待更长时间，避免大仓库过早超时导致 0 结果
-    const rootKey = String(currentRoot || '').toLowerCase();
-    const localAll = cacheByRoot.get(rootKey) || [];
-    const waitMs = localAll.length > 100000 ? 350 : localAll.length > 30000 ? 200 : 60;
-    // 统一 Promise，确保无论超时还是收到结果，都移除监听，避免泄漏
-    let ranked = await new Promise<any[]>((resolve) => {
-      let timeoutId: number | undefined;
-      const handler = (ev: MessageEvent) => {
-        const data: any = ev.data || {};
-        if (data && data.type === 'result' && String(data.q) === q) {
-          try { if (typeof timeoutId === 'number') window.clearTimeout(timeoutId); } catch {}
-          try { w.removeEventListener('message', handler as any); } catch {}
-          resolve(Array.isArray(data.items) ? data.items : []);
-        }
-      };
-      try { w.addEventListener('message', handler as any, { once: false }); } catch {}
-      try {
-        w.postMessage({ type: 'query', q, limit: want });
-      } catch {
-        try { w.removeEventListener('message', handler as any); } catch {}
-        resolve([]);
-        return;
-      }
-      timeoutId = window.setTimeout(() => {
-        try { w.removeEventListener('message', handler as any); } catch {}
-        resolve([]);
-      }, waitMs);
-    });
-
-    if ((!ranked || ranked.length === 0)) {
-      // Worker 尚未加载完成或空查询：回退到本地候选（不阻塞 UI）
-      const local = localAll;
-      if (!q) {
-        ranked = local.slice(0, want).map(it => ({ rel: it.rel, isDir: it.isDir, score: 0 }));
-      } else {
-        const nn = normalize(q);
-        const scored = local.map((it, i) => {
-          const relNorm = normalize(it.rel);
-          let s = 0;
-          if (relNorm.startsWith(nn)) s += 900;
-          if (relNorm.includes(nn)) s += 300;
-          if (nn.includes('/')) { if (it.isDir) s += 120; }
-          s -= it.rel.length * 0.3;
-          return { rel: it.rel, isDir: it.isDir, score: s, _i: i } as any;
-        }).sort((a, b) => b.score - a.score).slice(0, want).map(x => ({ rel: x.rel, isDir: x.isDir, score: x.score }));
-        ranked = scored;
-      }
-      perfLog(`search.fallback root='${currentRoot}' q='${q}' localCount=${local.length} res=${ranked.length} waitMs=${waitMs}`);
-    }
-
-    // 转为 AtItem
-    const items: FileItem[] = ranked.map((r, i) => toFileItem(r.rel, r.isDir, i));
-    perfLog(`search.worker root='${currentRoot}' q='${q}' res=${ranked.length} dur=${Date.now() - t0}ms`);
-    for (const it of items) results.push({ item: it as AtItem, score: 0 });
-  };
-
-  if (!q) {
-    await pickFiles();
-    await pickRules();
-    return results.slice(0, limit);
+    const groupKey = String((it as any).groupKey || "");
+    const group = groupKey ? (i18n.t(`at:groups.${groupKey}`) as string) : undefined;
+    const item: AtItem = buildRuleItem(it.rel, group);
+    out.push({ item, score: Number(it.score || 0) });
   }
-
-  await pickFiles();
-  await pickRules();
-  perfLog(`search.done root='${currentRoot}' q='${q}' scope='${scope}' total=${results.length}`);
-  return results.slice(0, limit);
+  return out.slice(0, Math.max(0, Math.min(50, limit)));
 }
 
+/**
+ * 中文说明：按 id 获取分类元数据。
+ */
 export function getCategoryById(id: AtCategoryId): AtCategory | undefined {
   return AT_CATEGORIES.find((c) => c.id === id);
 }
+

--- a/web/src/lib/fileIndexClient.ts
+++ b/web/src/lib/fileIndexClient.ts
@@ -4,6 +4,13 @@
 // 渲染进程侧的文件索引 API 封装（通过 preload 暴露的最小桥接）
 
 export type FileCandidate = { rel: string; isDir: boolean };
+export type AtSearchWireItem = {
+  categoryId: "files" | "rule";
+  rel: string;
+  isDir: boolean;
+  score: number;
+  groupKey?: "pinned" | "legacy" | "dynamic";
+};
 
 export async function ensureIndex(root: string, excludes?: string[]): Promise<{ total: number; updatedAt: number }> {
   const res: any = await (window as any).host?.fileIndex?.ensureIndex?.({ root, excludes });
@@ -15,5 +22,31 @@ export async function getAllCandidates(root: string): Promise<FileCandidate[]> {
   const res: any = await (window as any).host?.fileIndex?.getAllCandidates?.(root);
   if (res && res.ok && Array.isArray(res.items)) return res.items as FileCandidate[];
   return [];
+}
+
+/**
+ * 中文说明：主进程侧 @ 搜索（仅返回 topN）。
+ * @param args.root - 项目根（Windows/UNC）
+ * @param args.query - 查询串（不含 '@'）
+ * @param args.scope - all/files/rule
+ * @param args.limit - 返回上限
+ * @param args.excludes - 额外排除
+ */
+export async function searchAt(args: {
+  root: string;
+  query: string;
+  scope?: "all" | "files" | "rule";
+  limit?: number;
+  excludes?: string[];
+}): Promise<{ items: AtSearchWireItem[]; total: number; updatedAt: number }> {
+  const res: any = await (window as any).host?.fileIndex?.searchAt?.(args);
+  if (res && res.ok && Array.isArray(res.items)) {
+    return {
+      items: res.items as AtSearchWireItem[],
+      total: Number(res.total || 0),
+      updatedAt: Number(res.updatedAt || Date.now()),
+    };
+  }
+  return { items: [], total: 0, updatedAt: Date.now() };
 }
 

--- a/web/src/locales/en/at.json
+++ b/web/src/locales/en/at.json
@@ -1,6 +1,7 @@
 {
   "categoriesTitle": "Categories",
   "scopeAll": "All",
+  "loading": "Loading index...",
   "noResults": "No matches",
   "category": {
     "files": "Files & Folders",

--- a/web/src/locales/zh/at.json
+++ b/web/src/locales/zh/at.json
@@ -1,6 +1,7 @@
 {
   "categoriesTitle": "分类",
   "scopeAll": "全部",
+  "loading": "索引加载中...",
   "noResults": "无匹配项",
   "category": {
     "files": "文件与文件夹",

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -613,6 +613,29 @@ export interface WslAPI {
 export interface FileIndexAPI {
   ensureIndex(args: { root: string; excludes?: string[] }): Promise<{ ok: boolean; total?: number; updatedAt?: number; error?: string }>;
   getAllCandidates(root: string): Promise<{ ok: boolean; items?: Array<{ rel: string; isDir: boolean }>; error?: string }>;
+  /**
+   * 中文说明：主进程侧 @ 搜索（仅返回 topN）。
+   * 目的：避免把全量候选列表跨进程传到渲染层/Worker，导致大仓库下的内存峰值与页面刷新。
+   */
+  searchAt(args: {
+    root: string;
+    query: string;
+    scope?: "all" | "files" | "rule";
+    limit?: number;
+    excludes?: string[];
+  }): Promise<{
+    ok: boolean;
+    items?: Array<{
+      categoryId: "files" | "rule";
+      rel: string;
+      isDir: boolean;
+      score: number;
+      groupKey?: "pinned" | "legacy" | "dynamic";
+    }>;
+    total?: number;
+    updatedAt?: number;
+    error?: string;
+  }>;
   setActiveRoots(roots: string[]): Promise<{ ok: boolean; closed?: number; remain?: number; trimmed?: number; error?: string }>;
   onChanged?: (handler: (payload: { root: string; reason?: string; adds?: { rel: string; isDir: boolean }[]; removes?: { rel: string; isDir: boolean }[] }) => void) => () => void;
 }


### PR DESCRIPTION
- 新增主进程 fileIndex：基于 ripgrep 扫描构建 files/dirs 缓存，并支持磁盘缓存与 chokidar 增量监听
- @ 搜索改为主进程仅返回 topN（files/rule），渲染侧不再搬运全量候选，避免内存峰值导致 reload/白屏
- 新增 fileIndexSearch 轻量模糊匹配与单测；补充规则文件候选分组（pinned/legacy/dynamic）与 i18n 文案
- PTY/终端链路做性能修复：preload 单监听分发 + 主进程合并输出 IPC + xterm 分帧写入；新增 backlog/bootId 以支持 reload/HMR 恢复
- 修复：fileIndex.searchAt(limit=0) 被错误回退为默认值的问题