### PR TITLE
fix(gemini): 修复 Gemini 新版目录结构下历史会话不显示的问题

### DIFF
--- a/electron/agentSessions/gemini/discovery.test.ts
+++ b/electron/agentSessions/gemini/discovery.test.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { discoverGeminiSessionFiles } from "./discovery";
+
+/**
+ * 在临时目录中创建文件（自动创建父目录）。
+ *
+ * @param root 临时根目录
+ * @param relPath 相对路径
+ */
+async function touch(root: string, relPath: string): Promise<void> {
+  const fp = path.join(root, relPath);
+  await fs.promises.mkdir(path.dirname(fp), { recursive: true });
+  await fs.promises.writeFile(fp, "{}", "utf8");
+}
+
+describe("discoverGeminiSessionFiles", () => {
+  it("supports both hash and non-hash project directories", async () => {
+    const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codexflow-gemini-discovery-"));
+
+    await touch(root, "codexflow/chats/session-2026-03-04T17-09-cc28c19a.json");
+    await touch(root, "567266847957ce43ba0e98d21b65cf333047f193f52e511da7be4fcbf53e53ba/chats/session-2026-03-04T17-10-aabbccdd.json");
+    await touch(root, "codexflow/chats/ignore.txt");
+
+    const files = await discoverGeminiSessionFiles(root);
+    const rel = files.map((f) => path.relative(root, f).replace(/\\/g, "/")).sort();
+
+    expect(rel).toContain("codexflow/chats/session-2026-03-04T17-09-cc28c19a.json");
+    expect(rel).toContain("567266847957ce43ba0e98d21b65cf333047f193f52e511da7be4fcbf53e53ba/chats/session-2026-03-04T17-10-aabbccdd.json");
+    expect(rel.find((x) => x.endsWith("ignore.txt"))).toBeUndefined();
+  });
+});
+

--- a/electron/agentSessions/gemini/discovery.ts
+++ b/electron/agentSessions/gemini/discovery.ts
@@ -78,8 +78,11 @@ export async function getGeminiRootCandidatesFastAsync(): Promise<SessionsRootCa
 
 /**
  * 扫描 Gemini CLI 会话文件：
- * - 目录结构：`root/<projectHash>/chats/session-*.json`（优先）
- * - 兼容：`root/<projectHash>/session-*.json`
+ * - 目录结构：`root/<projectKey>/chats/session-*.json`（优先）
+ * - 兼容：`root/<projectKey>/session-*.json`
+ *
+ * 说明：
+ * - `projectKey` 既可能是旧版 `projectHash`（32~64 hex），也可能是新版可读目录名（如项目名）。
  */
 export async function discoverGeminiSessionFiles(root: string): Promise<string[]> {
   const out: string[] = [];
@@ -93,8 +96,6 @@ export async function discoverGeminiSessionFiles(root: string): Promise<string[]
       if (!ent.isDirectory()) continue;
       const name = ent.name;
       if (!name) continue;
-      // 过滤：Gemini 项目目录通常是 hash（32~64 hex）
-      if (!(name.length >= 32 && name.length <= 64 && /^[0-9a-fA-F]+$/.test(name))) continue;
       const projDir = path.join(baseRoot, name);
 
       // chats/session-*.json

--- a/electron/agentSessions/gemini/parser.test.ts
+++ b/electron/agentSessions/gemini/parser.test.ts
@@ -18,6 +18,21 @@ async function writeTempJson(obj: unknown, filename = `gemini-${Date.now()}-${Ma
   return fp;
 }
 
+/**
+ * 在临时目录的指定相对路径写入 JSON 文件并返回文件路径。
+ *
+ * @param obj 需要写入的 JSON 对象
+ * @param relPath 相对临时目录的目标路径
+ * @returns 临时文件路径
+ */
+async function writeTempJsonAtRelPath(obj: unknown, relPath: string): Promise<string> {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codexflow-gemini-"));
+  const fp = path.join(dir, relPath);
+  await fs.promises.mkdir(path.dirname(fp), { recursive: true });
+  await fs.promises.writeFile(fp, JSON.stringify(obj), "utf8");
+  return fp;
+}
+
 describe("parseGeminiSessionFile（超大文件 summaryOnly 预览兜底）", () => {
   it("当文件超过 maxBytes 时仍能从前缀提取 preview/sessionId/rawDate", async () => {
     const sessionId = "d3862d4d-7d74-46c4-9858-45cf754919ca";
@@ -61,6 +76,29 @@ describe("parseGeminiSessionFile（超大文件 summaryOnly 预览兜底）", ()
     expect(details.resumeId).toBe(sessionId);
     expect(details.rawDate).toBe(lastUpdated);
     expect(details.messages.length).toBe(0);
+  });
+
+  it("当路径不含 hash 目录时，仍可从 JSON 头部提取 projectHash", async () => {
+    const projectHash = "567266847957ce43ba0e98d21b65cf333047f193f52e511da7be4fcbf53e53ba";
+    const fp = await writeTempJsonAtRelPath(
+      {
+        sessionId: "cc28c19a-73b0-470a-b8cf-738ec6a547a8",
+        projectHash,
+        startTime: "2026-03-04T17:09:47.101Z",
+        lastUpdated: "2026-03-04T17:09:55.680Z",
+        messages: [
+          { type: "user", content: [{ text: "hello gemini" }] },
+          { type: "gemini", content: "你好！" },
+        ],
+      },
+      `codexflow/chats/session-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
+    );
+    const stat = await fs.promises.stat(fp);
+    const details = await parseGeminiSessionFile(fp, stat, { summaryOnly: true, maxBytes: 128 * 1024 });
+
+    expect(details.projectHash).toBe(projectHash);
+    expect(details.preview).toBe("hello gemini");
+    expect(details.resumeId).toBe("cc28c19a-73b0-470a-b8cf-738ec6a547a8");
   });
 });
 

