### PR TITLE
fix(history): 修复历史详情虚拟列表白屏

### DIFF
--- a/web/src/features/history/virtualized-list.test.ts
+++ b/web/src/features/history/virtualized-list.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { findVisibleStartIndex } from "@/features/history/virtualized-list";
+
+describe("history virtualized list window calculation", () => {
+  it("滚动窗口超过总高度时定位到最后一项而不是首项", () => {
+    expect(findVisibleStartIndex([0, 100, 260], [100, 160, 120], 999)).toBe(2);
+  });
+
+  it("滚动窗口落在中间内容时定位到第一个进入窗口的项目", () => {
+    expect(findVisibleStartIndex([0, 100, 260], [100, 160, 120], 180)).toBe(1);
+  });
+});

--- a/web/src/features/history/virtualized-list.tsx
+++ b/web/src/features/history/virtualized-list.tsx
@@ -44,11 +44,11 @@ function clampScrollTop(value: number, min: number, max: number): number {
 /**
  * 中文说明：二分查找第一个“底部进入可视区”的索引。
  */
-function findVisibleStartIndex(tops: number[], heights: number[], offset: number): number {
+export function findVisibleStartIndex(tops: number[], heights: number[], offset: number): number {
   if (tops.length === 0) return 0;
   let left = 0;
   let right = tops.length - 1;
-  let answer = 0;
+  let answer = tops.length - 1;
   while (left <= right) {
     const mid = (left + right) >> 1;
     const bottom = tops[mid] + heights[mid];
@@ -85,8 +85,9 @@ function findVisibleEndIndex(tops: number[], offset: number): number {
 /**
  * 中文说明：订阅滚动容器位置与高度，驱动虚拟列表窗口计算。
  */
-function useVirtualizedViewport(scrollContainerRef: React.RefObject<HTMLDivElement | null>): VirtualizedViewportState {
+function useVirtualizedViewport(scrollContainerRef: React.RefObject<HTMLDivElement | null>, syncSignal: number): VirtualizedViewportState {
   const [viewport, setViewport] = useState<VirtualizedViewportState>({ scrollTop: 0, height: 0 });
+  const syncViewportRef = useRef<(() => void) | null>(null);
 
   useLayoutEffect(() => {
     const container = scrollContainerRef.current;
@@ -105,6 +106,7 @@ function useVirtualizedViewport(scrollContainerRef: React.RefObject<HTMLDivEleme
         return { scrollTop: nextScrollTop, height: nextHeight };
       });
     };
+    syncViewportRef.current = syncViewport;
 
     /**
      * 中文说明：使用 rAF 合并高频滚动事件，降低状态更新压力。
@@ -130,6 +132,7 @@ function useVirtualizedViewport(scrollContainerRef: React.RefObject<HTMLDivEleme
 
     return () => {
       container.removeEventListener("scroll", scheduleSync);
+      if (syncViewportRef.current === syncViewport) syncViewportRef.current = null;
       if (resizeObserver) {
         try {
           resizeObserver.disconnect();
@@ -140,6 +143,10 @@ function useVirtualizedViewport(scrollContainerRef: React.RefObject<HTMLDivEleme
       if (rafId) window.cancelAnimationFrame(rafId);
     };
   }, [scrollContainerRef]);
+
+  useLayoutEffect(() => {
+    syncViewportRef.current?.();
+  }, [syncSignal]);
 
   return viewport;
 }
@@ -201,7 +208,6 @@ function VirtualizedListInner<TItem>({
   getItemKey,
   renderItem,
 }: VirtualizedListProps<TItem>, ref: React.ForwardedRef<VirtualizedListHandle>) {
-  const viewport = useVirtualizedViewport(scrollContainerRef);
   const hostRef = useRef<HTMLDivElement | null>(null);
   const heightsRef = useRef<Record<string, number>>({});
   const [layoutVersion, setLayoutVersion] = useState(0);
@@ -239,9 +245,19 @@ function VirtualizedListInner<TItem>({
     return { tops, heights, totalHeight };
   }, [items, estimateItemHeight, getItemKey, layoutVersion]);
 
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
+    if (container.scrollTop > maxScrollTop) container.scrollTop = maxScrollTop;
+  }, [layout.totalHeight, scrollContainerRef]);
+
+  const viewport = useVirtualizedViewport(scrollContainerRef, layout.totalHeight);
   const overscanPx = Math.max(estimateItemHeight, overscan ?? estimateItemHeight * 4);
-  const windowStart = Math.max(0, viewport.scrollTop - overscanPx);
-  const windowEnd = Math.max(0, viewport.scrollTop + viewport.height + overscanPx);
+  const hostOffsetTop = Math.max(0, hostRef.current?.offsetTop || 0);
+  const viewportTopInList = Math.max(0, viewport.scrollTop - hostOffsetTop);
+  const windowStart = Math.max(0, viewportTopInList - overscanPx);
+  const windowEnd = Math.max(0, viewportTopInList + viewport.height + overscanPx);
   const startIndex = items.length > 0 ? findVisibleStartIndex(layout.tops, layout.heights, windowStart) : 0;
   const endIndex = items.length > 0 ? Math.min(items.length - 1, findVisibleEndIndex(layout.tops, windowEnd)) : -1;
 


### PR DESCRIPTION
历史详情启用虚拟列表时，列表前方存在会话 header，原先直接使用滚动容器的 scrollTop 计算可见窗口，导致窗口坐标与列表内容坐标存在偏移。过滤、搜索或切换消息集合后内容高度缩短时，滚动位置还可能停留在新的最大高度之外，使可见窗口落到列表总高度之后并出现详情区域空白。

技术变更：
- 修正可见起始索引二分查找的越界兜底，滚动窗口超过列表总高度时定位到最后一项。
- 在虚拟列表总高度变化后钳制滚动容器 scrollTop，并同步最新视口状态。
- 将滚动容器坐标转换为列表内部坐标，扣除列表宿主节点相对滚动容器的 offsetTop。
- 增加虚拟列表窗口起始索引的边界单测。

产品影响：
- 历史详情在长会话、搜索过滤或切换消息集合后不再出现白屏。
- 保持搜索跳转、Ctrl+Home/End 和滚动按钮等既有交互不变。