### PR TITLE
fix(history): 修复历史详情 Markdown 行内代码长串溢出

### DIFF
--- a/web/src/features/history/renderers/history-markdown.tsx
+++ b/web/src/features/history/renderers/history-markdown.tsx
@@ -19,7 +19,7 @@ const CODE_BLOCK_CLASS_NAME =
   "overflow-x-auto rounded-apple bg-[var(--cf-surface-muted)] border border-[var(--cf-border)] p-3 text-xs text-[var(--cf-text-primary)] font-mono shadow-apple-inner";
 
 const INLINE_CODE_CLASS_NAME =
-  "rounded-apple-sm bg-[var(--cf-surface-muted)] px-1.5 py-0.5 text-[0.85em] text-[var(--cf-text-primary)] font-mono";
+  "rounded-apple-sm bg-[var(--cf-surface-muted)] px-1.5 py-0.5 text-[0.85em] text-[var(--cf-text-primary)] font-mono break-all [overflow-wrap:anywhere]";
 
 /**
  * 中文说明：判断当前行是否为 fenced code block 的起止行（``` 或 ~~~）。


### PR DESCRIPTION
- 为历史详情 Markdown 行内 code 增加自动换行能力（break-all + overflow-wrap:anywhere）
- 避免长路径、长 token 或连续字符串撑破卡片宽度，减少横向滚动与布局抖动
- 保持代码块高亮渲染路径不变，仅影响无 className 的 inline code