### PR TITLE
feat(at-mention): 扩展@面板宽度并优化长标题可读性

### DIFF
--- a/web/src/lib/AT_MENTION_README.md
+++ b/web/src/lib/AT_MENTION_README.md
@@ -33,7 +33,7 @@ import AtInput from "@/components/at-mention-new/CommandInputWithAt";
   className="pr-12"
 />
 ```
-- `AtInput` 内部仍渲染 `Input`，因此样式/大小与现有一致（已微调为更加紧凑的 360×280/160 面板）。
+- `AtInput` 内部仍渲染 `Input`，因此样式/大小与现有一致（当前默认宽度 540，结果区高度 250，分类区高度 160；小屏会按视口自适应收缩）。
 
 ## 接入真实数据（替换 Mock）
 当前 `searchAtItems()` 使用 `MOCK_ITEMS`。接入真实数据时，建议按以下最小改动路径：
@@ -52,7 +52,7 @@ import AtInput from "@/components/at-mention-new/CommandInputWithAt";
 - 进入新分类：在 `AT_CATEGORIES` 中新增条目，并确保你的数据映射产出对应 `categoryId` 的 `AtItem`。
 - 选中后的业务联动：当前默认“仅替换文本”。如需额外动作（如跳转/打开文件），可在 `AtInput` 的 `handlePick` 内扩展；或将其重构为支持外部回调（例如 `onPickItem`）。
 - 主题与尺寸：
-  - 固定宽度 `360px`；分类高度 `160px`、结果高度 `280px`；
+  - 默认宽度 `540px`（相较 360 提升 1.5 倍，且会按视口自适应收缩）；分类高度 `160px`、结果高度 `250px`；
   - 若下方空间不足自动上翻；左右贴边距 8px。
 
 ## 行为细节（校验点）


### PR DESCRIPTION
技术改动：
- 在 AtCommandPalette 中引入默认宽度常量（360 * 1.5 = 540），并按视口宽度自适应收缩，避免小屏越界。
- 结果面板容器改为 `w-full`，由外层定位样式统一控制宽度，保持分类与结果面板宽度一致。
- 新增 `middleEllipsis` 逻辑，对过长标题做中间省略并保留首尾关键信息。
- 为标题/副标题补充 `title` 属性，保证完整信息可悬停查看。

产品改动：
- @ 搜索结果面板默认更宽，可一次显示更多文件名信息，减少横向截断。
- 长文件名展示从“尾部截断”改为“中间省略+保留首尾”，提高同名前缀场景下的可区分性。
- 小屏场景下保持自适应收缩与边界夹紧，不改变既有弹窗定位规则。

文档同步：
- 更新 AT_MENTION_README 中的尺寸说明，明确默认宽度 540、结果高度 250、分类高度 160 与小屏自适应行为。