### PR TITLE
fix(worktree): 删除/重置 worktree 时如有终端，改为提醒

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -830,6 +830,7 @@ export default function CodexFlowManagerUI() {
   const worktreeDeleteInFlightByProjectIdRef = useRef<Record<string, boolean>>({});
   const [worktreeDeleteInFlightByProjectId, setWorktreeDeleteInFlightByProjectId] = useState<Record<string, boolean>>({});
   const [worktreeBlockedDialog, setWorktreeBlockedDialog] = useState<{ open: boolean; count: number }>(() => ({ open: false, count: 0 }));
+  const worktreeBlockedDialogResolverRef = useRef<((proceed: boolean) => void) | null>(null);
   const [worktreeRecycleTerminalAgentsDialog, setWorktreeRecycleTerminalAgentsDialog] = useState<{ open: boolean; count: number }>(() => ({ open: false, count: 0 }));
   const worktreeRecycleTerminalAgentsDialogResolverRef = useRef<((proceed: boolean) => void) | null>(null);
   const [baseWorktreeDirtyDialog, setBaseWorktreeDirtyDialog] = useState<BaseWorktreeDirtyDialogState>(() => ({ open: false, repoMainPath: "" }));
@@ -5512,15 +5513,36 @@ export default function CodexFlowManagerUI() {
   }, []);
 
   /**
-   * 中文说明：若当前项目仍存在终端代理，则拦截 worktree 删除/重置，并提示用户先关闭终端代理。
+   * 中文说明：关闭“删除/重置前终端代理提醒”弹窗，并将用户选择回写给等待中的 Promise。
    */
