### PR TITLE
chore(app): 优化折叠目录子活动角标样式

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7061,7 +7061,7 @@ export default function CodexFlowManagerUI() {
               {/* 右上角指示器：当项目折叠且子项目有活动项时显示 */}
               {hasActiveChild && !expanded ? (
                 <div
-                  className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-[var(--cf-accent)] ring-2 ring-white dark:ring-slate-900 shadow-md animate-in fade-in zoom-in duration-300"
+                  className="absolute top-1 right-1 h-[7px] w-[7px] rounded-full bg-[var(--cf-accent)] ring-1 ring-white dark:ring-slate-900 shadow-md animate-in fade-in zoom-in duration-300"
                   title={t("terminal:childTerminalsActive", "子项目有活动项") as string}
                 />
               ) : null}


### PR DESCRIPTION
- 调整目录行右上角子活动指示器的位置，从外侧偏移改为内侧对齐
- 缩小角标尺寸并降低描边厚度，减少视觉干扰并提升整体精致度
- 保持原有显示条件与提示文案不变，不影响交互与业务逻辑

产品影响：
- 折叠目录在存在子项目活动项时，提示更加克制，避免遮挡边缘视觉
- 深浅主题下仍保持可见性与层次，提升列表一致性