### PR TITLE
fix(worktree):  worktree 创建面板中的初始提示词路径格式转换

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -368,6 +368,13 @@ type WorktreeCreateDialogDraftRecord = {
   multiCounts: WorktreeProviderCounts;
 };
 
+type WorktreePromptSource = {
+  chips: PathChip[];
+  draft: string;
+  projectWinRoot?: string;
+  projectWslRoot?: string;
+};
+
 type CloseWorkingTabConfirmState = {
   open: boolean;
   tabId: string | null;
@@ -3833,6 +3840,29 @@ export default function CodexFlowManagerUI() {
   }, [buildProviderStartupCmd, codexCmd, codexTraceEnabled, providerItems]);
 
   /**
+   * 中文说明：按目标 Provider 的真实终端环境，编译 worktree 首次启动要注入的初始提示词。
+   * - 项目内路径统一转相对路径，保证不同 worktree 可复用；
+   * - 项目外绝对路径保留目标终端对应的 Windows / WSL 样式。
+   */
+  const buildWorktreePromptForProvider = useCallback((args: {
+    providerId: GitWorktreeProviderId;
+    prompt?: string;
+    promptSource?: WorktreePromptSource;
+  }): string => {
+    const prompt = typeof args.prompt === "string" ? String(args.prompt || "") : "";
+    if (prompt) return prompt;
+    if (!args.promptSource) return "";
+    const env = getProviderEnv(args.providerId);
+    return compileWorktreePromptText({
+      chips: args.promptSource.chips,
+      draft: args.promptSource.draft,
+      projectWinRoot: args.promptSource.projectWinRoot,
+      projectWslRoot: args.promptSource.projectWslRoot,
+      terminalMode: env.terminal as any,
+    });
+  }, [getProviderEnv]);
+
+  /**
    * 获取 Provider 的展示名称（用于菜单文案与外部终端标题）。
    */
   const getProviderLabel = useCallback((providerId: string): string => {
@@ -6015,7 +6045,8 @@ export default function CodexFlowManagerUI() {
   const startProviderInstanceInProject = useCallback(async (args: {
     project: Project;
     providerId: GitWorktreeProviderId;
-    prompt: string;
+    prompt?: string;
+    promptSource?: WorktreePromptSource;
     useYolo?: boolean;
   }): Promise<{ ok: boolean; tabId?: string; error?: string }> => {
     try {
@@ -6023,10 +6054,15 @@ export default function CodexFlowManagerUI() {
       const providerId = args.providerId;
       if (!project?.id) return { ok: false, error: "missing project" };
       const env = getProviderEnv(providerId);
+      const prompt = buildWorktreePromptForProvider({
+        providerId,
+        prompt: args.prompt,
+        promptSource: args.promptSource,
+      });
       const baseCmd = buildProviderStartupCmdForWorktreeCreate({ providerId, env, useYolo: args.useYolo });
-      const startupCmd = buildProviderStartupCmdWithInitialPrompt({ providerId, terminalMode: env.terminal as any, baseCmd, prompt: args.prompt });
+      const startupCmd = buildProviderStartupCmdWithInitialPrompt({ providerId, terminalMode: env.terminal as any, baseCmd, prompt });
       const started = await openProviderConsoleInProject({ project, providerId, startupCmd });
-      const hasInitialPrompt = String(args.prompt || "").trim().length > 0;
+      const hasInitialPrompt = String(prompt || "").trim().length > 0;
       const tabId = String(started.tabId || "").trim();
       if (started.ok && tabId && hasInitialPrompt && shouldEnableAgentTimerForProvider(providerId))
         startAgentTurnTimer(tabId);
@@ -6034,7 +6070,7 @@ export default function CodexFlowManagerUI() {
     } catch (e: any) {
       return { ok: false, error: String(e?.message || e) };
     }
-  }, [buildProviderStartupCmdForWorktreeCreate, getProviderEnv, openProviderConsoleInProject, shouldEnableAgentTimerForProvider, startAgentTurnTimer]);
+  }, [buildProviderStartupCmdForWorktreeCreate, buildWorktreePromptForProvider, getProviderEnv, openProviderConsoleInProject, shouldEnableAgentTimerForProvider, startAgentTurnTimer]);
 
   /**
    * 执行创建 worktree，并在每个 worktree 内启动对应引擎 CLI。
@@ -6044,7 +6080,8 @@ export default function CodexFlowManagerUI() {
     repoProject: Project;
     baseBranch: string;
     instances: Array<{ providerId: GitWorktreeProviderId; count: number }>;
-    prompt: string;
+    prompt?: string;
+    promptSource?: WorktreePromptSource;
     /** 新建子 worktree 的备注基名；为空则不自动写入备注。 */
     remarkBaseName?: string;
     /** 是否在本次创建/启动中临时启用 YOLO（不影响全局设置）。 */
@@ -6128,7 +6165,6 @@ export default function CodexFlowManagerUI() {
     setWorktreeCreateProgress(createWorktreeProgressInitialState(taskId));
     setWorktreeCreateDialog((prev) => (prev.open && prev.repoProjectId === repoId ? { ...prev, open: false, creating: false, error: undefined } : prev));
 
-    const prompt = String(args.prompt || "");
     const remarkBaseName = normalizeWorktreeRemarkBaseName(args.remarkBaseName);
     const managedChildProjectIds = listManagedWorktreeChildIds(repoId);
     let nextWorktreeRemarkIndex = resolveNextWorktreeRemarkIndex({
@@ -6264,7 +6300,13 @@ export default function CodexFlowManagerUI() {
         attachDirChildToParent(managementParentProjectId, wtProject.id);
         assignAutoRemarkLabelForWorktree(wtProject.id);
 
-        const started = await startProviderInstanceInProject({ project: wtProject, providerId, prompt, useYolo: args.useYolo });
+        const started = await startProviderInstanceInProject({
+          project: wtProject,
+          providerId,
+          prompt: args.prompt,
+          promptSource: args.promptSource,
+          useYolo: args.useYolo,
+        });
         if (started.ok && started.tabId) {
           if (!firstTabId) firstTabId = started.tabId;
           if (args.resetTransientPrefsOnSuccess && !transientRecordReset) {
@@ -10333,18 +10375,18 @@ export default function CodexFlowManagerUI() {
               if (!canSubmit) return;
               setDialog({ creating: true, error: undefined });
 
-              const prompt = compileWorktreePromptText({
+              const promptSource: WorktreePromptSource = {
                 chips: worktreeCreateDialog.promptChips,
                 draft: worktreeCreateDialog.promptDraft,
                 projectWinRoot: repo.winPath,
                 projectWslRoot: repo.wslPath,
-              });
+              };
 
               // 1) 优先在已选子 worktree 中启动实例（1:1 分配）
-	              const extraWarnings: string[] = [];
-	              let transientRecordReset = false;
-	              let firstReuseProjectId: string | null = null;
-	              let firstReuseTabId: string | null = null;
+              const extraWarnings: string[] = [];
+              let transientRecordReset = false;
+              let firstReuseProjectId: string | null = null;
+              let firstReuseTabId: string | null = null;
               for (let i = 0; i < selectedChildIdsOrdered.length; i++) {
                 const projectId = selectedChildIdsOrdered[i];
                 const wtProject = childWorktrees.find((p) => p.id === projectId) || null;
@@ -10352,16 +10394,21 @@ export default function CodexFlowManagerUI() {
                 const providerId = providerQueue[i] || worktreeCreateDialog.singleProviderId;
                 // 用户主动选择：若该 worktree 被隐藏，则自动取消隐藏
                 unhideProject(wtProject);
-	                const started = await startProviderInstanceInProject({ project: wtProject, providerId, prompt, useYolo: worktreeCreateDialog.useYolo });
-	                if (started.ok && started.tabId) {
-	                  if (!firstReuseTabId) firstReuseTabId = started.tabId;
-	                  if (!transientRecordReset) {
-	                    transientRecordReset = true;
-	                    resetWorktreeCreateTransientRecord(repo.id);
-	                  }
-	                } else if (!started.ok && started.error) {
-	                  extraWarnings.push(`${providerId}: ${started.error} (${getDirNodeLabel(wtProject)})`);
-	                }
+                const started = await startProviderInstanceInProject({
+                    project: wtProject,
+                    providerId,
+                    promptSource,
+                    useYolo: worktreeCreateDialog.useYolo,
+                  });
+                if (started.ok && started.tabId) {
+                  if (!firstReuseTabId) firstReuseTabId = started.tabId;
+                  if (!transientRecordReset) {
+                    transientRecordReset = true;
+                    resetWorktreeCreateTransientRecord(repo.id);
+                  }
+                } else if (!started.ok && started.error) {
+                  extraWarnings.push(`${providerId}: ${started.error} (${getDirNodeLabel(wtProject)})`);
+                }
                 if (!firstReuseProjectId) firstReuseProjectId = wtProject.id;
               }
 
@@ -10378,7 +10425,7 @@ export default function CodexFlowManagerUI() {
                   repoProject: repo,
                   baseBranch,
                   instances: remainingInstances,
-                  prompt,
+                  promptSource,
                   remarkBaseName: worktreeCreateDialog.remarkBaseName,
                   useYolo: worktreeCreateDialog.useYolo,
                   resetTransientPrefsOnSuccess: true,

--- a/web/src/app/app-shared.tsx
+++ b/web/src/app/app-shared.tsx
@@ -1039,9 +1039,28 @@ function areStringArraysEqual(a: string[] | null | undefined, b: string[] | null
 }
 
 /**
+ * 中文说明：按目标终端环境挑选 worktree 提示词中应使用的路径文本。
+ * - Windows / PowerShell：优先使用 Windows 路径；
+ * - WSL：优先使用 WSL 路径；
+ * - 任一路径缺失时自动回退到另一种路径或文件名。
+ */
+function resolveWorktreePromptChipPath(args: { chip: PathChip; terminalMode?: TerminalMode }): string {
+  const chipAny = args.chip as any;
+  const preferWindows = args.terminalMode === "windows" || args.terminalMode === "pwsh";
+  const candidates = preferWindows
+    ? [chipAny?.winPath, chipAny?.wslPath, chipAny?.fileName]
+    : [chipAny?.wslPath, chipAny?.winPath, chipAny?.fileName];
+  for (const item of candidates) {
+    const text = String(item || "").trim();
+    if (text) return text;
+  }
+  return "";
+}
+
+/**
  * 将 WSL/Windows 的绝对路径（若位于项目根内）转换为相对路径，用于 worktree 创建时的“可复用提示词”。
  * - 关键目标：避免把源项目的绝对路径直接分发到多个 worktree（不同 worktree 根目录不同，会导致路径失效）
- * - 若无法转换（不在项目内/无法识别），则返回原始路径文本
+ * - 若无法转换（不在项目内/无法识别），则保留原始路径样式
  */
 function toWorktreePromptRelPath(args: { pathText: string; projectWinRoot?: string; projectWslRoot?: string }): string {
   const raw = String(args.pathText || "").trim();
@@ -1078,7 +1097,10 @@ function toWorktreePromptRelPath(args: { pathText: string; projectWinRoot?: stri
     }
   } catch {}
 
-  // 3) 已是相对路径或无法转换：尽量统一分隔符为 /
+  // 3) 未命中项目根时：绝对路径保留原样；相对路径再统一分隔符为 /
+  if (/^[a-zA-Z]:[\\/]/.test(raw) || raw.startsWith("\\\\")) return raw;
+  const posixLike = raw.replace(/\\/g, "/");
+  if (posixLike.startsWith("/")) return posixLike;
   return raw.replace(/\\/g, "/");
 }
 
@@ -1086,8 +1108,15 @@ function toWorktreePromptRelPath(args: { pathText: string; projectWinRoot?: stri
  * 将 worktree 创建面板中的 chips + 草稿合并为最终提示词：
  * - 每个 chip 独占一行，并用反引号包裹
  * - 项目内绝对路径会被转换为相对路径，保证对不同 worktree 可复用
+ * - 项目外绝对路径会按目标终端环境保留对应样式（Windows / WSL）
  */
-function compileWorktreePromptText(args: { chips: PathChip[]; draft: string; projectWinRoot?: string; projectWslRoot?: string }): string {
+function compileWorktreePromptText(args: {
+  chips: PathChip[];
+  draft: string;
+  projectWinRoot?: string;
+  projectWslRoot?: string;
+  terminalMode?: TerminalMode;
+}): string {
   const chips = Array.isArray(args.chips) ? args.chips : [];
   const draft = String(args.draft || "");
   const parts: string[] = [];
@@ -1095,7 +1124,7 @@ function compileWorktreePromptText(args: { chips: PathChip[]; draft: string; pro
     parts.push(
       chips
         .map((c) => {
-          const raw = String((c as any)?.wslPath || (c as any)?.winPath || (c as any)?.fileName || "").trim();
+          const raw = resolveWorktreePromptChipPath({ chip: c, terminalMode: args.terminalMode });
           const p = toWorktreePromptRelPath({ pathText: raw, projectWinRoot: args.projectWinRoot, projectWslRoot: args.projectWslRoot });
           return p ? ("`" + p + "`") : "";
         })

--- a/web/src/app/app-shared.worktree.test.ts
+++ b/web/src/app/app-shared.worktree.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { compileWorktreePromptText, toWorktreePromptRelPath } from "./app-shared";
+
+describe("app-shared（worktree 初始提示词编译）", () => {
+  it("toWorktreePromptRelPath：将项目内 Windows 绝对路径转换为相对路径", () => {
+    expect(toWorktreePromptRelPath({
+      pathText: "C:\\repo\\docs\\task.md",
+      projectWinRoot: "C:\\repo",
+      projectWslRoot: "/mnt/c/repo",
+    })).toBe("docs/task.md");
+  });
+
+  it("toWorktreePromptRelPath：保留项目外 Windows 绝对路径样式", () => {
+    expect(toWorktreePromptRelPath({
+      pathText: "D:\\shared\\brief.md",
+      projectWinRoot: "C:\\repo",
+      projectWslRoot: "/mnt/c/repo",
+    })).toBe("D:\\shared\\brief.md");
+  });
+
+  it("toWorktreePromptRelPath：保留项目外 WSL 绝对路径样式", () => {
+    expect(toWorktreePromptRelPath({
+      pathText: "/mnt/d/shared/brief.md",
+      projectWinRoot: "C:\\repo",
+      projectWslRoot: "/mnt/c/repo",
+    })).toBe("/mnt/d/shared/brief.md");
+  });
+
+  it("compileWorktreePromptText：按 PowerShell 终端选择 Windows 路径并转换项目内相对路径", () => {
+    expect(compileWorktreePromptText({
+      chips: [{
+        fileName: "task.md",
+        winPath: "C:\\repo\\docs\\task.md",
+        wslPath: "/mnt/c/repo/docs/task.md",
+      } as any],
+      draft: "请先阅读上下文",
+      projectWinRoot: "C:\\repo",
+      projectWslRoot: "/mnt/c/repo",
+      terminalMode: "pwsh",
+    })).toBe("`docs/task.md`\n\n请先阅读上下文");
+  });
+
+  it("compileWorktreePromptText：按目标终端保留项目外绝对路径样式", () => {
+    const chips = [{
+      fileName: "brief.md",
+      winPath: "D:\\shared\\brief.md",
+      wslPath: "/mnt/d/shared/brief.md",
+    } as any];
+
+    expect(compileWorktreePromptText({
+      chips,
+      draft: "",
+      projectWinRoot: "C:\\repo",
+      projectWslRoot: "/mnt/c/repo",
+      terminalMode: "windows",
+    })).toBe("`D:\\shared\\brief.md`");
+
+    expect(compileWorktreePromptText({
+      chips,
+      draft: "",
+      projectWinRoot: "C:\\repo",
+      projectWslRoot: "/mnt/c/repo",
+      terminalMode: "wsl",
+    })).toBe("`/mnt/d/shared/brief.md`");
+  });
+});


### PR DESCRIPTION
- 将 worktree 创建面板中的初始提示词延后到目标 Provider 实例启动时再编译
- 让路径 chips 按目标终端环境选择 Windows / WSL 样式，并仅将项目内路径转换为相对路径
- 修复复用已有 worktree 与新建 worktree 混合启动时的跨环境路径失效问题
- 补充 worktree 提示词路径编译的回归测试

验证：
- npx vitest run web/src/app/app-shared.notify.test.ts web/src/app/app-shared.worktree.test.ts
- npm run test
- npm run i18n:check