### PR TITLE
fix(notifications): 修复重复通知

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -170,6 +170,7 @@ import {
   normDir,
   normalizeCompletionPrefs,
   normalizeCompletionPreview,
+  normalizeCompletionPreviewForDedupe,
   normalizeDirTreeStore,
   normalizeMsToIso,
   normalizeResumeMode,
@@ -1160,7 +1161,7 @@ export default function CodexFlowManagerUI() {
   const autoCommitQueueByProjectIdRef = useRef<Record<string, Promise<void>>>({});
   const RESUME_COMPLETION_GUARD_MS = 8_000;
   const COMPLETION_DEDUPE_WINDOW_MS = 1_600;
-  const COMPLETION_CROSS_SOURCE_WINDOW_MS = 450;
+  const COMPLETION_CROSS_SOURCE_WINDOW_MS = 5_000;
 
   useEffect(() => { editingTabIdRef.current = editingTabId; }, [editingTabId]);
   useEffect(() => { notificationPrefsRef.current = notificationPrefs; }, [notificationPrefs]);
@@ -1823,8 +1824,8 @@ export default function CodexFlowManagerUI() {
    * - 兼容“一个是另一个前缀”的截断差异（例如 OSC 截断 vs hook 完整预览）。
    */
   function isEquivalentCompletionPreview(leftRaw: string, rightRaw: string): boolean {
-    const left = normalizeCompletionPreview(leftRaw);
-    const right = normalizeCompletionPreview(rightRaw);
+    const left = normalizeCompletionPreviewForDedupe(leftRaw);
+    const right = normalizeCompletionPreviewForDedupe(rightRaw);
     if (!left && !right) return true;
     if (!left || !right) return false;
     if (left === right) return true;
@@ -1849,8 +1850,11 @@ export default function CodexFlowManagerUI() {
     const last = completionSnapshotRef.current[safeId];
     if (!last) return false;
     const delta = Date.now() - last.ts;
-    if (!(delta >= 0 && delta <= windowMs)) return false;
-    if (isEquivalentCompletionPreview(String(last.preview || ""), String(preview || ""))) return true;
+    if (delta < 0) return false;
+    if (
+      delta <= windowMs &&
+      isEquivalentCompletionPreview(String(last.preview || ""), String(preview || ""))
+    ) return true;
     const currentSource = source || "unknown";
     const crossSource =
       (last.source === "osc" && currentSource === "external") ||

--- a/web/src/app/app-shared.notify.test.ts
+++ b/web/src/app/app-shared.notify.test.ts
@@ -5,6 +5,7 @@ import {
   GEMINI_NOTIFY_ENV_KEYS,
   buildProviderNotifyEnv,
   isAgentCompletionMessage,
+  normalizeCompletionPreviewForDedupe,
 } from "./app-shared";
 
 describe("app-shared（完成通知：识别与环境变量注入）", () => {
@@ -16,6 +17,18 @@ describe("app-shared（完成通知：识别与环境变量注入）", () => {
   it("isAgentCompletionMessage：过滤非完成类通知（approval requested / codex wants to edit）", () => {
     expect(isAgentCompletionMessage("Approval requested: run rm -rf")).toBe(false);
     expect(isAgentCompletionMessage("codex wants to edit foo.ts")).toBe(false);
+  });
+
+  it("normalizeCompletionPreviewForDedupe：统一空白并清理前缀", () => {
+    expect(normalizeCompletionPreviewForDedupe(" agent-turn-complete:\n已完成\t任务   输出 ")).toBe("已完成 任务 输出");
+  });
+
+  it("normalizeCompletionPreviewForDedupe：兼容字面量转义空白", () => {
+    expect(normalizeCompletionPreviewForDedupe("agent-turn-complete: 已完成\\n- 位置： [accountStore.ts]")).toBe("已完成 - 位置： [accountStore.ts]");
+  });
+
+  it("normalizeCompletionPreviewForDedupe：不误伤 Windows 路径中的反斜杠片段", () => {
+    expect(normalizeCompletionPreviewForDedupe("agent-turn-complete: 已完成 C:\\new\\temp\\task.md")).toBe("已完成 C:\\new\\temp\\task.md");
   });
 
   it("buildProviderNotifyEnv：Gemini 注入 GEMINI_CLI_CODEXFLOW_*", () => {
@@ -49,4 +62,3 @@ describe("app-shared（完成通知：识别与环境变量注入）", () => {
     expect(buildProviderNotifyEnv("tab-3", "terminal", "Ubuntu-24.04")).toEqual({});
   });
 });
-

--- a/web/src/app/app-shared.tsx
+++ b/web/src/app/app-shared.tsx
@@ -1502,6 +1502,23 @@ function normalizeCompletionPreview(raw: string): string {
   return text.replace(/^agent-turn-complete\s*[:：]?\s*/i, "").trim();
 }
 
+/**
+ * 中文说明：生成用于“完成事件去重”的预览指纹。
+ * - 先复用 `normalizeCompletionPreview` 去掉统一前缀；
+ * - 将“分隔符语义”的字面量转义空白（如 `\n`/`\t`/`\r`）归一为空格，兼容 JSONL 与 OSC 之间的编码差异；
+ *   同时避免误伤 Windows 路径中的 `\n` / `\t` 片段（例如 `C:\new\temp`）；
+ * - 再将连续空白折叠为单空格，减少格式差异造成的误判。
+ */
+function normalizeCompletionPreviewForDedupe(raw: string): string {
+  const normalized = normalizeCompletionPreview(raw);
+  if (!normalized) return "";
+  const normalizedLiteralWhitespace = normalized.replace(
+    /(^|[^A-Za-z0-9_])\\[rnt](?=$|[^A-Za-z0-9_])/g,
+    (_match, prefix: string) => `${prefix} `,
+  );
+  return normalizedLiteralWhitespace.replace(/\s+/g, " ").trim();
+}
+
 // 筛选键规范化：将等价的 tags 与 type 统一到一个"规范键"，用于去重显示与匹配
 function canonicalFilterKey(k?: string): string {
   try {
@@ -1763,6 +1780,7 @@ export {
   normalizeCompletionPrefs,
   isAgentCompletionMessage,
   normalizeCompletionPreview,
+  normalizeCompletionPreviewForDedupe,
   canonicalFilterKey,
   keysOfItemCanonical,
   StatusDot,


### PR DESCRIPTION
技术变更：
- 将完成事件跨来源防重窗口从 450ms 调整为 5000ms，覆盖 JSONL/OSC 到达时序抖动场景。
- 去重比较改为使用 normalizeCompletionPreviewForDedupe，对前缀、字面量转义空白与连续空白做统一归一化。
- 修复归一化误伤风险：仅替换具备“分隔符语义”的 \n/\t/\r，避免破坏 Windows 路径片段（如 C:\new\temp）。
- 新增对应单测，覆盖空白归一化、字面量转义兼容与 Windows 路径保护。

产品价值：
- 降低同一轮完成事件因多来源重复上报导致的重复通知。
- 提升跨平台（尤其含 Windows 路径文本）通知去重稳定性，避免误判导致的体验波动。