### PR TITLE
fix(worktree): 持久化初始提示词并容错残留 REBASE_HEAD

### DIFF
--- a/web/src/app/app-shared.tsx
+++ b/web/src/app/app-shared.tsx
@@ -104,9 +104,6 @@ import type {
 } from "@/types/host";
 import type { TerminalThemeId } from "@/types/terminal-theme";
 
-// 发送命令后延迟清理粘贴图片 3 分钟，避免命令执行期间文件提前被删除
-const CHIP_COMMIT_RELEASE_DELAY_MS = 180_000;
-
 // ---------- Types ----------
 
 type TerminalMode = NonNullable<AppSettings["terminal"]>;
@@ -1619,7 +1616,6 @@ function TerminalView({
 }
 
 export {
-  CHIP_COMMIT_RELEASE_DELAY_MS,
   GEMINI_NOTIFY_ENV_KEYS,
   CLAUDE_NOTIFY_ENV_KEYS,
   PROJECT_SORT_STORAGE_KEY,

--- a/web/src/lib/imageResourceRegistry.ts
+++ b/web/src/lib/imageResourceRegistry.ts
@@ -18,16 +18,111 @@ type ResourceEntry = {
   fileName?: string;
   fromPaste: boolean;
   refCount: number;
+  createdAt: number;
+  lastAccessAt: number;
 };
 
 const resourcesByWinPath = new Map<string, ResourceEntry>();
 const resourcesByFingerprint = new Map<string, ResourceEntry>();
 
+/**
+ * 中文说明：限制图片资源 registry 的内存增长（长会话反复粘贴不同图片时避免无限增长）。
+ * - 淘汰仅影响“内存索引”，不影响磁盘文件；
+ * - 磁盘文件仍由主进程在“应用关闭/下次启动”统一清理（见 images/sessionPastedImages）。
+ */
+const MAX_RESOURCE_ENTRIES = 2048;
+const RESOURCE_TTL_MS = 2 * 60 * 60_000; // 2 小时
+const CLEANUP_MIN_INTERVAL_MS = 15_000; // 15 秒（节流，避免频繁扫描）
+let lastCleanupAt = 0;
+
+/**
+ * 中文说明：获取当前时间戳（毫秒）。
+ */
+function nowMs(): number {
+  return Date.now();
+}
+
+/**
+ * 中文说明：更新条目的最近访问时间（用于 LRU）。
+ */
+function touchEntry(entry: ResourceEntry): void {
+  try { entry.lastAccessAt = nowMs(); } catch {}
+}
+
+/**
+ * 中文说明：从两个索引 Map 中移除同一条目（仅移除内存引用，不删除文件）。
+ */
+function removeEntryFromMaps(winPathKey: string, entry: ResourceEntry): void {
+  try {
+    const cur = resourcesByWinPath.get(winPathKey);
+    if (cur === entry) resourcesByWinPath.delete(winPathKey);
+    const fp = normalizeFingerprint(entry.fingerprint);
+    if (fp) {
+      const curFp = resourcesByFingerprint.get(fp);
+      if (curFp === entry) resourcesByFingerprint.delete(fp);
+    }
+  } catch {}
+}
+
+/**
+ * 中文说明：对 registry 做 TTL + 最大条目数淘汰。
+ * - 优先淘汰 refCount=0 的条目；
+ * - 若仍超过上限，则继续按 LRU 淘汰（即便 refCount>0，也不会影响“退出/下次启动清理文件”的策略）。
+ */
+function cleanupRegistry(options?: { force?: boolean }): void {
+  try {
+    const now = nowMs();
+    const force = !!options?.force;
+    if (!force && now - lastCleanupAt < CLEANUP_MIN_INTERVAL_MS) return;
+    lastCleanupAt = now;
+
+    // 1) TTL：移除长时间未访问且无引用的条目
+    if (RESOURCE_TTL_MS > 0) {
+      for (const [key, entry] of resourcesByWinPath.entries()) {
+        const last = Number(entry.lastAccessAt || entry.createdAt || 0);
+        if (entry.refCount > 0) continue;
+        if (last > 0 && now - last > RESOURCE_TTL_MS) {
+          removeEntryFromMaps(key, entry);
+        }
+      }
+    }
+
+    // 2) 上限：按 LRU 淘汰
+    if (resourcesByWinPath.size <= MAX_RESOURCE_ENTRIES) return;
+    const items = Array.from(resourcesByWinPath.entries()).map(([key, entry]) => ({
+      key,
+      entry,
+      score: Number(entry.lastAccessAt || entry.createdAt || 0),
+    }));
+    items.sort((a, b) => a.score - b.score);
+
+    for (const it of items) {
+      if (resourcesByWinPath.size <= MAX_RESOURCE_ENTRIES) break;
+      if (it.entry.refCount > 0) continue;
+      removeEntryFromMaps(it.key, it.entry);
+    }
+    if (resourcesByWinPath.size <= MAX_RESOURCE_ENTRIES) return;
+    for (const it of items) {
+      if (resourcesByWinPath.size <= MAX_RESOURCE_ENTRIES) break;
+      if (!resourcesByWinPath.has(it.key)) continue;
+      removeEntryFromMaps(it.key, it.entry);
+    }
+  } catch {}
+}
+
+/**
+ * 中文说明：归一化图片指纹字符串（去空白；无效时返回空串）。
+ */
 function normalizeFingerprint(fp?: string): string {
   if (!fp) return "";
   return String(fp).trim();
 }
 
+/**
+ * 中文说明：获取或创建资源条目，并同步维护 winPath / fingerprint 双索引。
+ * - `createIfMissing=true`：允许创建新条目；
+ * - 会更新最近访问时间，并在必要时触发清理（TTL/LRU/上限）。
+ */
 function getEntry(meta: ChipResourceLike, createIfMissing: boolean): ResourceEntry | null {
   if (!meta || !meta.fromPaste) return null;
   const winPath = typeof meta.winPath === "string" ? meta.winPath.trim() : "";
@@ -39,6 +134,7 @@ function getEntry(meta: ChipResourceLike, createIfMissing: boolean): ResourceEnt
   if (!entry) {
     if (!createIfMissing) return null;
     if (!winPath && !fingerprint) return null;
+    const now = nowMs();
     entry = {
       fingerprint: fingerprint || undefined,
       winPath: winPath || undefined,
@@ -46,16 +142,33 @@ function getEntry(meta: ChipResourceLike, createIfMissing: boolean): ResourceEnt
       fileName: meta.fileName ? String(meta.fileName) : undefined,
       fromPaste: !!meta.fromPaste,
       refCount: 0,
+      createdAt: now,
+      lastAccessAt: now,
     };
   } else {
-    if (winPath) entry.winPath = winPath;
-    if (fingerprint) entry.fingerprint = fingerprint;
+    touchEntry(entry);
+    const prevWinPath = String(entry.winPath || "").trim();
+    const prevFingerprint = normalizeFingerprint(entry.fingerprint);
+    if (winPath && prevWinPath && winPath !== prevWinPath) {
+      // 避免同一 entry 产生“旧 key 残留”导致 Map 无界增长
+      try { if (resourcesByWinPath.get(prevWinPath) === entry) resourcesByWinPath.delete(prevWinPath); } catch {}
+      entry.winPath = winPath;
+    } else if (winPath) {
+      entry.winPath = winPath;
+    }
+    if (fingerprint && prevFingerprint && fingerprint !== prevFingerprint) {
+      try { if (resourcesByFingerprint.get(prevFingerprint) === entry) resourcesByFingerprint.delete(prevFingerprint); } catch {}
+      entry.fingerprint = fingerprint;
+    } else if (fingerprint) {
+      entry.fingerprint = fingerprint;
+    }
     if (meta.wslPath && !entry.wslPath) entry.wslPath = String(meta.wslPath);
     if (meta.fileName && !entry.fileName) entry.fileName = String(meta.fileName);
     if (meta.fromPaste) entry.fromPaste = true;
   }
   if (entry.winPath) resourcesByWinPath.set(entry.winPath, entry);
   if (entry.fingerprint) resourcesByFingerprint.set(entry.fingerprint, entry);
+  cleanupRegistry({ force: resourcesByWinPath.size > MAX_RESOURCE_ENTRIES });
   return entry;
 }
 
@@ -65,6 +178,7 @@ export function rememberSavedImages(images: SavedImage[]): void {
       if (!image || !image.fromPaste || !image.winPath) continue;
       getEntry(image, true);
     }
+    cleanupRegistry({ force: resourcesByWinPath.size > MAX_RESOURCE_ENTRIES });
   } catch {}
 }
 
