### PR TITLE
fix(projects): 搜索支持目录备注名匹配

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3416,8 +3416,12 @@ export default function CodexFlowManagerUI() {
   const filtered = useMemo(() => {
     if (!query.trim()) return sortedProjects;
     const q = query.toLowerCase();
-    return sortedProjects.filter((p) => `${p.name} ${p.winPath}`.toLowerCase().includes(q));
-  }, [sortedProjects, query]);
+    return sortedProjects.filter((p) => {
+      const id = String(p?.id || "").trim();
+      const label = id ? String(dirTreeStore.labelById?.[id] || "") : "";
+      return `${p.name} ${p.winPath} ${label}`.toLowerCase().includes(q);
+    });
+  }, [dirTreeStore.labelById, sortedProjects, query]);
 
   const tabsForProject = tabsByProject[selectedProjectId] || [];
   const activeTab = useMemo(() => tabsForProject.find((tab) => tab.id === activeTabId) || null, [tabsForProject, activeTabId]);


### PR DESCRIPTION
产品层面：
- 项目侧栏搜索框现在会匹配目录备注名（重命名显示名），用户可直接通过备注快速定位项目。

技术层面：
- 调整 `web/src/App.tsx` 中 `filtered` 的过滤条件，将 `dirTreeStore.labelById[projectId]` 纳入匹配字段。
- 为 `filtered` 的 `useMemo` 增加 `dirTreeStore.labelById` 依赖，确保备注名变更后搜索结果即时更新。
- 保持原有匹配语义（不区分大小写、空查询返回全部排序结果）不变。

影响范围：
- 仅影响项目列表搜索匹配逻辑，不改变目录树结构、项目排序、选择态与运行态行为。