### PR TITLE
fix(notifications): 多实例避免窗口错弹完成通知

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1876,7 +1876,17 @@ export default function CodexFlowManagerUI() {
    */
   function resolveExternalTabId(payload: { tabId?: string; providerId?: string; envLabel?: string }): string | null {
     const direct = String(payload?.tabId || "").trim();
-    if (direct) return direct;
+    if (direct) {
+      let existsInCurrentWindow = false;
+      for (const list of Object.values(tabsByProjectRef.current)) {
+        if ((list || []).some((tab) => String(tab?.id || "").trim() === direct)) {
+          existsInCurrentWindow = true;
+          break;
+        }
+      }
+      if (existsInCurrentWindow) return direct;
+      return null;
+    }
     const providerId = String(payload?.providerId || "codex").trim().toLowerCase();
     const envLabel = String(payload?.envLabel || "").trim();
     const matched: ConsoleTab[] = [];
@@ -3291,7 +3301,7 @@ export default function CodexFlowManagerUI() {
           envLabel: payload?.envLabel,
         });
         if (!resolvedTabId) {
-          notifyLog(`externalCompletion skip: no tab match provider=${providerId} env=${payload?.envLabel || ""}`);
+          notifyLog(`externalCompletion skip: no tab match provider=${providerId} tab=${String(payload?.tabId || "")} env=${payload?.envLabel || ""}`);
           return;
         }
         const cleanedPreview = normalizeCompletionPreview(preview);


### PR DESCRIPTION
产品层面：
- 外部完成通知在多窗口/多工作区场景下，不再误命中当前窗口不存在的标签页。
- 当 payload 携带的 tabId 不属于当前窗口时，明确跳过并记录日志，避免错误徽标与提示音。

技术层面：
- 调整 resolveExternalTabId 的 direct tabId 分支：先在 tabsByProjectRef.current 中校验存在性，再决定是否返回。
- 增强 no tab match 日志，补充 tab 字段，便于排查上游通知载荷与映射问题。
- 保持 providerId/envLabel 的原有回退匹配逻辑不变，最小化改动范围。