### PR TITLE
fix: 代理完成通知改为 JSONL 桥接并补齐 osc9 配置

### DIFF
--- a/electron/claude/notifications.ts
+++ b/electron/claude/notifications.ts
@@ -3,25 +3,41 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { BrowserWindow } from "electron";
 import { perfLogger } from "../log";
 import { uncToWsl, type SessionsRootCandidate } from "../wsl";
 import { getClaudeRootCandidatesFastAsync } from "../agentSessions/claude/discovery";
 
 const CLAUDE_HOOK_FILENAME = "codexflow_stop_notify.js";
 const CLAUDE_HOOK_TIMEOUT_MS = 5000;
+const CLAUDE_NOTIFY_FILENAME = "codexflow_after_agent_notify.jsonl";
+const CLAUDE_NOTIFY_POLL_INTERVAL_MS = 1200;
+const CLAUDE_NOTIFY_READ_LIMIT_BYTES = 128 * 1024;
 
 const CLAUDE_HOOK_SCRIPT = String.raw`#!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
 /**
- * CodexFlow: Claude Code Stop hook -> OSC 9; agent-turn-complete
+ * CodexFlow: Claude Code Stop hook -> 完成事件桥接
  *
  * 说明：
- * - Claude Code hook 的 stdout/stderr 会参与 CLI 的 hook 输出流程。
- * - 为避免污染 transcript，OSC 序列直接写入控制台（/dev/tty 或 CONOUT$）。
+ * - Claude Code 会捕获 hook 的 stdout 用于解析 JSON（continue/suppressOutput 等）。
+ * - 在部分环境下 hook 进程可能没有可用的 controlling TTY（/dev/tty/CONOUT$），直接写 OSC 可能丢失。
+ * - 主通道：写入 JSONL 通知文件，供 CodexFlow 主进程轮询读取并转发给渲染进程。
+ * - 兜底：当未注入 CodexFlow 环境变量时，尝试写入 OSC 9; 通知到真实终端。
  */
 const fs = require("node:fs");
+const path = require("node:path");
+
+// 中文说明：诊断日志路径（用于排查 hook 是否执行与写入路径）。
+const LOG_PATH = path.join(__dirname, "codexflow_stop_notify.log");
+const LOG_MAX_BYTES = 256 * 1024;
+const NOTIFY_PATH = path.join(__dirname, "${CLAUDE_NOTIFY_FILENAME}");
+const NOTIFY_MAX_BYTES = 512 * 1024;
+const ENV_TAB_ID = "CLAUDE_CODEXFLOW_TAB_ID";
+const ENV_ENV_LABEL = "CLAUDE_CODEXFLOW_ENV_LABEL";
+const ENV_PROVIDER_ID = "CLAUDE_CODEXFLOW_PROVIDER_ID";
 
 /**
  * 中文说明：将多行压缩成单行，便于通知展示。
@@ -45,6 +61,69 @@ function clip(input, limit) {
     count++;
   }
   return out;
+}
+
+/**
+ * 中文说明：追加诊断日志（带简单截断，避免无限增长）。
+ */
+function appendLog(message) {
+  try {
+    const line = "[" + new Date().toISOString() + "] " + String(message || "") + "\n";
+    try {
+      const st = fs.statSync(LOG_PATH);
+      if (st && typeof st.size === "number" && st.size > LOG_MAX_BYTES) {
+        fs.writeFileSync(LOG_PATH, "", "utf8");
+      }
+    } catch {}
+    fs.appendFileSync(LOG_PATH, line, "utf8");
+  } catch {}
+}
+
+/**
+ * 中文说明：记录关键流程日志，便于排查 hook 是否执行。
+ */
+function logInfo(message) {
+  appendLog(message);
+}
+
+/**
+ * 中文说明：追加 CodexFlow 通知 JSONL（供主进程轮询）。
+ */
+function appendNotifyLine(payload) {
+  try {
+    const line = JSON.stringify(payload || {}) + "\n";
+    try {
+      const st = fs.statSync(NOTIFY_PATH);
+      if (st && typeof st.size === "number" && st.size > NOTIFY_MAX_BYTES) {
+        fs.writeFileSync(NOTIFY_PATH, "", "utf8");
+      }
+    } catch {}
+    fs.appendFileSync(NOTIFY_PATH, line, "utf8");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 中文说明：构造 JSONL 事件负载（包含 tabId/环境标签等元数据）。
+ */
+function buildNotifyPayload(input) {
+  const tabId = String(process.env[ENV_TAB_ID] || "").trim();
+  const envLabel = String(process.env[ENV_ENV_LABEL] || "").trim();
+  const providerId = String(process.env[ENV_PROVIDER_ID] || "claude").trim() || "claude";
+  return {
+    v: 1,
+    eventId: String(process.pid) + "-" + String(Date.now()),
+    providerId,
+    tabId: tabId || "",
+    envLabel: envLabel || "",
+    preview: String(input?.preview || ""),
+    timestamp: new Date().toISOString(),
+    sessionId: typeof input?.sessionId === "string" ? input.sessionId : "",
+    cwd: typeof input?.cwd === "string" ? input.cwd : "",
+    transcriptPath: typeof input?.transcriptPath === "string" ? input.transcriptPath : "",
+  };
 }
 
 /**
@@ -183,6 +262,7 @@ function writeOscToControllingTty(oscText) {
 
 const raw = safeReadStdin();
 const data = safeParseJson(raw) || {};
+logInfo("start pid=" + process.pid + " inputBytes=" + raw.length);
 const directResponse =
   (typeof data.assistant_response === "string" ? data.assistant_response : "") ||
   (typeof data.response === "string" ? data.response : "") ||
@@ -197,7 +277,20 @@ const BEL = "\u0007";
 const payload = preview ? preview : "agent-turn-complete";
 const osc = ESC + "]9;" + payload + BEL;
 
-writeOscToControllingTty(osc);
+const notifyPayload = buildNotifyPayload({
+  preview,
+  sessionId: typeof data.session_id === "string" ? data.session_id : "",
+  cwd: typeof data.cwd === "string" ? data.cwd : "",
+  transcriptPath,
+});
+const notifyOk = appendNotifyLine(notifyPayload);
+const hasCodexFlowEnv = !!(String(process.env[ENV_TAB_ID] || "").trim() || String(process.env[ENV_ENV_LABEL] || "").trim() || String(process.env[ENV_PROVIDER_ID] || "").trim());
+
+// 中文说明：当注入了 CodexFlow 环境变量时，优先走 JSONL 桥接，避免 /dev/tty 不可用导致通知丢失。
+if (!(notifyOk && hasCodexFlowEnv)) {
+  writeOscToControllingTty(osc);
+}
+logInfo("notify=" + (notifyOk ? "1" : "0") + " hasEnv=" + (hasCodexFlowEnv ? "1" : "0") + " previewLen=" + String(preview || "").length);
 
 try { process.stdout.write(JSON.stringify({ continue: true, suppressOutput: true })); } catch {}
 process.exit(0);
@@ -273,7 +366,8 @@ function writeJsonFile(filePath: string, data: any): boolean {
  * 中文说明：判断 hook 是否已指向 CodexFlow 的 Claude 通知脚本。
  */
 function isClaudeHookCommand(command: unknown): boolean {
-  return typeof command === "string" && command.toLowerCase().includes(CLAUDE_HOOK_FILENAME);
+  // 中文说明：兼容历史遗留的 .sh/.ps1 版本：统一识别并替换为当前 .js hook，避免旧 hook 失败或重复触发。
+  return typeof command === "string" && command.toLowerCase().includes("codexflow_stop_notify");
 }
 
 /**
@@ -333,6 +427,14 @@ function ensureClaudeStopHooks(groups: HookGroup[], command: string): { groups: 
     } else if (nextHooks !== rawHooks) {
       group.hooks = nextHooks;
     }
+
+    // 中文说明：若该 matcher 组内的 hooks 被清理为空（通常是历史遗留的 codexflow_stop_notify.* 重复项），
+    // 则不保留空组，避免 Claude Code 侧反复扫描无效 matcher。
+    if (rawHooks.length > 0 && nextHooks.length === 0) {
+      changed = true;
+      continue;
+    }
+
     nextGroups.push(group);
   }
 
@@ -408,4 +510,198 @@ export async function ensureAllClaudeNotifications(): Promise<void> {
     }
   })().finally(() => { inflight = null; });
   return inflight;
+}
+
+type ClaudeNotifyEntry = {
+  v?: number;
+  eventId?: string;
+  providerId?: string;
+  tabId?: string;
+  envLabel?: string;
+  preview?: string;
+  timestamp?: string;
+  sessionId?: string;
+  cwd?: string;
+  transcriptPath?: string;
+};
+
+type ClaudeNotifySource = {
+  filePath: string;
+  offset: number;
+  remainder: string;
+};
+
+const claudeNotifySources = new Map<string, ClaudeNotifySource>();
+let claudeNotifyTimer: NodeJS.Timeout | null = null;
+let claudeNotifyPolling = false;
+let claudeNotifyWindowGetter: (() => BrowserWindow | null) | null = null;
+
+/**
+ * 中文说明：列出需要监听的 Claude 通知文件路径（Windows/UNC）。
+ */
+async function listClaudeNotifyFiles(): Promise<string[]> {
+  try {
+    const roots = await getClaudeRootCandidatesFastAsync();
+    return roots.map((root) => path.join(root.path, "hooks", CLAUDE_NOTIFY_FILENAME));
+  } catch (error) {
+    logClaudeNotification(`list notify files failed: ${String(error)}`);
+    return [];
+  }
+}
+
+/**
+ * 中文说明：同步通知源列表，保留已有读取偏移。
+ */
+function syncClaudeNotifySources(paths: string[]): void {
+  const normalized = new Set<string>();
+  for (const p of paths) {
+    const key = String(p || "").replace(/\\/g, "/").toLowerCase();
+    if (key) normalized.add(key);
+  }
+  for (const [key, source] of Array.from(claudeNotifySources.entries())) {
+    if (!normalized.has(key)) {
+      claudeNotifySources.delete(key);
+      try { logClaudeNotification(`notify source removed path=${source.filePath}`); } catch {}
+    }
+  }
+  for (const p of paths) {
+    const key = String(p || "").replace(/\\/g, "/").toLowerCase();
+    if (!key || claudeNotifySources.has(key)) continue;
+    let offset = 0;
+    try {
+      const st = fs.statSync(p);
+      if (st && st.isFile && st.isFile()) offset = typeof st.size === "number" ? st.size : 0;
+    } catch {}
+    claudeNotifySources.set(key, { filePath: p, offset, remainder: "" });
+    try { logClaudeNotification(`notify source added path=${p} offset=${offset}`); } catch {}
+  }
+}
+
+/**
+ * 中文说明：解析单行 JSONL，失败则返回 null。
+ */
+function parseClaudeNotifyLine(line: string): ClaudeNotifyEntry | null {
+  const raw = String(line || "").trim();
+  if (!raw) return null;
+  try {
+    const obj = JSON.parse(raw);
+    if (!obj || typeof obj !== "object") return null;
+    return obj as ClaudeNotifyEntry;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 中文说明：从通知文件中读取新增内容并解析为事件列表。
+ */
+function readClaudeNotifyEntries(source: ClaudeNotifySource): ClaudeNotifyEntry[] {
+  try {
+    const st = fs.statSync(source.filePath);
+    if (!st || !st.isFile || !st.isFile()) return [];
+    const size = typeof st.size === "number" ? st.size : 0;
+    if (size < source.offset) {
+      source.offset = 0;
+      source.remainder = "";
+    }
+    if (size === source.offset) return [];
+
+    let start = source.offset;
+    let length = size - start;
+    if (length > CLAUDE_NOTIFY_READ_LIMIT_BYTES) {
+      start = Math.max(0, size - CLAUDE_NOTIFY_READ_LIMIT_BYTES);
+      length = size - start;
+      source.remainder = "";
+      logClaudeNotification(`notify tail read: path=${source.filePath} len=${length}`);
+    }
+
+    const fd = fs.openSync(source.filePath, "r");
+    const buf = Buffer.alloc(length);
+    try { fs.readSync(fd, buf, 0, length, start); } finally { try { fs.closeSync(fd); } catch {} }
+    source.offset = start + length;
+
+    const text = source.remainder + buf.toString("utf8");
+    const lines = text.split(/\r?\n/);
+    source.remainder = lines.pop() || "";
+    const out: ClaudeNotifyEntry[] = [];
+    for (const line of lines) {
+      const entry = parseClaudeNotifyLine(line);
+      if (entry) out.push(entry);
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * 中文说明：将 Claude 通知事件转发给渲染进程。
+ */
+function emitClaudeNotify(entry: ClaudeNotifyEntry): void {
+  const win = claudeNotifyWindowGetter ? claudeNotifyWindowGetter() : null;
+  if (!win) return;
+  const providerId = String(entry.providerId || "claude").toLowerCase();
+  if (providerId && providerId !== "claude") return;
+  const payload = {
+    providerId: "claude" as const,
+    tabId: entry.tabId ? String(entry.tabId) : "",
+    envLabel: entry.envLabel ? String(entry.envLabel) : "",
+    preview: entry.preview ? String(entry.preview) : "",
+    timestamp: entry.timestamp ? String(entry.timestamp) : "",
+    eventId: entry.eventId ? String(entry.eventId) : "",
+  };
+  try {
+    win.webContents.send("notifications:externalAgentComplete", payload);
+    logClaudeNotification(`notify event tab=${payload.tabId || "n/a"} previewLen=${payload.preview.length}`);
+  } catch (error) {
+    logClaudeNotification(`emit notify failed: ${String(error)}`);
+  }
+}
+
+/**
+ * 中文说明：轮询读取 Claude 通知文件，避免依赖不稳定的 /dev/tty/CONOUT$。
+ */
+async function pollClaudeNotifyFiles(): Promise<void> {
+  if (claudeNotifyPolling) return;
+  claudeNotifyPolling = true;
+  try {
+    for (const source of Array.from(claudeNotifySources.values())) {
+      const entries = readClaudeNotifyEntries(source);
+      if (!entries.length) continue;
+      for (const entry of entries) emitClaudeNotify(entry);
+    }
+  } finally {
+    claudeNotifyPolling = false;
+  }
+}
+
+/**
+ * 中文说明：启动 Claude 通知桥接（重复调用只刷新源列表）。
+ */
+export async function startClaudeNotificationBridge(getWindow: () => BrowserWindow | null): Promise<void> {
+  claudeNotifyWindowGetter = getWindow;
+  const paths = await listClaudeNotifyFiles();
+  syncClaudeNotifySources(paths);
+  try {
+    const watchList = paths.map((p) => `${p}${fs.existsSync(p) ? "" : " (missing)"}`);
+    logClaudeNotification(`notify bridge watch=${watchList.join(" | ") || "none"}`);
+  } catch {}
+  if (claudeNotifyTimer) return;
+  claudeNotifyTimer = setInterval(() => {
+    void pollClaudeNotifyFiles();
+  }, CLAUDE_NOTIFY_POLL_INTERVAL_MS);
+  try { logClaudeNotification(`notify bridge started sources=${claudeNotifySources.size}`); } catch {}
+}
+
+/**
+ * 中文说明：停止 Claude 通知桥接。
+ */
+export function stopClaudeNotificationBridge(): void {
+  if (claudeNotifyTimer) {
+    try { clearInterval(claudeNotifyTimer); } catch {}
+  }
+  claudeNotifyTimer = null;
+  claudeNotifyPolling = false;
+  claudeNotifyWindowGetter = null;
+  claudeNotifySources.clear();
 }

--- a/electron/codex/config.test.ts
+++ b/electron/codex/config.test.ts
@@ -1,0 +1,151 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * 中文说明：创建临时 HOME 目录，并同步覆盖 HOME/USERPROFILE，便于测试 os.homedir() 相关逻辑。
+ */
+function createTempHome(): { home: string; cleanup: () => void } {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "codexflow-codex-home-"));
+  const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+
+  /**
+   * 中文说明：恢复环境变量到原值；若原值不存在则删除，避免把 undefined 写成字符串污染后续测试。
+   */
+  const restoreEnv = (key: string, value: string | undefined) => {
+    try {
+      if (typeof value === "string") process.env[key] = value;
+      else delete process.env[key];
+    } catch {}
+  };
+
+  const cleanup = () => {
+    restoreEnv("HOME", prevHome);
+    restoreEnv("USERPROFILE", prevUserProfile);
+    try { fs.rmSync(home, { recursive: true, force: true }); } catch {}
+  };
+  return { home, cleanup };
+}
+
+/**
+ * 中文说明：读取当前 HOME 下的 ~/.codex/config.toml（若不存在则返回空字符串）。
+ */
+function readCodexConfigToml(home: string): string {
+  const configPath = path.join(home, ".codex", "config.toml");
+  try { return fs.readFileSync(configPath, "utf8"); } catch { return ""; }
+}
+
+/**
+ * 中文说明：写入当前 HOME 下的 ~/.codex/config.toml（自动创建目录）。
+ */
+function writeCodexConfigToml(home: string, content: string): void {
+  const dir = path.join(home, ".codex");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "config.toml"), content, "utf8");
+}
+
+/**
+ * 中文说明：加载 config.ts，并 mock 掉 getCodexRootsFastAsync，避免测试访问真实环境。
+ */
+async function loadConfigModule(): Promise<{ ensureAllCodexNotifications: () => Promise<void> }> {
+  vi.resetModules();
+  vi.doMock("../wsl", () => ({
+    getCodexRootsFastAsync: vi.fn(async () => ({ wsl: [], windowsCodex: null })),
+  }));
+  return await import("./config");
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("electron/codex/config（tui 通知配置修复）", () => {
+  it("空配置：补齐 [tui] notifications + notification_method=osc9", async () => {
+    const { home, cleanup } = createTempHome();
+    try {
+      const mod = await loadConfigModule();
+      await mod.ensureAllCodexNotifications();
+      const body = readCodexConfigToml(home);
+      expect(body).toContain("[tui]");
+      expect(body).toContain('notification_method = "osc9"');
+      expect(body).toContain('notifications = ["agent-turn-complete"]');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("root dotted：更新 tui.notifications 并强制 tui.notification_method=osc9（不追加 [tui]）", async () => {
+    const { home, cleanup } = createTempHome();
+    try {
+      writeCodexConfigToml(home, [
+        'tui.notifications = ["foo"]',
+        'tui.notification_method = "auto"',
+        "",
+      ].join("\n"));
+      const mod = await loadConfigModule();
+      await mod.ensureAllCodexNotifications();
+      const body = readCodexConfigToml(home);
+      expect(body).not.toContain("[tui]");
+      expect(body).toContain('tui.notification_method = "osc9"');
+      expect(body).toContain('tui.notifications = ["foo", "agent-turn-complete"]');
+      expect((body.match(/tui\.notifications\s*=/g) || []).length).toBe(1);
+      expect((body.match(/tui\.notification_method\s*=/g) || []).length).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("root dotted + 其它 section：补齐 method 时必须插在首个 section 之前", async () => {
+    const { home, cleanup } = createTempHome();
+    try {
+      writeCodexConfigToml(home, [
+        'tui.notifications = ["agent-turn-complete"]',
+        "",
+        "[other]",
+        'foo = "bar"',
+        "",
+      ].join("\n"));
+      const mod = await loadConfigModule();
+      await mod.ensureAllCodexNotifications();
+      const body = readCodexConfigToml(home);
+      const idxMethod = body.indexOf('tui.notification_method = "osc9"');
+      const idxOther = body.indexOf("[other]");
+      expect(idxMethod).toBeGreaterThanOrEqual(0);
+      expect(idxOther).toBeGreaterThanOrEqual(0);
+      expect(idxMethod).toBeLessThan(idxOther);
+      expect(body).not.toContain("[tui]");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("同时存在 [tui] 与 root dotted：移除重复 dotted，并合并 notifications 到 [tui]", async () => {
+    const { home, cleanup } = createTempHome();
+    try {
+      writeCodexConfigToml(home, [
+        'tui.notifications = ["x"]',
+        'tui.notification_method = "auto"',
+        "",
+        "[tui]",
+        'notifications = ["y"]',
+        "",
+      ].join("\n"));
+      const mod = await loadConfigModule();
+      await mod.ensureAllCodexNotifications();
+      const body = readCodexConfigToml(home);
+      expect(body).toContain("[tui]");
+      expect(body).toContain('notification_method = "osc9"');
+      expect(body).toContain('notifications = ["y", "x", "agent-turn-complete"]');
+      expect(body).not.toContain("tui.notifications");
+      expect(body).not.toContain("tui.notification_method");
+      expect((body.match(/\bnotifications\s*=/g) || []).length).toBe(1);
+      expect((body.match(/\bnotification_method\s*=/g) || []).length).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -35,7 +35,7 @@ import { registerQuitConfirmIPC, requestQuitConfirmFromRenderer } from "./quitCo
 import { CodexBridge, type CodexBridgeOptions } from "./codex/bridge";
 import { applyCodexAuthBackupAsync, deleteCodexAuthBackupAsync, isSafeAuthBackupId, listCodexAuthBackupsAsync, readCodexAuthBackupMetaAsync, resolveCodexAccountSignature, resolveCodexAuthJsonPathAsync, upsertCodexAuthBackupAsync, upsertCodexAuthBackupMetaOnlyAsync } from "./codex/authBackups";
 import { ensureAllCodexNotifications } from "./codex/config";
-import { ensureAllClaudeNotifications } from "./claude/notifications";
+import { ensureAllClaudeNotifications, startClaudeNotificationBridge, stopClaudeNotificationBridge } from "./claude/notifications";
 import { getClaudeUsageSnapshotAsync } from "./claude/usage";
 import { ensureAllGeminiNotifications, startGeminiNotificationBridge, stopGeminiNotificationBridge } from "./gemini/notifications";
 import { getGeminiQuotaSnapshotAsync } from "./gemini/usage";
@@ -1317,6 +1317,7 @@ if (!gotLock) {
       try { await ensureAllCodexNotifications(); } catch {}
       try { await ensureAllClaudeNotifications(); } catch {}
       try { await ensureAllGeminiNotifications(); } catch {}
+      try { await startClaudeNotificationBridge(() => mainWindow); } catch {}
       try { await startGeminiNotificationBridge(() => mainWindow); } catch {}
       if (DIAG) { try { perfLogger.log(`[BOOT] Locale: ${i18n.getCurrentLocale?.()}`); } catch {} }
       try { registerNotificationIPC(() => mainWindow, { appUserModelId, protocolScheme: PROTOCOL_SCHEME, profileId: instanceProfile.profileId }); } catch {}
@@ -1369,6 +1370,7 @@ if (!gotLock) {
   });
 
   app.on('will-quit', () => {
+    try { stopClaudeNotificationBridge(); } catch {}
     try { stopGeminiNotificationBridge(); } catch {}
     disposeAllPtys();
     cleanupPastedImages().catch(() => {});
@@ -3593,6 +3595,7 @@ ipcMain.handle('settings.get', async () => {
   try { await ensureAllCodexNotifications(); } catch {}
   try { await ensureAllClaudeNotifications(); } catch {}
   try { await ensureAllGeminiNotifications(); } catch {}
+  try { await startClaudeNotificationBridge(() => mainWindow); } catch {}
   try { await startGeminiNotificationBridge(() => mainWindow); } catch {}
   const cfg = settings.getSettings() as any;
   try {
@@ -3649,6 +3652,7 @@ ipcMain.handle('settings.update', async (_e, partial: any) => {
   try { await ensureAllCodexNotifications(); } catch {}
   try { await ensureAllClaudeNotifications(); } catch {}
   try { await ensureAllGeminiNotifications(); } catch {}
+  try { await startClaudeNotificationBridge(() => mainWindow); } catch {}
   try { await startGeminiNotificationBridge(() => mainWindow); } catch {}
   // 若刚开启“记录账号”，立即刷新一次账号信息并触发初始备份（便于立刻出现在备份列表）
   try {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -473,7 +473,7 @@ contextBridge.exposeInMainWorld('host', {
     showAgentCompletion: (payload: { tabId: string; tabName?: string; projectName?: string; preview?: string; title: string; body: string; appTitle?: string }) => {
       ipcRenderer.send('notifications:agentComplete', payload);
     },
-    // 中文说明：监听主进程转发的外部完成通知（Gemini hook）。
+    // 中文说明：监听主进程转发的外部完成通知（Gemini/Claude hook -> JSONL 桥接）。
     onExternalAgentComplete: (handler: (payload: any) => void) => {
       const listener = (_: unknown, payload: any) => handler(payload);
       ipcRenderer.on('notifications:externalAgentComplete', listener);

--- a/web/src/app/app-shared.notify.test.ts
+++ b/web/src/app/app-shared.notify.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import {
+  CLAUDE_NOTIFY_ENV_KEYS,
+  GEMINI_NOTIFY_ENV_KEYS,
+  buildProviderNotifyEnv,
+  isAgentCompletionMessage,
+} from "./app-shared";
+
+describe("app-shared（完成通知：识别与环境变量注入）", () => {
+  it("isAgentCompletionMessage：空 payload 也视为完成事件", () => {
+    expect(isAgentCompletionMessage("")).toBe(true);
+    expect(isAgentCompletionMessage("   ")).toBe(true);
+  });
+
+  it("isAgentCompletionMessage：过滤非完成类通知（approval requested / codex wants to edit）", () => {
+    expect(isAgentCompletionMessage("Approval requested: run rm -rf")).toBe(false);
+    expect(isAgentCompletionMessage("codex wants to edit foo.ts")).toBe(false);
+  });
+
+  it("buildProviderNotifyEnv：Gemini 注入 GEMINI_CLI_CODEXFLOW_*", () => {
+    const env = buildProviderNotifyEnv("tab-1", "gemini", "Ubuntu-24.04");
+    expect(env).toEqual({
+      [GEMINI_NOTIFY_ENV_KEYS.tabId]: "tab-1",
+      [GEMINI_NOTIFY_ENV_KEYS.envLabel]: "Ubuntu-24.04",
+      [GEMINI_NOTIFY_ENV_KEYS.providerId]: "gemini",
+    });
+  });
+
+  it("buildProviderNotifyEnv：Claude 注入 CLAUDE_CODEXFLOW_*", () => {
+    const env = buildProviderNotifyEnv("tab-2", "claude", "Ubuntu-24.04");
+    expect(env).toEqual({
+      [CLAUDE_NOTIFY_ENV_KEYS.tabId]: "tab-2",
+      [CLAUDE_NOTIFY_ENV_KEYS.envLabel]: "Ubuntu-24.04",
+      [CLAUDE_NOTIFY_ENV_KEYS.providerId]: "claude",
+    });
+  });
+
+  it("buildProviderNotifyEnv：其它 provider 不注入", () => {
+    expect(buildProviderNotifyEnv("tab-3", "codex", "Ubuntu-24.04")).toEqual({});
+    expect(buildProviderNotifyEnv("tab-3", "terminal", "Ubuntu-24.04")).toEqual({});
+  });
+});
+

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -573,8 +573,8 @@ export interface GeminiAPI {
 export interface NotificationsAPI {
   setBadgeCount(count: number): void;
   showAgentCompletion(payload: { tabId: string; tabName?: string; projectName?: string; preview?: string; title: string; body: string; appTitle?: string }): void;
-  /** 监听主进程转发的外部完成通知（如 Gemini hook）。 */
-  onExternalAgentComplete?(handler: (payload: { providerId?: "gemini"; tabId?: string; envLabel?: string; preview?: string; timestamp?: string; eventId?: string }) => void): () => void;
+  /** 监听主进程转发的外部完成通知（如 Gemini/Claude hook -> JSONL 桥接）。 */
+  onExternalAgentComplete?(handler: (payload: { providerId?: "gemini" | "claude"; tabId?: string; envLabel?: string; preview?: string; timestamp?: string; eventId?: string }) => void): () => void;
   onFocusTab?(handler: (payload: { tabId: string }) => void): () => void;
 }
 


### PR DESCRIPTION
- Claude Code Stop hook 写入 JSONL 通知文件并保留 /dev/tty 兜底，主进程轮询转发 externalAgentComplete
- 渲染层支持 providerId=claude，并在启动 Claude 会话时注入 CLAUDE_CODEXFLOW_* 环境变量以关联 tab
- Codex ~/.codex/config.toml：确保 [tui] notifications 含 agent-turn-complete 且 notification_method=osc9（兼容 root dotted 写法）
- 新增单测覆盖 config.toml 规范化与通知 env 注入/空 payload 识别