### PR TITLE
fix(history): 修复历史详情跨环境读取空白

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3312,58 +3312,153 @@ ipcMain.handle('history.list', async (_e, args: {
   }
 });
 
-ipcMain.handle('history.read', async (_e, args: { filePath: string; providerId?: string }) => {
-  const filePath = String(args?.filePath || '');
-  const providerHint = String(args?.providerId || '').trim().toLowerCase();
-  try {
-    const cached = getCachedDetails(filePath);
-    if (cached) return cached;
-  } catch {}
-  try {
-    const det = getIndexedDetails(filePath);
-    if (det) {
-      try { cacheDetails(filePath, det); } catch {}
-      return det;
-    }
-  } catch {}
+type HistoryReadProviderId = "codex" | "claude" | "gemini";
 
-  const inferProviderId = (): "codex" | "claude" | "gemini" => {
-    const hint = providerHint;
-    if (hint === 'codex' || hint === 'claude' || hint === 'gemini') return hint as any;
-    try {
-      const found = getIndexedSummaries().find((s: any) => String(s?.filePath || '') === filePath);
-      const pid = String((found as any)?.providerId || '').trim().toLowerCase();
-      if (pid === 'codex' || pid === 'claude' || pid === 'gemini') return pid as any;
-    } catch {}
-    try {
-      const fp = filePath.replace(/\\/g, '/').toLowerCase();
-      const base = fp.split('/').pop() || '';
-      if (fp.includes('/.claude/')) return 'claude';
-      if (fp.includes('/.gemini/')) return 'gemini';
-      if (base.endsWith('.ndjson')) return 'claude';
-      if (base.startsWith('session-') && base.endsWith('.json')) return 'gemini';
-    } catch {}
-    return 'codex';
+/**
+ * 中文说明：规范化 history.read 的 provider hint，避免无效字符串影响路径推断。
+ */
+function normalizeHistoryReadProviderHint(providerHint?: string): HistoryReadProviderId | null {
+  const hint = String(providerHint || "").trim().toLowerCase();
+  if (hint === "codex" || hint === "claude" || hint === "gemini") return hint;
+  return null;
+}
+
+/**
+ * 中文说明：根据文件路径特征判断会话所属 Provider，路径特征优先于外部 hint。
+ */
+function inferHistoryReadProviderFromPath(filePath?: string): HistoryReadProviderId | null {
+  const fp = String(filePath || "").replace(/\\/g, "/").toLowerCase();
+  if (!fp) return null;
+  const base = fp.split("/").pop() || "";
+  if (fp.includes("/.codex/")) return "codex";
+  if (fp.includes("/.claude/")) return "claude";
+  if (fp.includes("/.gemini/")) return "gemini";
+  if (base.endsWith(".ndjson")) return "claude";
+  if (base.startsWith("session-") && base.endsWith(".json")) return "gemini";
+  return null;
+}
+
+/**
+ * 中文说明：生成 history.read 可尝试的文件系统路径，兼容 Windows 侧读取 WSL/POSIX 路径。
+ */
+function buildHistoryReadPathCandidates(filePath: string): string[] {
+  const raw = String(filePath || "").trim();
+  const candidates: string[] = [];
+  /**
+   * 中文说明：按优先级加入候选路径，并保持去重后的稳定顺序。
+   */
+  const push = (value?: string) => {
+    const next = String(value || "").trim();
+    if (next && !candidates.includes(next)) candidates.push(next);
   };
+  if (!raw) return candidates;
 
-  const providerId = inferProviderId();
+  if (process.platform === "win32") {
+    if (/^\//.test(raw)) {
+      const mnt = raw.match(/^\/mnt\/([a-zA-Z])\/(.*)$/);
+      if (mnt?.[1]) push(`${mnt[1].toUpperCase()}:\\${String(mnt[2] || "").replace(/\//g, "\\")}`);
+      try { push(wsl.wslToUNC(raw, settings.getSettings().distro || "Ubuntu-24.04")); } catch {}
+    }
+    try { push(wsl.normalizeWinPath(raw)); } catch {}
+  }
+
+  push(raw);
+  return candidates;
+}
+
+/**
+ * 中文说明：选择第一个当前进程可直接读取的历史文件路径。
+ */
+function resolveHistoryReadFilePath(filePath: string): string {
+  const candidates = buildHistoryReadPathCandidates(filePath);
+  for (const candidate of candidates) {
+    try {
+      const stat = fs.statSync(candidate);
+      if (stat.isFile()) return candidate;
+    } catch {}
+  }
+  return candidates[0] || String(filePath || "").trim();
+}
+
+/**
+ * 中文说明：从缓存或索引详情中读取非空历史详情，支持原始路径与解析路径双 key 查询。
+ */
+function getHistoryReadCachedDetails(filePaths: string[]): any | null {
+  const candidates = Array.from(new Set(filePaths.map((item) => String(item || "").trim()).filter(Boolean)));
+  for (const candidate of candidates) {
+    try {
+      const cached = getCachedDetails(candidate);
+      if (cached) return cached;
+    } catch {}
+  }
+  for (const candidate of candidates) {
+    try {
+      const det = getIndexedDetails(candidate);
+      if (det) return det;
+    } catch {}
+  }
+  return null;
+}
+
+/**
+ * 中文说明：把解析出的详情写入原始路径与解析路径两个缓存 key，避免下次重复全量解析。
+ */
+function cacheHistoryReadDetails(filePaths: string[], details: any): void {
+  const candidates = Array.from(new Set(filePaths.map((item) => String(item || "").trim()).filter(Boolean)));
+  for (const candidate of candidates) {
+    try { cacheDetails(candidate, details); } catch {}
+  }
+}
+
+/**
+ * 中文说明：综合路径、索引摘要和外部 hint 推断 history.read 应使用的 Provider 解析器。
+ */
+function inferHistoryReadProviderId(filePaths: string[], providerHint?: string): HistoryReadProviderId {
+  for (const candidate of filePaths) {
+    const byPath = inferHistoryReadProviderFromPath(candidate);
+    if (byPath) return byPath;
+  }
+  try {
+    const candidates = new Set(filePaths.map((item) => String(item || "").trim()).filter(Boolean));
+    const found = getIndexedSummaries().find((summary: any) => candidates.has(String(summary?.filePath || "").trim()));
+    const indexed = normalizeHistoryReadProviderHint(String((found as any)?.providerId || ""));
+    if (indexed) return indexed;
+  } catch {}
+  return normalizeHistoryReadProviderHint(providerHint) || "codex";
+}
+
+ipcMain.handle('history.read', async (_e, args: { filePath: string; providerId?: string; forceParse?: boolean }) => {
+  const requestedFilePath = String(args?.filePath || '').trim();
+  const filePath = resolveHistoryReadFilePath(requestedFilePath);
+  const lookupPaths = Array.from(new Set([requestedFilePath, filePath].filter(Boolean)));
+  const providerHint = String(args?.providerId || '').trim().toLowerCase();
+  const forceParse = !!args?.forceParse;
+  if (!forceParse) {
+    const cached = getHistoryReadCachedDetails(lookupPaths);
+    if (cached) {
+      cacheHistoryReadDetails(lookupPaths, cached);
+      return cached;
+    }
+  }
+
+  const providerId = inferHistoryReadProviderId(lookupPaths, providerHint);
 
   if (providerId === "claude") {
     const stat = await fsp.stat(filePath);
     const parsed = await parseClaudeSessionFile(filePath, stat, { summaryOnly: false, maxLines: 50_000 });
-    try { cacheDetails(filePath, parsed as any); } catch {}
+    cacheHistoryReadDetails(lookupPaths, parsed as any);
     return parsed as any;
   }
   if (providerId === "gemini") {
     const stat = await fsp.stat(filePath);
     const parsed = await parseGeminiSessionFile(filePath, stat, { summaryOnly: false, maxBytes: 64 * 1024 * 1024 });
-    try { cacheDetails(filePath, parsed as any); } catch {}
+    cacheHistoryReadDetails(lookupPaths, parsed as any);
     return parsed as any;
   }
 
   const parsed = await history.readHistoryFile(filePath, { maxLines: 0 });
-  const withMeta = { ...(parsed as any), providerId: "codex", filePath };
-  try { cacheDetails(filePath, withMeta as any); } catch {}
+  const withMeta = { ...(parsed as any), providerId: "codex", filePath: requestedFilePath || filePath };
+  cacheHistoryReadDetails(lookupPaths, withMeta as any);
   return withMeta;
 });
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -377,7 +377,7 @@ contextBridge.exposeInMainWorld('host', {
     }) => {
       return await ipcRenderer.invoke('history.list', args);
     },
-    read: async (args: { filePath: string; providerId?: "codex" | "claude" | "gemini" }) => {
+    read: async (args: { filePath: string; providerId?: "codex" | "claude" | "gemini"; forceParse?: boolean }) => {
       return await ipcRenderer.invoke('history.read', args);
     },
     findEmptySessions: async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13003,6 +13003,45 @@ function filterHistoryMessages(
   return { messages: filteredMessages, matches };
 }
 
+/**
+ * 中文说明：规整 history.read 返回的消息数组，避免异常返回结构让详情加载流程中断。
+ */
+function normalizeHistoryReadMessages(res: any): HistoryMessage[] {
+  const rawMessages = Array.isArray(res?.messages) ? res.messages : [];
+  return rawMessages.map((message: any) => ({
+    role: String(message?.role || "unknown"),
+    content: Array.isArray(message?.content) ? message.content : [],
+  }));
+}
+
+/**
+ * 中文说明：从历史消息内容中构造筛选项状态，默认只展示主对话文本与图片。
+ */
+function buildHistoryTypeFilter(messages: HistoryMessage[]): Record<string, boolean> {
+  const allKeys = new Set<string>();
+  for (const message of messages) {
+    for (const item of message.content || []) {
+      for (const key of keysOfItemCanonical(item)) allKeys.add(key);
+    }
+  }
+
+  // 去重策略：若同时存在 base 与 message.<base>，则仅保留 base，避免筛选项重复展示。
+  const bases = new Set(['input_text','output_text','text','code','json','instructions','environment_context','summary']);
+  const filtered: string[] = [];
+  for (const key of Array.from(allKeys)) {
+    if (key.startsWith('message.')) {
+      const tail = key.slice('message.'.length);
+      if (bases.has(tail) && allKeys.has(tail)) continue;
+    }
+    filtered.push(key);
+  }
+  filtered.sort();
+
+  const next: Record<string, boolean> = {};
+  for (const key of filtered) next[key] = (key === 'input_text' || key === 'output_text' || key === 'image');
+  return next;
+}
+
 function HistoryDetail({ sessions, selectedHistoryId, projectWinPath, onBack, onResume, onResumeExternal, getResumeShellLabel }: { sessions: HistorySession[]; selectedHistoryId: string | null; projectWinPath?: string; onBack?: () => void; onResume?: (filePath?: string) => void; onResumeExternal?: (filePath?: string) => void; getResumeShellLabel: (filePath?: string) => ShellLabel }) {
   const { t } = useTranslation(['history', 'common']);
   const MAX_HISTORY_MESSAGE_CACHE = 5;
@@ -13400,13 +13439,23 @@ function HistoryDetail({ sessions, selectedHistoryId, projectWinPath, onBack, on
     if (!selectedHistoryId || !selectedSession || !selectedSession.filePath) return;
     const signature = selectedSessionFingerprint;
     const hasMessages = !!(selectedLocalSession && Array.isArray(selectedLocalSession.messages) && selectedLocalSession.messages.length > 0);
-    if (hasMessages && lastLoadedFingerprintRef.current === signature) return;
+    if (lastLoadedFingerprintRef.current === signature && (hasMessages || loaded)) return;
     setLoaded(false);
+    setTypeFilter({});
     const seq = ++reqSeq.current;
     (async () => {
       try {
-        const res: any = await window.host.history.read({ filePath: String(selectedSession.filePath || ''), providerId: selectedSession.providerId });
-        const msgs = (res.messages || []).map((m: any) => ({ role: m.role as any, content: m.content }));
+        const filePath = String(selectedSession.filePath || '');
+        let res: any = await window.host.history.read({ filePath, providerId: selectedSession.providerId });
+        let msgs = normalizeHistoryReadMessages(res);
+        if (msgs.length === 0 && filePath) {
+          const reparsed: any = await window.host.history.read({ filePath, forceParse: true });
+          const reparsedMessages = normalizeHistoryReadMessages(reparsed);
+          if (reparsedMessages.length > 0) {
+            res = reparsed;
+            msgs = reparsedMessages;
+          }
+        }
         if (seq === reqSeq.current) {
           const allowedIds = new Set(touchMessageCache(selectedHistoryId));
           setLocalSessions((cur) => {
@@ -13418,25 +13467,7 @@ function HistoryDetail({ sessions, selectedHistoryId, projectWinPath, onBack, on
           lastLoadedFingerprintRef.current = signature;
         }
         try {
-          const allKeys = new Set<string>();
-          for (const mm of msgs) {
-            for (const it of (mm.content || [])) for (const k of keysOfItemCanonical(it)) allKeys.add(k);
-          }
-          // 去重策略：若同时存在 base 与 message.<base>，则仅保留 base（避免重复展示）。
-          const BASES = new Set(['input_text','output_text','text','code','json','instructions','environment_context','summary']);
-          const hasBase = (b: string) => allKeys.has(b);
-          const filtered: string[] = [];
-          for (const k of Array.from(allKeys)) {
-            if (k.startsWith('message.')) {
-              const tail = k.slice('message.'.length);
-              if (BASES.has(tail) && hasBase(tail)) continue;
-            }
-            filtered.push(k);
-          }
-          filtered.sort();
-          // 默认仅勾选 input_text 与 output_text，以突出用户与助手的主要对话内容
-          const next: Record<string, boolean> = {};
-          for (const k of filtered) next[k] = (k === 'input_text' || k === 'output_text' || k === 'image');
+          const next = buildHistoryTypeFilter(msgs);
           if (seq === reqSeq.current) setTypeFilter(next);
         } catch {}
       } catch (e) {
@@ -13687,7 +13718,7 @@ function HistoryDetail({ sessions, selectedHistoryId, projectWinPath, onBack, on
                   ))
                 ) : (
                   <div className="col-span-full flex items-center justify-center py-2 text-[var(--cf-text-muted)] font-apple-regular text-[0.68rem]">
-                    {t('history:loadingFilters')}
+                    {loaded ? t('history:noFilterOptions') : t('history:loadingFilters')}
                   </div>
                 )}
               </div>

--- a/web/src/locales/en/history.json
+++ b/web/src/locales/en/history.json
@@ -10,6 +10,7 @@
   "deselectAll": "Deselect All",
   "invertSelection": "Invert",
   "loadingFilters": "Loading filters…",
+  "noFilterOptions": "No filterable content",
   "skippedLines": "Skipped {count} unparsable lines during parsing.",
   "selectRightToView": "Select a history item on the right to view details.",
   "showing": "… {total} total, showing first {count}",

--- a/web/src/locales/zh/history.json
+++ b/web/src/locales/zh/history.json
@@ -10,6 +10,7 @@
   "deselectAll": "取消全选",
   "invertSelection": "反选",
   "loadingFilters": "加载筛选项中…",
+  "noFilterOptions": "暂无可筛选内容",
   "skippedLines": "解析时跳过了 {count} 行不可解析内容。",
   "selectRightToView": "请选择右侧一条历史以查看详情。",
   "showing": "… 共 {total} 条，展示前 {count} 条",

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -459,7 +459,7 @@ export interface HistoryAPI {
     offset?: number;
     historyRoot?: string;
   }): Promise<{ ok: boolean; sessions?: HistorySummary[]; error?: string }>;
-  read(args: { filePath: string; providerId?: "codex" | "claude" | "gemini" }): Promise<{ id: string; title: string; date: number; messages: HistoryMessage[]; skippedLines: number; providerId?: "codex" | "claude" | "gemini" }>;
+  read(args: { filePath: string; providerId?: "codex" | "claude" | "gemini"; forceParse?: boolean }): Promise<{ id: string; title: string; date: number; messages: HistoryMessage[]; skippedLines: number; providerId?: "codex" | "claude" | "gemini" }>;
   findEmptySessions(): Promise<{ ok: boolean; candidates?: Array<{ id: string; title: string; rawDate?: string; date: number; filePath: string; sizeKB?: number }>; error?: string }>;
   trash(args: { filePath: string }): Promise<{ ok: true; notFound?: boolean } | { ok: false; error: string }>;
   trashMany(args: { filePaths: string[] }): Promise<{ ok: boolean; results?: Array<{ filePath: string; ok: boolean; notFound?: boolean; error?: string }>; summary?: { ok: number; notFound: number; failed: number }; error?: string }>;


### PR DESCRIPTION
- 读取历史详情时按原始路径与解析路径双 key 查询缓存和索引
- 为 Windows 主进程补齐 POSIX、/mnt 与 UNC 文件路径候选
- 详情页在缓存返回空消息时强制重解析，并补充空筛选项占位文案