--- a/electron/agentSessions/gemini/parser.ts
+++ b/electron/agentSessions/gemini/parser.ts
@@ -126,7 +126,7 @@ export async function parseGeminiSessionFile(filePath: string, stat: Stats, opts
   const sizeBytes = Number((stat as any)?.size ?? 0);
   let runtimeShell: RuntimeShell = detectRuntimeShell(filePath);
   const id = `gemini:${sha256Hex(filePath)}`;
-  const projectHash = extractGeminiProjectHashFromPath(filePath) || undefined;
+  let projectHash = extractGeminiProjectHashFromPath(filePath) || undefined;
 
   let rawDate: string | undefined = undefined;
   let cwd: string | undefined = undefined;
@@ -150,6 +150,7 @@ export async function parseGeminiSessionFile(filePath: string, stat: Stats, opts
       if (extracted.resumeId) resumeId = extracted.resumeId;
       if (extracted.cwd) cwd = extracted.cwd;
       if (extracted.preview) preview = extracted.preview;
+      if (!projectHash && extracted.projectHash) projectHash = extracted.projectHash;
     } catch {}
 
     // hash 校验（避免把别的项目路径误归到当前会话）
@@ -218,6 +219,10 @@ export async function parseGeminiSessionFile(filePath: string, stat: Stats, opts
   const { items, meta } = extractGeminiItemsAndMeta(any);
   rawDate = pickFirstStringOrNumberAsString(meta.lastUpdated ?? meta.startTime ?? meta.firstTS ?? meta.lastTS);
   if (typeof any?.sessionId === "string" && any.sessionId.trim()) resumeId = any.sessionId.trim();
+  if (!projectHash) {
+    const normalizedHash = normalizeGeminiProjectHash(any?.projectHash ?? any?.project_hash);
+    if (normalizedHash) projectHash = normalizedHash;
+  }
 
   // 先尝试从元信息与对象字段提取 cwd，再做 hash 校验
   cwd = tryExtractGeminiCwdFromAny(any, items) || undefined;
@@ -281,7 +286,7 @@ export async function parseGeminiSessionFile(filePath: string, stat: Stats, opts
 }
 
 type GeminiExtractedMeta = { startTime?: unknown; lastUpdated?: unknown; firstTS?: unknown; lastTS?: unknown };
-type GeminiPrefixExtracted = { rawDate?: string; cwd?: string; preview?: string; resumeId?: string };
+type GeminiPrefixExtracted = { rawDate?: string; cwd?: string; preview?: string; resumeId?: string; projectHash?: string };
 
 /**
  * 在不读取完整文件的情况下，从 Gemini 会话 JSON 的“前缀内容”中提取摘要信息：
@@ -309,6 +314,9 @@ async function extractGeminiSummaryFromJsonPrefix(filePath: string, prefixBytes:
 
     const resumeId = extractJsonStringFieldFromPrefix(head, "sessionId");
     const rawDate = extractJsonStringFieldFromPrefix(head, "lastUpdated") || extractJsonStringFieldFromPrefix(head, "startTime");
+    const projectHash = normalizeGeminiProjectHash(
+      extractJsonStringFieldFromPrefix(head, "projectHash") || extractJsonStringFieldFromPrefix(head, "project_hash"),
+    );
 
     // 预览：尽量从 messages 数组中解析出前几条 item，找到首条 user 文本。
     const preview = tryExtractGeminiPreviewFromMessagesPrefix(prefix);
@@ -325,6 +333,7 @@ async function extractGeminiSummaryFromJsonPrefix(filePath: string, prefixBytes:
       resumeId: resumeId ? String(resumeId).trim() : undefined,
       cwd: cwd ? tidyPathCandidate(cwd) : undefined,
       preview,
+      projectHash,
     };
   } catch {
     return {};
@@ -658,4 +667,20 @@ function pickFirstStringOrNumberAsString(value: unknown): string | undefined {
   if (typeof value === "string" && value.trim()) return value.trim();
   if (typeof value === "number" && isFinite(value)) return String(value);
   return undefined;
+}
+
+/**
+ * 规范化并校验 Gemini projectHash（仅接受 32~64 位十六进制）。
+ */
+function normalizeGeminiProjectHash(value: unknown): string | undefined {
+  try {
+    if (typeof value !== "string") return undefined;
+    const hash = value.trim().toLowerCase();
+    if (!hash) return undefined;
+    if (hash.length < 32 || hash.length > 64) return undefined;
+    if (!/^[0-9a-f]+$/.test(hash)) return undefined;
+    return hash;
+  } catch {
+    return undefined;
+  }
 }

--- a/electron/history.ts
+++ b/electron/history.ts
@@ -30,6 +30,7 @@ export type HistorySummary = {
   filePath: string;
   rawDate?: string;
   preview?: string;
+  projectHash?: string;
   resumeMode?: 'modern' | 'legacy' | 'unknown';
   resumeId?: string;
   runtimeShell?: RuntimeShell;

--- a/electron/indexer.ts
+++ b/electron/indexer.ts
@@ -24,7 +24,7 @@ try { chokidar = require("chokidar"); } catch {}
 
 type ProviderId = "codex" | "claude" | "gemini";
 type FileSig = { mtimeMs: number; size: number };
-type IndexSummary = HistorySummary & { providerId: ProviderId; dirKey: string };
+type IndexSummary = HistorySummary & { providerId: ProviderId; dirKey: string; projectHash?: string };
 type Details = {
   providerId: ProviderId;
   id: string;
@@ -37,6 +37,7 @@ type Details = {
   cwd?: string;
   dirKey?: string;
   preview?: string;
+  projectHash?: string;
   resumeMode?: 'modern' | 'legacy' | 'unknown';
   resumeId?: string;
   runtimeShell?: RuntimeShell;
@@ -1310,6 +1311,7 @@ export async function startHistoryIndexer(getWindow: () => BrowserWindow | null)
               rawDate: details.rawDate,
               dirKey: details.dirKey || dirKeyOf(fp),
               preview: details.preview,
+              projectHash: (details as any).projectHash,
               resumeMode: details.resumeMode,
               resumeId: details.resumeId,
               runtimeShell: details.runtimeShell && details.runtimeShell !== 'unknown' ? details.runtimeShell : detectRuntimeShell(fp),
@@ -1367,6 +1369,7 @@ export async function startHistoryIndexer(getWindow: () => BrowserWindow | null)
             rawDate: details.rawDate,
             dirKey: details.dirKey || dirKeyOf(fp),
             preview: details.preview,
+            projectHash: (details as any).projectHash,
             resumeMode: details.resumeMode,
             resumeId: details.resumeId,
             runtimeShell: details.runtimeShell && details.runtimeShell !== 'unknown' ? details.runtimeShell : detectRuntimeShell(fp),
@@ -1432,6 +1435,7 @@ export async function startHistoryIndexer(getWindow: () => BrowserWindow | null)
             rawDate: details.rawDate,
             dirKey: details.dirKey || dirKeyOf(fp),
             preview: details.preview,
+            projectHash: (details as any).projectHash,
             resumeMode: details.resumeMode,
             resumeId: details.resumeId,
             runtimeShell: details.runtimeShell && details.runtimeShell !== 'unknown' ? details.runtimeShell : detectRuntimeShell(fp),
@@ -1649,6 +1653,7 @@ export async function startHistoryIndexer(getWindow: () => BrowserWindow | null)
                 rawDate: details.rawDate,
                 dirKey: details.dirKey || dirKeyOf(fp),
                 preview: details.preview,
+                projectHash: (details as any).projectHash,
                 resumeMode: details.resumeMode,
                 resumeId: details.resumeId,
                 runtimeShell: details.runtimeShell && details.runtimeShell !== 'unknown' ? details.runtimeShell : detectRuntimeShell(fp),

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3028,7 +3028,9 @@ ipcMain.handle('history.list', async (_e, args: { projectWslPath?: string; proje
         : all.filter((s) => {
             if (needles.some((n) => startsWithBoundary(s.dirKey, n))) return true;
             if (s.providerId === 'gemini' && geminiHashNeedles.size > 0) {
-              const h = extractGeminiProjectHashFromPath(String(s.filePath || ''));
+              const hs = String((s as any)?.projectHash || '').trim().toLowerCase();
+              const hp = extractGeminiProjectHashFromPath(String(s.filePath || ''));
+              const h = hs || hp || '';
               if (h && geminiHashNeedles.has(h)) return true;
             }
             return false;
@@ -3055,6 +3057,7 @@ ipcMain.handle('history.list', async (_e, args: { projectWslPath?: string; proje
         filePath: x.filePath,
         rawDate: x.rawDate,
         preview: (x as any).preview,
+        projectHash: (x as any).projectHash,
         resumeMode: (x as any).resumeMode,
         resumeId: (x as any).resumeId,
         runtimeShell: (x as any).runtimeShell,

--- a/electron/projects.fast.ts
+++ b/electron/projects.fast.ts
@@ -468,10 +468,20 @@ export async function scanProjectsAsync(_roots?: string[], verbose = false): Pro
           const files = await discoverGeminiSessionFiles(root);
           const picked: string[] = [];
           const seenHash = new Set<string>();
+          const seenProjectKey = new Set<string>();
           for (const fp of files) {
             const h = extractGeminiProjectHashFromPath(fp);
-            if (!h || seenHash.has(h)) continue;
-            seenHash.add(h);
+            if (h) {
+              if (seenHash.has(h)) continue;
+              seenHash.add(h);
+              picked.push(fp);
+              continue;
+            }
+            // 非 hash 目录（如 root/<projectName>/chats/session-*.json）按项目目录去重，避免被全部跳过。
+            const rel = path.relative(root, fp).replace(/\\/g, "/");
+            const projectKey = String(rel.split("/").filter(Boolean)[0] || path.dirname(fp)).toLowerCase();
+            if (!projectKey || seenProjectKey.has(projectKey)) continue;
+            seenProjectKey.add(projectKey);
             picked.push(fp);
           }
           for (const fp of picked) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3902,7 +3902,9 @@ export default function CodexFlowManagerUI() {
       try {
         const pid = String(item?.providerId || '').toLowerCase();
         if (pid === 'gemini') {
-          const h = extractGeminiProjectHashFromPath(String(item?.filePath || ''));
+          const hs = String(item?.projectHash || '').trim().toLowerCase();
+          const hp = extractGeminiProjectHashFromPath(String(item?.filePath || ''));
+          const h = hs || hp || '';
           if (h && geminiProjectHashNeedlesRef.current.has(h)) return true;
         }
       } catch {}

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -142,6 +142,7 @@ export type HistorySummary = {
   filePath: string;
   rawDate?: string;
   preview?: string;
+  projectHash?: string;
   resumeMode?: 'modern' | 'legacy' | 'unknown';
   resumeId?: string;
   runtimeShell?: 'wsl' | 'windows' | 'unknown';


### PR DESCRIPTION
技术变更：
- discovery 放宽 Gemini 会话目录识别，支持 `root/<projectKey>/chats/session-*.json` 与兼容回退路径。
- parser 在路径不含 hash 时，从 JSON 头部提取并规范化 `projectHash`（含大文件前缀解析分支）。
- indexer/main/web 透传并优先使用 `projectHash` 进行项目归属过滤，路径提取作为兜底。
- projects.fast 针对非 hash 目录按项目目录键去重，避免新目录结构会话被整体跳过。
- 补齐 Gemini 的 discovery/parser 测试用例，覆盖 hash 与非 hash 目录场景。

产品影响：
- 修复 Gemini 新版可读目录结构下“历史会话不显示/项目归属失败”的问题。
- 提升 history 列表与实时索引更新的项目匹配准确率，减少误漏筛。