### PR TITLE
fix(projects): 折叠目录时蓝点提示子项目活动状态

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6797,8 +6797,24 @@ export default function CodexFlowManagerUI() {
             const p = row.project;
             const depth = row.depth;
             const tabsInProject = tabsByProject[p.id] || [];
-            const liveCount = tabsInProject.filter((tab) => !!ptyAlive[tab.id]).length;
-            const pendingCount = pendingByProject[p.id] ?? 0;
+            const ownLiveCount = tabsInProject.filter((tab) => !!ptyAlive[tab.id]).length;
+            const ownPendingCount = pendingByProject[p.id] ?? 0;
+            const hasChildren = depth === 0 && hasDirChildren(p.id);
+            const expanded = hasChildren && dirTreeStore.expandedById[p.id] !== false;
+
+            let childLiveCount = 0;
+            let childPendingCount = 0;
+            if (depth === 0 && !expanded) {
+              const childIds = dirTreeStore.childOrderByParent[p.id] || [];
+              for (const childId of childIds) {
+                const childTabs = tabsByProject[childId] || [];
+                childLiveCount += childTabs.filter((tab) => !!ptyAlive[tab.id]).length;
+                childPendingCount += pendingByProject[childId] ?? 0;
+              }
+            }
+            const hasActiveChild = childLiveCount > 0 || childPendingCount > 0;
+            const liveCount = ownLiveCount;
+            const pendingCount = ownPendingCount;
             const isHidden = hiddenProjectIdSet.has(p.id);
             const git = gitInfoByProjectId[p.id];
             const exists = git ? git.exists && git.isDirectory : true;
@@ -6810,8 +6826,6 @@ export default function CodexFlowManagerUI() {
             const isWorktreeNode = !!git?.isWorktree && !!git?.isRepoRoot;
             const isSecondaryWorktree = isWorktreeNode && !isMainWorktree;
             const selected = p.id === selectedProjectId;
-            const hasChildren = depth === 0 && hasDirChildren(p.id);
-            const expanded = hasChildren && dirTreeStore.expandedById[p.id] !== false;
             const canOperateOnDir = exists;
             const canDrag = !query.trim();
             const isEditingDirLabel = dirLabelDialog.open && dirLabelDialog.projectId === p.id;
@@ -7031,15 +7045,23 @@ export default function CodexFlowManagerUI() {
                       title={t("common:notifications.openTabHint", "点击查看详情") as string}
                     ></span>
                   ) : null}
-                  {liveCount > 0 ? (
-                    <span className="ml-1 inline-flex items-center justify-center rounded-full bg-[var(--cf-accent)] text-white text-[10px] font-apple-semibold h-5 min-w-[20px] px-1 shadow-apple-xs ring-1 ring-[var(--cf-accent)]/20">
-                      {liveCount}
-                    </span>
-                  ) : null}
-                </div>
+                {liveCount > 0 ? (
+                  <span className="ml-1 inline-flex items-center justify-center rounded-full bg-[var(--cf-accent)] text-white text-[10px] font-apple-semibold h-5 min-w-[20px] px-1 shadow-apple-xs ring-1 ring-[var(--cf-accent)]/20">
+                    {liveCount}
+                  </span>
+                ) : null}
               </div>
-            );
-          })}
+
+              {/* 右上角指示器：当项目折叠且子项目有活动项时显示 */}
+              {hasActiveChild && !expanded ? (
+                <div
+                  className="absolute top-1 right-1 h-1.5 w-1.5 rounded-full bg-[var(--cf-accent)] ring-1 ring-white dark:ring-slate-900 shadow-sm animate-in fade-in zoom-in duration-300"
+                  title={t("terminal:childTerminalsActive", "子项目有活动项") as string}
+                />
+              ) : null}
+            </div>
+          );
+        })}
         </div>
       </ScrollArea>
     </div>

--- a/web/src/locales/en/terminal.json
+++ b/web/src/locales/en/terminal.json
@@ -12,6 +12,7 @@
   "collapseInput": "Exit expand",
   "readyPlaceholder": "# Terminal ready. Embedded console placeholder (UI prototype; no real PTY yet).",
   "openFailed": "Failed to start console: {error}",
+  "childTerminalsActive": "Active items in sub-projects",
   "ctx": {
     "copy": "Copy",
     "copyLine": "Copy Line",

--- a/web/src/locales/zh/terminal.json
+++ b/web/src/locales/zh/terminal.json
@@ -12,6 +12,7 @@
   "collapseInput": "退出大屏",
   "readyPlaceholder": "# 终端就绪。这里是内嵌控制台的视觉占位（UI 原型，未接真 PTY）。",
   "openFailed": "启动终端失败：{error}",
+  "childTerminalsActive": "子项目有活动项",
   "ctx": {
     "copy": "复制",
     "copyLine": "复制整行",


### PR DESCRIPTION
在项目侧栏目录树中，当一级父节点处于折叠状态时，
新增右上角活动提示点，用于提示子项目仍有运行中终端或待处理事项。
这可以减少“父节点看起来无活动”带来的误判，提升多项目并行场景下的状态可见性。

技术实现：
- 在目录行渲染阶段拆分本项目与子项目活动计数（live/pending）
- 仅在根节点且折叠状态下聚合直接子项目活动
- 保持原有本项目 live/pending 指示逻辑不变
- 新增 i18n 文案键 `terminal.childTerminalsActive`（en/zh）