@@ -74,6 +188,8 @@ export function reuseSavedImageFromFingerprint(image: PastedImage): SavedImage |
     if (!fingerprint) return null;
     const entry = resourcesByFingerprint.get(fingerprint);
     if (!entry || !entry.winPath) return null;
+    touchEntry(entry);
+    cleanupRegistry();
     return {
       ...image,
       saved: true,
@@ -93,6 +209,7 @@ export function retainPastedImage(meta: ChipResourceLike): void {
     const entry = getEntry(meta, true);
     if (!entry) return;
     entry.refCount += 1;
+    cleanupRegistry();
   } catch {}
 }
 
@@ -102,10 +219,10 @@ export function releasePastedImage(meta: ChipResourceLike): { shouldTrash: boole
     const entry = getEntry(meta, false);
     if (!entry) return { shouldTrash: false };
     entry.refCount = Math.max(0, entry.refCount - 1);
-    if (entry.refCount > 0) return { shouldTrash: false };
-    if (entry.winPath) resourcesByWinPath.delete(entry.winPath);
-    if (entry.fingerprint) resourcesByFingerprint.delete(entry.fingerprint);
-    return { shouldTrash: entry.fromPaste && !!entry.winPath, winPath: entry.winPath };
+    // 新策略：粘贴的临时图片在“应用关闭/下次启动”统一清理；
+    // 因此渲染进程不再基于 refCount 主动触发删除，避免 N 分钟定时清理带来的体验与竞态问题。
+    cleanupRegistry({ force: resourcesByWinPath.size > MAX_RESOURCE_ENTRIES });
+    return { shouldTrash: false, winPath: entry.winPath };
   } catch {
     return { shouldTrash: false };
   }

