### PR TITLE
chore(app): 优化通知角标视觉样式与层级

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7045,12 +7045,12 @@ export default function CodexFlowManagerUI() {
 
                   {pendingCount > 0 ? (
                     <span
-                      className="ml-1 inline-flex h-2 w-2 rounded-full bg-red-500 dark:bg-[var(--cf-red)] dark:shadow-sm"
+                      className="ml-1 inline-flex h-2.5 w-2.5 rounded-full bg-[var(--cf-red)] ring-2 ring-white dark:ring-slate-900 shadow-md transition-transform"
                       title={t("common:notifications.openTabHint", "点击查看详情") as string}
                     ></span>
                   ) : null}
                 {liveCount > 0 ? (
-                  <span className="ml-1 inline-flex items-center justify-center rounded-full bg-[var(--cf-accent)] text-white text-[10px] font-apple-semibold h-5 min-w-[20px] px-1 shadow-apple-xs ring-1 ring-[var(--cf-accent)]/20">
+                  <span className="ml-1 inline-flex items-center justify-center rounded-full bg-[var(--cf-accent)] text-white text-[10px] font-bold h-[18px] min-w-[20px] px-1.5 shadow-apple-sm ring-1 ring-white/10">
                     {liveCount}
                   </span>
                 ) : null}
@@ -7059,7 +7059,7 @@ export default function CodexFlowManagerUI() {
               {/* 右上角指示器：当项目折叠且子项目有活动项时显示 */}
               {hasActiveChild && !expanded ? (
                 <div
-                  className="absolute top-1 right-1 h-1.5 w-1.5 rounded-full bg-[var(--cf-accent)] ring-1 ring-white dark:ring-slate-900 shadow-sm animate-in fade-in zoom-in duration-300"
+                  className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-[var(--cf-accent)] ring-2 ring-white dark:ring-slate-900 shadow-md animate-in fade-in zoom-in duration-300"
                   title={t("terminal:childTerminalsActive", "子项目有活动项") as string}
                 />
               ) : null}
@@ -7241,7 +7241,7 @@ export default function CodexFlowManagerUI() {
                         <span id={`tab-label-${tab.id}`} className="truncate max-w-[8rem]">{tab.name}</span>
                         {hasPending ? (
                           <span
-                            className="inline-flex h-2 w-2 rounded-full bg-red-500 dark:bg-[var(--cf-red)] dark:shadow-sm"
+                            className="ml-0.5 inline-flex h-2 w-2 rounded-full bg-[var(--cf-red)] ring-2 ring-white dark:ring-slate-950 shadow-sm"
                             title={t('common:notifications.openTabHint', '点击查看详情') as string}
                           ></span>
                         ) : null}


### PR DESCRIPTION
- 调整项目列表待处理角标的尺寸、描边与阴影，提升浅色/深色主题识别度
- 调整运行中数量徽标的字体权重与尺寸，改善小尺寸下数字可读性
- 调整折叠项目子活动角标的位置与视觉权重，降低与内容区混淆
- 调整标签页待处理角标样式，与项目列表视觉语言保持一致

技术说明：
- 仅修改 web/src/App.tsx 中 4 处 className，不涉及状态流与业务逻辑
- 提交前修复混合行尾导致的整文件噪音，最终差异收敛为最小改动