### PR TITLE
feat(history): 支持历史分页加载并增强搜索体验

### DIFF
--- a/electron/indexer.ts
+++ b/electron/indexer.ts
@@ -56,6 +56,8 @@ type PersistDetails = {
 
 // 单次偏好的详情缓存大小：保留最近查看的几条，防止无限增长
 const DETAILS_CACHE_LIMIT = 8;
+// 历史首条输入预览的索引长度上限：用于搜索匹配（展示仍由前端自行截断）
+const HISTORY_PREVIEW_SEARCH_MAX_CHARS = 240;
 
 const g: any = global as any;
 if (!g.__indexer) g.__indexer = {};
@@ -136,7 +138,7 @@ function stripDetailsForPersist(details: Details): Details {
   return { ...rest, messages: [] };
 }
 
-const VERSION = "v8";
+const VERSION = "v9";
 
 /**
  * 读取 Claude Code 的 Agent 历史开关（默认 false）。
@@ -786,7 +788,7 @@ async function parseCodexDetails(fp: string, stat: fs.Stats, opts?: { summaryOnl
                       if (t) {
                         // 预览行级过滤：跳过路径/空行，直到遇到有效内容
                         const filtered = filterHistoryPreviewText(t);
-                        if (filtered) { preview = filtered.slice(0, 40); break; }
+                        if (filtered) { preview = filtered.slice(0, HISTORY_PREVIEW_SEARCH_MAX_CHARS); break; }
                       }
                     }
                   }
@@ -797,7 +799,7 @@ async function parseCodexDetails(fp: string, stat: fs.Stats, opts?: { summaryOnl
                       const t = String((it as any)?.text || '').trim();
                       if (t) {
                         const filtered = filterHistoryPreviewText(t);
-                        if (filtered) { preview = filtered.slice(0, 40); break; }
+                        if (filtered) { preview = filtered.slice(0, HISTORY_PREVIEW_SEARCH_MAX_CHARS); break; }
                       }
                     }
                   }


### PR DESCRIPTION
- 历史侧栏新增分页状态（hasMore/nextOffset）与“加载更多”交互
- 搜索回车改为可增量拉取后续分页，直到命中或无更多数据
- 将项目历史缓存升级为带 LRU 的结构化缓存，保留分页游标信息
- 统一 history.list 映射逻辑并增强路径检索（兼容反斜杠与尾斜杠）
- 索引器将首条输入预览上限从 40 提升到 240，并升级索引版本到 v9
- 历史 Markdown 行内代码增加断行能力，避免长路径撑破布局