### PR TITLE
fix(history): 修复历史详情本地路径MD缺少行号后缀

### DIFF
--- a/web/src/features/history/renderers/history-markdown.test.ts
+++ b/web/src/features/history/renderers/history-markdown.test.ts
@@ -2,7 +2,11 @@
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
 import { describe, expect, it } from "vitest";
-import { resolveHistoryLocalPathLink } from "./history-markdown";
+import {
+  formatHistoryLocalPathPositionSuffix,
+  resolveHistoryLocalPathLink,
+  shouldAppendHistoryLocalPathPositionSuffix,
+} from "./history-markdown";
 
 describe("resolveHistoryLocalPathLink", () => {
   it("支持解析 WSL 绝对路径并移除行号", () => {
@@ -57,5 +61,37 @@ describe("resolveHistoryLocalPathLink", () => {
 
   it("非本地路径链接返回 null", () => {
     expect(resolveHistoryLocalPathLink("https://example.com/docs")).toBeNull();
+  });
+});
+
+describe("formatHistoryLocalPathPositionSuffix", () => {
+  it("line+column 时返回 :line:column", () => {
+    expect(formatHistoryLocalPathPositionSuffix({ line: 205, column: 3 })).toBe(":205:3");
+  });
+
+  it("仅 line 时返回 :line", () => {
+    expect(formatHistoryLocalPathPositionSuffix({ line: 205, column: undefined })).toBe(":205");
+  });
+
+  it("无效 line 时返回空字符串", () => {
+    expect(formatHistoryLocalPathPositionSuffix({ line: undefined, column: 5 })).toBe("");
+  });
+});
+
+describe("shouldAppendHistoryLocalPathPositionSuffix", () => {
+  it("链接文本未包含行号时应追加后缀", () => {
+    expect(shouldAppendHistoryLocalPathPositionSuffix("accountStorage.ts", { line: 205, column: undefined })).toBe(true);
+  });
+
+  it("链接文本已包含 :line 时不应重复追加", () => {
+    expect(shouldAppendHistoryLocalPathPositionSuffix("accountStorage.ts:205", { line: 205, column: undefined })).toBe(false);
+  });
+
+  it("链接文本已包含 #Lline 时不应重复追加", () => {
+    expect(shouldAppendHistoryLocalPathPositionSuffix("accountStorage.ts#L205", { line: 205, column: undefined })).toBe(false);
+  });
+
+  it("链接文本已包含相同行号（无列号）时，不应因链接含列号而重复追加", () => {
+    expect(shouldAppendHistoryLocalPathPositionSuffix("accountStorage.ts:205", { line: 205, column: 3 })).toBe(false);
   });
 });

--- a/web/src/features/history/renderers/history-markdown.tsx
+++ b/web/src/features/history/renderers/history-markdown.tsx
@@ -344,6 +344,53 @@ export function resolveHistoryLocalPathLink(href: string | null | undefined): Re
 }
 
 /**
+ * 中文说明：将“行/列”信息格式化为 `:line[:column]` 文本后缀。
+ */
+export function formatHistoryLocalPathPositionSuffix(link: Pick<ResolvedHistoryLocalLink, "line" | "column"> | null | undefined): string {
+  const line = typeof link?.line === "number" && link.line > 0 ? Math.floor(link.line) : 0;
+  const column = typeof link?.column === "number" && link.column > 0 ? Math.floor(link.column) : 0;
+  if (!line) return "";
+  if (!column) return `:${line}`;
+  return `:${line}:${column}`;
+}
+
+/**
+ * 中文说明：判断链接文本是否需要追加 `:line[:column]` 后缀，避免重复展示行号。
+ */
+export function shouldAppendHistoryLocalPathPositionSuffix(
+  labelText: string,
+  link: Pick<ResolvedHistoryLocalLink, "line" | "column"> | null | undefined,
+): boolean {
+  const suffix = formatHistoryLocalPathPositionSuffix(link);
+  if (!suffix) return false;
+
+  const compact = String(labelText || "").replace(/\s+/g, "");
+  if (!compact) return false;
+  if (compact.endsWith(suffix)) return false;
+
+  const line = typeof link?.line === "number" && link.line > 0 ? Math.floor(link.line) : 0;
+  if (!line) return false;
+
+  const suffixPattern = new RegExp(`(?:#L${line}(?:C\\d+)?|:${line}(?::\\d+)?)$`, "i");
+  if (suffixPattern.test(compact)) return false;
+  return true;
+}
+
+/**
+ * 中文说明：提取 React 子节点中的纯文本，用于判断链接文本是否已包含行号信息。
+ */
+function extractPlainTextFromReactNode(node: React.ReactNode): string {
+  if (node === null || node === undefined || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map((it) => extractPlainTextFromReactNode(it)).join("");
+  if (React.isValidElement(node)) {
+    const child = (node.props as { children?: React.ReactNode } | null | undefined)?.children;
+    return extractPlainTextFromReactNode(child);
+  }
+  return "";
+}
+
+/**
  * 中文说明：归一化内置 IDE 标识，非法时返回 null。
  */
 function normalizeHistoryBuiltinIdeId(raw: unknown): HistoryBuiltinIdeId | null {
@@ -464,9 +511,15 @@ async function openHistoryLocalPath(link: ResolvedHistoryLocalLink, projectRootP
  * 中文说明：Markdown 链接渲染，默认走 Host API 打开外部链接，避免在 Electron 内部直接跳转。
  */
 function MarkdownLink(props: MarkdownAnchorProps) {
-  const { href, onClick, onContextMenu, ...rest } = props;
+  const { href, onClick, onContextMenu, children, ...rest } = props;
   const { t } = useTranslation(["history"]);
   const localLink = useMemo(() => resolveHistoryLocalPathLink(String(href || "")), [href]);
+  const labelText = useMemo(() => extractPlainTextFromReactNode(children), [children]);
+  const positionSuffix = useMemo(() => formatHistoryLocalPathPositionSuffix(localLink), [localLink]);
+  const shouldAppendPositionSuffix = useMemo(
+    () => shouldAppendHistoryLocalPathPositionSuffix(labelText, localLink),
+    [labelText, localLink],
+  );
   const menuCtx = useContext(HistoryMarkdownLinkMenuContext);
   return (
     <a
@@ -507,7 +560,10 @@ function MarkdownLink(props: MarkdownAnchorProps) {
           }
         } catch {}
       }}
-    />
+    >
+      {children}
+      {shouldAppendPositionSuffix ? positionSuffix : null}
+    </a>
   );
 }
 


### PR DESCRIPTION
技术变更：
- 在 `history-markdown.tsx` 中新增路径位置后缀能力：
  - `formatHistoryLocalPathPositionSuffix`：统一格式化 `:line[:column]`。
  - `shouldAppendHistoryLocalPathPositionSuffix`：仅在链接文案未包含同一行号信息时才追加后缀。
  - `extractPlainTextFromReactNode`：提取链接子节点文本用于去重判断。
- 调整 `MarkdownLink` 渲染逻辑，保留原有点击/右键行为的同时，在本地文件链接文案后按需追加行号后缀。
- 修复边界场景：当链接已含相同行号（如 `:205` 或 `#L205`）且目标链接包含列号时，不再重复追加，避免出现 `:205:205:3` 这类重复展示。
- 在 `history-markdown.test.ts` 补充后缀格式化与去重判断测试，新增“已含相同行号且链接带列号”的回归用例。

产品影响：
- 历史记录中的本地文件链接在未显式展示行号时会自动补齐，定位意图更清晰。
- 已包含行号信息的链接不会出现重复数字后缀，阅读体验更稳定一致。
- 仅变更展示层，不改变“复制路径”“打开文件/定位行列”的现有交互链路。