### PR TITLE
fix(worktree): 为worktree初始提示词启动补齐Working计时

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4598,11 +4598,16 @@ export default function CodexFlowManagerUI() {
       const env = getProviderEnv(providerId);
       const baseCmd = buildProviderStartupCmdForWorktreeCreate({ providerId, env, useYolo: args.useYolo });
       const startupCmd = buildProviderStartupCmdWithInitialPrompt({ providerId, terminalMode: env.terminal as any, baseCmd, prompt: args.prompt });
-      return await openProviderConsoleInProject({ project, providerId, startupCmd });
+      const started = await openProviderConsoleInProject({ project, providerId, startupCmd });
+      const hasInitialPrompt = String(args.prompt || "").trim().length > 0;
+      const tabId = String(started.tabId || "").trim();
+      if (started.ok && tabId && hasInitialPrompt && shouldEnableAgentTimerForProvider(providerId))
+        startAgentTurnTimer(tabId);
+      return started;
     } catch (e: any) {
       return { ok: false, error: String(e?.message || e) };
     }
-  }, [buildProviderStartupCmdForWorktreeCreate, getProviderEnv, openProviderConsoleInProject]);
+  }, [buildProviderStartupCmdForWorktreeCreate, getProviderEnv, openProviderConsoleInProject, shouldEnableAgentTimerForProvider, startAgentTurnTimer]);
 
   /**
    * 执行创建 worktree，并在每个 worktree 内启动对应引擎 CLI。


### PR DESCRIPTION
技术变更：
- 在 `startProviderInstanceInProject` 中，启动实例后基于 `started.ok/tabId`、`prompt` 非空与 provider 能力判断，补充调用 `startAgentTurnTimer(tabId)`。
- 保持现有发送链路计时逻辑不变，仅覆盖“通过启动命令注入首条提示词”的场景，避免状态分叉。
- 同步补全该回调的依赖数组，确保 Hook 引用一致性。

产品影响：
- 从 worktree 创建/复用流程直接注入首条提示词时，顶部状态可立即进入 Working 计时。
- 完成通知到达后可正常收口为 Done/Interrupted，用户可见体验与手动发送消息保持一致。
- 空提示词或不支持会话计时的 provider 不受影响。