### PR TITLE
feat(worktree): 优化 worktree 删除弹窗的对齐判定与偏好记忆

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -343,6 +343,10 @@ contextBridge.exposeInMainWorld('host', {
     reset: async (args: any) => {
       return await ipcRenderer.invoke("gitWorktree.reset", args);
     },
+    /** 检测 worktree 是否已与主工作区当前基线对齐（只读，不修改状态）。 */
+    isAlignedToMain: async (args: any) => {
+      return await ipcRenderer.invoke("gitWorktree.isAlignedToMain", args);
+    },
     /** worktree 自动提交（有变更才提交）。 */
     autoCommit: async (args: any) => {
       return await ipcRenderer.invoke("gitWorktree.autoCommit", args);

--- a/web/src/app/app-shared.tsx
+++ b/web/src/app/app-shared.tsx
@@ -230,6 +230,10 @@ type BaseWorktreeDirtyDialogState = {
 type WorktreeDeleteDialogState = {
   open: boolean;
   projectId: string;
+  /** 偏好存储维度 key（通常为主 worktree 路径归一化结果）。 */
+  prefsKey?: string;
+  /** 当前 worktree 是否已与主 worktree 对齐（用于面板说明提示）。 */
+  alignedToMain?: boolean;
   /** 操作类型：delete=删除 worktree；reset=对齐到主工作区当前基线（保持目录，不删除）。 */
   action: "delete" | "reset";
   /** 是否为“回收成功后”的推荐删除（仅用于 UI 文案） */

--- a/web/src/lib/worktree-delete-prefs.ts
+++ b/web/src/lib/worktree-delete-prefs.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+/**
+ * “删除 worktree / 对齐到主 worktree”对话框偏好持久化。
+ *
+ * 设计目标：
+ * - 按仓库维度（repoKey）隔离，避免不同仓库互相覆盖；
+ * - 仅保存一个稳定偏好：是否默认勾选“保留目录并对齐到主 worktree”；
+ * - 读写失败时静默降级，不阻断主流程。
+ */
+
+const WORKTREE_DELETE_PREFS_STORAGE_KEY = "codexflow.worktreeDeletePrefs.v1";
+const WORKTREE_DELETE_PREFS_VERSION = 1 as const;
+
+export type WorktreeDeletePrefs = {
+  preferResetToMain: boolean;
+};
+
+type PersistedWorktreeDeletePrefsRoot = {
+  version: typeof WORKTREE_DELETE_PREFS_VERSION;
+  savedAt: number;
+  byRepoKey: Record<string, WorktreeDeletePrefs>;
+};
+
+/**
+ * 中文说明：安全读取 localStorage（某些环境可能抛异常）。
+ */
+function getLocalStorageSafe(): Storage | null {
+  try {
+    if (typeof window === "undefined") return null;
+    return window.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 中文说明：将输入收敛为可用的 repoKey（去空格）。
+ */
+function normalizeRepoKey(value: unknown): string {
+  const s = typeof value === "string" ? value.trim() : String(value ?? "").trim();
+  return s;
+}
+
+/**
+ * 中文说明：归一化删除/对齐偏好对象。
+ */
+function normalizePrefs(input: unknown): WorktreeDeletePrefs {
+  const obj = (input && typeof input === "object") ? (input as any) : {};
+  return { preferResetToMain: obj.preferResetToMain === true };
+}
+
+/**
+ * 中文说明：读取指定 repoKey 的删除/对齐偏好；不存在时返回 null。
+ */
+export function loadWorktreeDeletePrefs(repoKey: string): WorktreeDeletePrefs | null {
+  const key = normalizeRepoKey(repoKey);
+  if (!key) return null;
+  const ls = getLocalStorageSafe();
+  if (!ls) return null;
+  try {
+    const raw = ls.getItem(WORKTREE_DELETE_PREFS_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as any;
+    if (Number(parsed?.version) !== WORKTREE_DELETE_PREFS_VERSION) return null;
+    const byRepoKey = (parsed?.byRepoKey && typeof parsed.byRepoKey === "object") ? parsed.byRepoKey : {};
+    const prefsRaw = byRepoKey[key];
+    if (!prefsRaw) return null;
+    return normalizePrefs(prefsRaw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 中文说明：写入指定 repoKey 的删除/对齐偏好（覆盖保存）。
+ */
+export function saveWorktreeDeletePrefs(repoKey: string, prefs: WorktreeDeletePrefs): void {
+  const key = normalizeRepoKey(repoKey);
+  if (!key) return;
+  const ls = getLocalStorageSafe();
+  if (!ls) return;
+  try {
+    let root: PersistedWorktreeDeletePrefsRoot = {
+      version: WORKTREE_DELETE_PREFS_VERSION,
+      savedAt: Date.now(),
+      byRepoKey: {},
+    };
+    try {
+      const raw = ls.getItem(WORKTREE_DELETE_PREFS_STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as any;
+        if (Number(parsed?.version) === WORKTREE_DELETE_PREFS_VERSION && parsed?.byRepoKey && typeof parsed.byRepoKey === "object") {
+          root = {
+            version: WORKTREE_DELETE_PREFS_VERSION,
+            savedAt: Date.now(),
+            byRepoKey: parsed.byRepoKey as any,
+          };
+        }
+      }
+    } catch {
+      // ignore
+    }
+    root.byRepoKey = { ...(root.byRepoKey || {}), [key]: normalizePrefs(prefs) };
+    root.savedAt = Date.now();
+    ls.setItem(WORKTREE_DELETE_PREFS_STORAGE_KEY, JSON.stringify(root));
+  } catch {
+    // ignore
+  }
+}

--- a/web/src/locales/en/projects.json
+++ b/web/src/locales/en/projects.json
@@ -197,6 +197,8 @@
   "worktreeResetDesc": "Resets this worktree to match the revision currently checked out in the main worktree, and cleans it. Uncommitted changes will be discarded.",
   "worktreeDeleteResetOption": "Keep directory and sync to main",
   "worktreeDeleteResetHint": "Does not remove the worktree; syncs to the main worktree revision and cleans.",
+  "worktreeDeleteResetHintChecked": "Will sync to the main worktree revision and clean; it will not remove the worktree.",
+  "worktreeDeleteResetHintAligned": "It is already aligned with the main worktree, and the alignment option is hidden.",
   "worktreeDeleteForceRemoveHint": "Uncommitted changes: force delete will discard them.",
   "worktreeDeleteForceBranchHint": "Branch not merged: force delete will lose its commits.",
   "worktreeDeleteForceAction": "Force delete",

--- a/web/src/locales/zh/projects.json
+++ b/web/src/locales/zh/projects.json
@@ -197,6 +197,8 @@
   "worktreeResetDesc": "将该 worktree 对齐到主 worktree 当前签出版本，并清理工作区。未提交修改会被丢弃。",
   "worktreeDeleteResetOption": "保留目录并对齐到主 worktree",
   "worktreeDeleteResetHint": "不移除 worktree；对齐到主 worktree 当前签出版本并清理。",
+  "worktreeDeleteResetHintChecked": "将对齐到主 worktree 当前签出版本并清理；不会执行“移除 worktree”。",
+  "worktreeDeleteResetHintAligned": "检测到当前已与主 worktree 对齐，已隐藏对齐选项。",
   "worktreeDeleteForceRemoveHint": "有未提交修改：强制删除会丢弃这些修改。",
   "worktreeDeleteForceBranchHint": "分支未合并：强制删除会丢弃该分支提交。",
   "worktreeDeleteForceAction": "强制删除",

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -259,8 +259,12 @@ export type RecycleWorktreeResult =
   | { ok: false; errorCode: RecycleWorktreeErrorCode; details?: RecycleWorktreeDetails };
 
 export type ResetWorktreeResult =
-  | { ok: true }
+  | { ok: true; alreadyAligned?: boolean }
   | { ok: false; needsForce?: boolean; error?: string };
+
+export type IsWorktreeAlignedToMainResult =
+  | { ok: true; aligned: boolean }
+  | { ok: false; error?: string };
 
 export type CreatedWorktree = {
   providerId: "codex" | "claude" | "gemini";
@@ -388,6 +392,7 @@ export interface GitWorktreeAPI {
   validateForkPointRef(args: { worktreePath: string; wtBranch: string; ref: string }): Promise<{ ok: boolean; commit?: GitCommitSummary; error?: string }>;
   remove(args: { worktreePath: string; deleteBranch?: boolean; forceDeleteBranch?: boolean; forceRemoveWorktree?: boolean }): Promise<any>;
   reset(args: { worktreePath: string; targetRef?: string; force?: boolean }): Promise<ResetWorktreeResult>;
+  isAlignedToMain(args: { worktreePath: string; targetRef?: string }): Promise<IsWorktreeAlignedToMainResult>;
   autoCommit(args: { worktreePath: string; message: string }): Promise<{ ok: boolean; committed: boolean; error?: string }>;
   openExternalTool(dir: string): Promise<{ ok: boolean; error?: string }>;
   openTerminal(dir: string): Promise<{ ok: boolean; error?: string }>;


### PR DESCRIPTION
新增“是否已与主 worktree 对齐”的只读链路（main/preload/host API）， 在删除弹窗打开时主动查询并在已对齐场景隐藏“保留并重置”选项，避免无效操作。

同时新增按仓库维度的本地偏好存储：
- 记忆用户在删除弹窗中选择“删除”或“保留并重置”的默认行为
- 多子 worktree 共享同一仓库偏好，减少重复勾选
- 同步补充中英文文案