-  const guardWorktreeDeleteAndResetByTerminalAgents = useCallback((project: Project): boolean => {
+  const resolveWorktreeDeleteResetTerminalAgentsConfirm = useCallback((proceed: boolean) => {
+    const resolver = worktreeBlockedDialogResolverRef.current;
+    worktreeBlockedDialogResolverRef.current = null;
+    setWorktreeBlockedDialog((prev) => ({ ...prev, open: false }));
+    if (resolver) resolver(proceed);
+  }, []);
+
+  /**
+   * 中文说明：若当前项目仍存在终端代理，则在“删除/重置 worktree”前弹出提醒（取消/继续）。
+   * @returns 用户是否选择继续删除/重置
+   */
+  const confirmWorktreeDeleteAndResetByTerminalAgents = useCallback(async (project: Project): Promise<boolean> => {
     const pid = String(project?.id || "").trim();
     if (!pid) return false;
     const runningCount = countRunningTerminalAgentsByProjectId(pid);
     if (runningCount <= 0) return true;
-    setWorktreeBlockedDialog({ open: true, count: runningCount });
-    return false;
+
+    // 若上一次确认尚未返回，默认取消，避免悬挂 Promise。
+    const prev = worktreeBlockedDialogResolverRef.current;
+    if (prev) {
+      try { prev(false); } catch {}
+      worktreeBlockedDialogResolverRef.current = null;
+    }
+
+    return await new Promise<boolean>((resolve) => {
+      worktreeBlockedDialogResolverRef.current = resolve;
+      setWorktreeBlockedDialog({ open: true, count: runningCount });
+    });
   }, [countRunningTerminalAgentsByProjectId]);
 
   /**
@@ -6178,7 +6200,7 @@ export default function CodexFlowManagerUI() {
   /**
    * 打开“删除 worktree / 对齐到主工作区”对话框。
    */
-		  const openWorktreeDeleteDialog = useCallback((project: Project, afterRecycle?: boolean, action?: "delete" | "reset", afterRecycleHint?: string) => {
+		  const openWorktreeDeleteDialog = useCallback(async (project: Project, afterRecycle?: boolean, action?: "delete" | "reset", afterRecycleHint?: string) => {
 		    const pid = String(project?.id || "").trim();
 		    if (!pid) return;
 
@@ -6199,7 +6221,7 @@ export default function CodexFlowManagerUI() {
 		      });
 		      return;
 		    }
-		    if (!guardWorktreeDeleteAndResetByTerminalAgents(project)) return;
+		    if (!(await confirmWorktreeDeleteAndResetByTerminalAgents(project))) return;
 		    if (worktreeDeleteInFlightByProjectIdRef.current[pid]) {
 		      setNoticeDialog({
 		        open: true,
@@ -6228,7 +6250,7 @@ export default function CodexFlowManagerUI() {
 	      error: undefined,
 	    });
 	    void refreshWorktreeDeleteAlignedState(project);
-	  }, [guardWorktreeDeleteAndResetByTerminalAgents, refreshWorktreeDeleteAlignedState, resolveWorktreeDeletePrefsKey, t]);
+	  }, [confirmWorktreeDeleteAndResetByTerminalAgents, refreshWorktreeDeleteAlignedState, resolveWorktreeDeletePrefsKey, t]);
 
   /**
    * 关闭“删除 worktree / 对齐到主工作区”对话框。
@@ -6271,8 +6293,6 @@ export default function CodexFlowManagerUI() {
 		      });
 	      return;
 	    }
-	    if (!guardWorktreeDeleteAndResetByTerminalAgents(project)) return;
-
 	    // 防重复：即使用户关闭弹窗后再次打开，也不允许重复触发同一 worktree 的删除
 	    if (worktreeDeleteInFlightByProjectIdRef.current[String(project.id || "").trim()]) {
       setNoticeDialog({
@@ -6345,7 +6365,7 @@ export default function CodexFlowManagerUI() {
     } finally {
       setWorktreeDeleteInFlight(project.id, false);
     }
-  }, [guardWorktreeDeleteAndResetByTerminalAgents, refreshGitInfoForProjectIds, setWorktreeDeleteInFlight, showGitActionErrorDialog, t, worktreeDeleteDialog]);
+  }, [refreshGitInfoForProjectIds, setWorktreeDeleteInFlight, showGitActionErrorDialog, t, worktreeDeleteDialog]);
 
 	  /**
 	   * 若当前项目满足“worktree 自动提交”条件，则将一次自动提交加入队列（同一项目串行执行，避免 git lock 冲突）。
@@ -6575,7 +6595,7 @@ export default function CodexFlowManagerUI() {
         if (key === "d" || isHistoryDeleteKey) {
           if (canDeleteWorktree) {
             event.preventDefault();
-            openWorktreeDeleteDialog(project, false);
+            void openWorktreeDeleteDialog(project, false);
             hoveredProjectShortcutRef.current = null;
             return;
           }
@@ -10222,7 +10242,7 @@ export default function CodexFlowManagerUI() {
                     className="h-8 text-xs"
                     onClick={() => {
                       close();
-                      openWorktreeDeleteDialog(project, true, "reset", hint);
+                      void openWorktreeDeleteDialog(project, true, "reset", hint);
                     }}
                   >
 	                    {t("projects:worktreePostRecycleActionReset", "重置为主 worktree 状态") as string}
@@ -10233,7 +10253,7 @@ export default function CodexFlowManagerUI() {
                     className="h-8 text-xs"
                     onClick={() => {
                       close();
-                      openWorktreeDeleteDialog(project, true, "delete", hint);
+                      void openWorktreeDeleteDialog(project, true, "delete", hint);
                     }}
                   >
                     {t("projects:worktreePostRecycleActionDelete", "删除该子 worktree") as string}
@@ -10277,23 +10297,27 @@ export default function CodexFlowManagerUI() {
       <Dialog
         open={worktreeBlockedDialog.open}
         onOpenChange={(open) => {
-          if (!open) setWorktreeBlockedDialog((prev) => ({ ...prev, open: false }));
+          if (open) return;
+          resolveWorktreeDeleteResetTerminalAgentsConfirm(false);
         }}
       >
         <DialogContent className="max-w-md">
           <DialogHeader>
-            <DialogTitle>{t("projects:worktreeActionBlockedTitle", "操作不可用") as string}</DialogTitle>
+            <DialogTitle>{t("projects:worktreeDeleteResetTerminalAgentsTitle", "检测到终端代理仍在运行") as string}</DialogTitle>
             <DialogDescription>
               {t(
-                "projects:worktreeActionBlockedByTerminals",
-                "当前项目存在 {count} 个终端代理，删除/重置 worktree 功能不可用。请关闭所有终端代理再尝试。",
+                "projects:worktreeDeleteResetTerminalAgentsDesc",
+                "当前项目存在 {count} 个终端代理仍在运行。继续删除/重置 worktree 可能影响正在执行的任务。是否继续？",
                 { count: worktreeBlockedDialog.count }
               ) as string}
             </DialogDescription>
           </DialogHeader>
           <div className="flex justify-end gap-2 pt-2">
-            <Button variant="outline" onClick={() => setWorktreeBlockedDialog((prev) => ({ ...prev, open: false }))}>
-              {t("common:close", "关闭") as string}
+            <Button variant="outline" onClick={() => resolveWorktreeDeleteResetTerminalAgentsConfirm(false)}>
+              {t("common:cancel", "取消") as string}
+            </Button>
+            <Button variant="secondary" onClick={() => resolveWorktreeDeleteResetTerminalAgentsConfirm(true)}>
+              {t("common:continue", "继续") as string}
             </Button>
           </div>
         </DialogContent>

--- a/web/src/locales/en/projects.json
+++ b/web/src/locales/en/projects.json
@@ -38,6 +38,8 @@
   "worktreeDelete": "Delete worktree",
   "worktreeActionBlockedTitle": "Action Unavailable",
   "worktreeActionBlockedByTerminals": "Deleting or resetting the worktree is unavailable because the current project has {count} terminal agent(s) running. Close all terminal agents and try again.",
+  "worktreeDeleteResetTerminalAgentsTitle": "Terminal agent(s) still running",
+  "worktreeDeleteResetTerminalAgentsDesc": "Detected {count} terminal agent(s) still running in this project. Continuing to delete/reset the worktree may affect running tasks/processes. Continue?",
   "worktreeRecycleTerminalAgentsTitle": "Terminal agent(s) still running",
   "worktreeRecycleTerminalAgentsDesc": "Detected {count} terminal agent(s) still running in this project. Continuing the merge may affect running tasks/processes. Continue?",
   "worktreeCreateDisabledChild": "This node is already a child; cannot create a worktree (max depth: 1).",

--- a/web/src/locales/zh/projects.json
+++ b/web/src/locales/zh/projects.json
@@ -38,6 +38,8 @@
   "worktreeDelete": "删除工作区",
   "worktreeActionBlockedTitle": "操作不可用",
   "worktreeActionBlockedByTerminals": "当前项目存在 {count} 个终端代理，删除/重置 worktree 功能不可用。请关闭所有终端代理再尝试。",
+  "worktreeDeleteResetTerminalAgentsTitle": "检测到终端代理仍在运行",
+  "worktreeDeleteResetTerminalAgentsDesc": "当前项目存在 {count} 个终端代理仍在运行。继续删除/重置 worktree 可能影响正在执行的任务。是否继续？",
   "worktreeRecycleTerminalAgentsTitle": "终端代理仍在运行",
   "worktreeRecycleTerminalAgentsDesc": "检测到当前项目存在 {count} 个终端代理仍在运行。继续合并可能影响正在运行的任务/进程。是否继续？",
   "worktreeCreateDisabledChild": "该节点已为子级，无法再创建 worktree（层级至多一级）",


### PR DESCRIPTION
产品层面：
- 删除/重置 worktree 时，不再直接“不可用”拦截。
- 当检测到终端代理仍在运行时，改为弹出“取消/继续”确认，允许用户按风险自行决策。

技术层面：
- 将删除/重置前的终端占用检查升级为基于 Promise 的异步确认流程。
- 新增确认弹窗 resolver 引用，保证并发触发时不会产生悬挂 Promise。
- openWorktreeDeleteDialog 改为 async，并在所有触发点使用 void 调用以显式忽略返回 Promise。
- 新增并接入中英文 i18n 文案键：
  - projects.worktreeDeleteResetTerminalAgentsTitle
  - projects.worktreeDeleteResetTerminalAgentsDesc