### PR TITLE
feat(worktree): 初始提示词支持大屏编辑

### DIFF
--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -178,7 +178,7 @@ export function DialogTrigger({ asChild, children }: { asChild?: boolean; childr
   return child;
 }
 
-export function DialogContent({ className, children }: React.HTMLAttributes<HTMLDivElement>) {
+export function DialogContent({ className, children, ...rest }: React.HTMLAttributes<HTMLDivElement>) {
   const ctx = React.useContext(DialogContext);
   const [isVisible, setIsVisible] = React.useState(false);
 
@@ -239,6 +239,7 @@ export function DialogContent({ className, children }: React.HTMLAttributes<HTML
           className
         )}
         data-cf-dialog-content="true"
+        {...rest}
       >
         {children}
       </div>

--- a/web/src/locales/en/projects.json
+++ b/web/src/locales/en/projects.json
@@ -75,7 +75,7 @@
   "worktreeYoloHint": "Applies only to this operation and does not modify global settings.",
   "worktreeUseMultipleModels": "Mixed parallel mode",
   "worktreeTotalCount": "Total: {count} / 8",
-  "worktreeInitialPrompt": "Initial prompt (optional)",
+  "worktreeInitialPrompt": "Initial prompt",
   "worktreeCreating": "Creating…",
   "worktreeCreateCancelAction": "Cancel creation",
   "worktreeCreateCanceling": "Canceling…",

--- a/web/src/locales/en/terminal.json
+++ b/web/src/locales/en/terminal.json
@@ -1,7 +1,7 @@
 {
   "dirMissing": "Directory missing, unable to create console",
   "newConsole": "New Agent",
-  "inputPlaceholder": "Type message to Codex (paste images, @ search files), Ctrl+Enter to send",
+  "inputPlaceholder": "Type a message to send (paste images, @ search files, @/ search folders, drag & drop files), press Ctrl+Enter to send",
   "send": "Send",
   "expandInput": "Expand composer",
   "collapseInput": "Exit expand",

--- a/web/src/locales/zh/projects.json
+++ b/web/src/locales/zh/projects.json
@@ -75,7 +75,7 @@
   "worktreeYoloHint": "仅对本次操作生效，不会修改全局设置。",
   "worktreeUseMultipleModels": "并行混合模式",
   "worktreeTotalCount": "总计：{count} / 8",
-  "worktreeInitialPrompt": "初始提示词（可选）",
+  "worktreeInitialPrompt": "初始提示词",
   "worktreeCreating": "创建中…",
   "worktreeCreateCancelAction": "取消创建",
   "worktreeCreateCanceling": "取消中…",

--- a/web/src/locales/zh/terminal.json
+++ b/web/src/locales/zh/terminal.json
@@ -1,7 +1,7 @@
 {
   "dirMissing": "目录缺失，无法创建控制台",
   "newConsole": "新建代理",
-  "inputPlaceholder": "输入要发给 Codex 的消息（支持粘贴图片、@ 搜索文件），Ctrl + Enter 发送",
+  "inputPlaceholder": "输入要发送的消息（支持粘贴图片、@ 搜索文件、@/ 搜索文件夹、拖拽文件），按 Ctrl + Enter 发送",
   "send": "发送",
   "expandInput": "展开输入框",
   "collapseInput": "退出大屏",


### PR DESCRIPTION
- worktree 创建面板的“初始提示词”输入支持一键展开/收起，便于编辑长提示词
- 面板关闭时同步关闭大屏弹窗，避免状态残留
- 初始提示词输入补齐 Ctrl/⌘+Enter 快捷提交
- DialogContent 支持透传 HTML 属性（如 style），用于大屏尺寸定制
- 更新相关 i18n 文案（projects.worktreeInitialPrompt、terminal.inputPlaceholder）