### PR TITLE
fix(history): developer 内容需显式启用类型筛选

### DIFF
--- a/electron/history.ts
+++ b/electron/history.ts
@@ -1313,6 +1313,16 @@ export async function readHistoryFile(filePath: string, opts?: { chunkSize?: num
             }
           } catch {}
         }
+        // developer 角色增强：为其内容项补充稳定标签，便于前端在“类型筛选”中单独开关
+        try {
+          const roleLower = String(role || '').trim().toLowerCase();
+          if (roleLower === 'developer') {
+            for (const it of contentArr) {
+              const prev = Array.isArray(it.tags) ? it.tags : [];
+              if (!prev.includes('developer')) it.tags = [...prev, 'developer'];
+            }
+          }
+        } catch {}
         if (contentArr.length > 0) messages.push({ role, content: contentArr });
       } else if (obj.type === 'function_call' || (obj.type === 'response_item' && obj.payload && obj.payload.type === 'function_call')) {
         // 工具/函数调用

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8900,6 +8900,8 @@ function filterHistoryMessages(session: HistorySession, typeFilter: Record<strin
   const allowItem = (item: any) => {
     if (!typeFilter) return true;
     const keys = keysOfItemCanonical(item);
+    // developer 标签需要显式启用：避免 developer 内容被 input_text 等类型“顺带展示”
+    if (keys.includes('developer') && Object.prototype.hasOwnProperty.call(typeFilter, 'developer') && !(typeFilter as any)['developer']) return false;
     for (const key of keys) {
       if (Object.prototype.hasOwnProperty.call(typeFilter, key) && !!(typeFilter as any)[key]) return true;
     }
@@ -9332,6 +9334,8 @@ function HistoryDetail({ sessions, selectedHistoryId, onBack, onResume, onResume
     if (!s) return '';
     const allowItem = (it: any) => {
       const keys = keysOfItemCanonical(it);
+      // developer 标签需要显式启用：避免 developer 内容被 input_text 等类型“顺带展示”
+      if (keys.includes('developer') && Object.prototype.hasOwnProperty.call(typeFilter, 'developer') && !typeFilter['developer']) return false;
       for (const k of keys) { if (Object.prototype.hasOwnProperty.call(typeFilter, k) && !!typeFilter[k]) return true; }
       return !!typeFilter['other'];
     };


### PR DESCRIPTION
- 解析 Codex history 时：当消息 role 为 developer，为每个内容项追加稳定标签 developer
- 前端类型筛选：developer 标签需显式勾选，否则即便命中 input_text 等类型也不展示

这样可避免 developer 内容被默认的 input_text/output_text 勾选“顺带显示”，并支持在历史详情中单独开关。