--- a/web/src/lib/worktree-create-prefs.ts
+++ b/web/src/lib/worktree-create-prefs.ts
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+/**
+ * worktree 创建面板（“从分支创建 worktree”）的轻量持久化。
+ *
+ * 设计目标
+ * - 按 repoProjectId（项目节点 id）隔离保存：每个项目独立记录上次设置；
+ * - 仅保存“可跨会话复用”的字段（去除 blob/previewUrl 等运行态字段）；
+ * - 初始提示词在“已发送”后会被调用方清空（本模块提供清空接口）。
+ */
+
+const WORKTREE_CREATE_PREFS_STORAGE_KEY = "codexflow.worktreeCreatePrefs.v1";
+const WORKTREE_CREATE_PREFS_VERSION = 1 as const;
+
+export type GitWorktreeProviderId = "codex" | "claude" | "gemini";
+
+export type PersistedWorktreePromptChip = {
+  chipKind?: "file" | "image" | "rule";
+  winPath?: string;
+  wslPath?: string;
+  fileName?: string;
+  isDir?: boolean;
+  rulePath?: string;
+};
+
+export type WorktreeCreatePrefs = {
+  baseBranch: string;
+  selectedChildWorktreeIds: string[];
+  promptChips: PersistedWorktreePromptChip[];
+  promptDraft: string;
+  useYolo: boolean;
+  useMultipleModels: boolean;
+  singleProviderId: GitWorktreeProviderId;
+  multiCounts: Record<GitWorktreeProviderId, number>;
+};
+
+type PersistedWorktreeCreatePrefsRoot = {
+  version: typeof WORKTREE_CREATE_PREFS_VERSION;
+  savedAt: number;
+  byRepoProjectId: Record<string, WorktreeCreatePrefs>;
+};
+
+/**
+ * 中文说明：安全获取 localStorage（某些环境下可能抛异常）。
+ */
+function getLocalStorageSafe(): Storage | null {
+  try {
+    if (typeof window === "undefined") return null;
+    return window.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 中文说明：将输入转为非空字符串；否则返回空串。
+ */
+function toNonEmptyString(value: unknown): string {
+  const s = typeof value === "string" ? value.trim() : String(value ?? "").trim();
+  return s;
+}
+
+/**
+ * 中文说明：归一化 ProviderId，非内置三引擎则回退为 codex。
+ */
+function normalizeProviderId(value: unknown): GitWorktreeProviderId {
+  const v = toNonEmptyString(value).toLowerCase();
+  if (v === "codex" || v === "claude" || v === "gemini") return v as GitWorktreeProviderId;
+  return "codex";
+}
+
+/**
+ * 中文说明：将计数限制在 0..8（与 UI 控件上限一致）。
+ */
+function clampCount(value: unknown): number {
+  const n = Math.floor(Number(value) || 0);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(8, n));
+}
+
+/**
+ * 中文说明：归一化 multiCounts，确保三个引擎键齐全。
+ */
+function normalizeMultiCounts(input: unknown): Record<GitWorktreeProviderId, number> {
+  const obj = (input && typeof input === "object") ? (input as any) : {};
+  return {
+    codex: clampCount(obj.codex),
+    claude: clampCount(obj.claude),
+    gemini: clampCount(obj.gemini),
+  };
+}
+
+/**
+ * 中文说明：归一化字符串数组（去空、去重、保持顺序）。
+ */
+function normalizeStringArray(input: unknown): string[] {
+  const arr = Array.isArray(input) ? input : [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const it of arr) {
+    const s = toNonEmptyString(it);
+    if (!s) continue;
+    if (seen.has(s)) continue;
+    seen.add(s);
+    out.push(s);
+  }
+  return out;
+}
+
+/**
+ * 中文说明：归一化提示词 chips（仅保留稳定字段）。
+ */
+function normalizePromptChips(input: unknown): PersistedWorktreePromptChip[] {
+  const arr = Array.isArray(input) ? input : [];
+  const out: PersistedWorktreePromptChip[] = [];
+  for (const item of arr) {
+    if (!item || typeof item !== "object") continue;
+    const obj = item as any;
+    const winPath = toNonEmptyString(obj.winPath);
+    const wslPath = toNonEmptyString(obj.wslPath);
+    const fileName = toNonEmptyString(obj.fileName);
+    const rulePath = toNonEmptyString(obj.rulePath);
+    const chipKindRaw = toNonEmptyString(obj.chipKind);
+    const chipKind = (chipKindRaw === "file" || chipKindRaw === "image" || chipKindRaw === "rule") ? (chipKindRaw as any) : undefined;
+    const isDir = typeof obj.isDir === "boolean" ? obj.isDir : undefined;
+    // 至少要有一个可定位的字段，否则丢弃
+    if (!winPath && !wslPath && !fileName && !rulePath) continue;
+    out.push({ chipKind, winPath: winPath || undefined, wslPath: wslPath || undefined, fileName: fileName || undefined, isDir, rulePath: rulePath || undefined });
+  }
+  return out;
+}
+
+/**
+ * 中文说明：归一化单个项目的 worktree 创建面板偏好。
+ */
+function normalizePrefs(input: unknown): WorktreeCreatePrefs {
+  const obj = (input && typeof input === "object") ? (input as any) : {};
+  const singleProviderId = normalizeProviderId(obj.singleProviderId);
+  const multiCounts = normalizeMultiCounts(obj.multiCounts);
+  return {
+    baseBranch: toNonEmptyString(obj.baseBranch),
+    selectedChildWorktreeIds: normalizeStringArray(obj.selectedChildWorktreeIds),
+    promptChips: normalizePromptChips(obj.promptChips),
+    promptDraft: String(obj.promptDraft ?? ""),
+    useYolo: typeof obj.useYolo === "boolean" ? obj.useYolo : true,
+    useMultipleModels: typeof obj.useMultipleModels === "boolean" ? obj.useMultipleModels : false,
+    singleProviderId,
+    multiCounts,
+  };
+}
+
+/**
+ * 中文说明：读取指定 repoProjectId 的 worktree 创建面板偏好；不存在则返回 null。
+ */
+export function loadWorktreeCreatePrefs(repoProjectId: string): WorktreeCreatePrefs | null {
+  const repoId = toNonEmptyString(repoProjectId);
+  if (!repoId) return null;
+  const ls = getLocalStorageSafe();
+  if (!ls) return null;
+  try {
+    const raw = ls.getItem(WORKTREE_CREATE_PREFS_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as any;
+    if (Number(parsed?.version) !== WORKTREE_CREATE_PREFS_VERSION) return null;
+    const by = (parsed?.byRepoProjectId && typeof parsed.byRepoProjectId === "object") ? parsed.byRepoProjectId : {};
+    const prefsRaw = by[repoId];
+    if (!prefsRaw) return null;
+    return normalizePrefs(prefsRaw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 中文说明：写入指定 repoProjectId 的 worktree 创建面板偏好（覆盖保存）。
+ */
+export function saveWorktreeCreatePrefs(repoProjectId: string, prefs: WorktreeCreatePrefs): void {
+  const repoId = toNonEmptyString(repoProjectId);
+  if (!repoId) return;
+  const ls = getLocalStorageSafe();
+  if (!ls) return;
+  try {
+    let root: PersistedWorktreeCreatePrefsRoot = {
+      version: WORKTREE_CREATE_PREFS_VERSION,
+      savedAt: Date.now(),
+      byRepoProjectId: {},
+    };
+    try {
+      const raw = ls.getItem(WORKTREE_CREATE_PREFS_STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as any;
+        if (Number(parsed?.version) === WORKTREE_CREATE_PREFS_VERSION && parsed?.byRepoProjectId && typeof parsed.byRepoProjectId === "object") {
+          root = {
+            version: WORKTREE_CREATE_PREFS_VERSION,
+            savedAt: Date.now(),
+            byRepoProjectId: parsed.byRepoProjectId as any,
+          };
+        }
+      }
+    } catch {
+      // ignore
+    }
+    root.byRepoProjectId = { ...(root.byRepoProjectId || {}), [repoId]: normalizePrefs(prefs) };
+    root.savedAt = Date.now();
+    ls.setItem(WORKTREE_CREATE_PREFS_STORAGE_KEY, JSON.stringify(root));
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * 中文说明：清空指定 repoProjectId 的“初始提示词记录”（chips + draft），保留其他设置不变。
+ */
+export function clearWorktreeCreatePromptPrefs(repoProjectId: string): void {
+  const repoId = toNonEmptyString(repoProjectId);
+  if (!repoId) return;
+  const existing = loadWorktreeCreatePrefs(repoId);
+  if (!existing) return;
+  saveWorktreeCreatePrefs(repoId, { ...existing, promptChips: [], promptDraft: "" });
+}
+


### PR DESCRIPTION
- 创建 worktree 面板按 repo 维度持久化上次设置（含基分支、引擎分配、提示词草稿）
- 新增 prompt 偏好存储模块，过滤运行态字段并在提示词发送成功后自动清空记录
- recycle 前置检测区分强阻断标记与弱标记，遇到孤立 REBASE_HEAD 自动归档后继续
- 补充 REBASE_HEAD 归档与真实 rebase-merge 阻断的回归测试
- 调整粘贴图片生命周期：渲染层不再按 refCount 立即删文件，改为主进程会话结束/下次启动统一清理
- 启动阶段增加遗留粘贴图片目录清理，处理异常退出后的临时文件残留