### PR TITLE
fix(terminal): 优化 Codex Windows 短文本提交

### DIFF
--- a/web/src/lib/TerminalManager.ts
+++ b/web/src/lib/TerminalManager.ts
@@ -65,6 +65,7 @@ const TERMINAL_SEND_SCREEN_ACK_STABLE_POLLS = 2;
 const CLAUDE_LARGE_PASTE_LINE_THRESHOLD = 5;
 const CLAUDE_LARGE_PASTE_CHAR_THRESHOLD = 1000;
 const CODEX_LARGE_PASTE_CHAR_THRESHOLD = 1000;
+const CODEX_WINDOWS_FAST_SUBMIT_DELAY_MS = 32;
 const GEMINI_LARGE_PASTE_LINE_THRESHOLD = 5;
 const GEMINI_LARGE_PASTE_CHAR_THRESHOLD = 500;
 const GEMINI_HUGE_PASTE_CHUNK_THRESHOLD = 900;
@@ -780,6 +781,57 @@ export default class TerminalManager {
   }
 
   /**
+   * 中文说明：Codex 在 Windows/PowerShell 短文本场景下，快速写入正文并在短暂 settle 后提交。
+   *
+   * 设计背景：
+   * - 短文本不需要等待局部屏幕 ACK；等待 ACK 失败时会退到数秒级 hard timeout，造成“短消息偶现几秒后才发送”；
+   * - 多行短文本仍保留显式 bracketed paste，避免 PowerShell/ConPTY 将内嵌换行拆成多次提交；
+   * - 单行短文本优先复用 xterm paste 通道，失败时再直接写入 PTY。
+   *
+   * @param ptyId 当前标签页绑定的 PTY id
+   * @param text 已规范化的待发送文本（不含尾随换行）
+   * @param adapter 当前 tab 绑定的终端适配器
+   * @param terminalMode 当前终端类型
+   * @param traceId 可选诊断 trace id
+   */
+  private sendCodexWindowsFastTextAndEnter(
+    ptyId: string,
+    text: string,
+    adapter: TerminalAdapterAPI | null,
+    terminalMode: TerminalMode,
+    traceId?: string | null,
+  ): void {
+    const normalizedText = String(text ?? "");
+    const sendEnter = () => {
+      this.logSendDiagnostic(traceId, `fast.enter delayMs=${CODEX_WINDOWS_FAST_SUBMIT_DELAY_MS}`);
+      try { this.hostPty.write(ptyId, "\r"); } catch {}
+    };
+    const scheduleEnter = () => {
+      try { window.setTimeout(sendEnter, CODEX_WINDOWS_FAST_SUBMIT_DELAY_MS); } catch { sendEnter(); }
+    };
+
+    if (this.shouldForceCodexWindowsBracketedPaste("codex", terminalMode, normalizedText)) {
+      this.logSendDiagnostic(traceId, `trigger.mode=host.bracketed.fast chars=${normalizedText.length}`);
+      try { this.hostPty.write(ptyId, buildBracketedPastePayload(normalizedText)); } catch {}
+      scheduleEnter();
+      return;
+    }
+
+    if (adapter && typeof (adapter as any).paste === "function") {
+      try {
+        (adapter as any).paste(normalizedText);
+        this.logSendDiagnostic(traceId, `trigger.mode=adapter.paste.fast chars=${normalizedText.length}`);
+        scheduleEnter();
+        return;
+      } catch {}
+    }
+
+    this.logSendDiagnostic(traceId, `trigger.mode=host.write.fast chars=${normalizedText.length}`);
+    try { this.hostPty.write(ptyId, normalizedText); } catch {}
+    scheduleEnter();
+  }
+
+  /**
    * 中文说明：Codex 在 Windows/PowerShell 长文本场景下，使用“等待 PTY 回显静默后再回车”的保守提交策略。
    *
    * 设计背景：
@@ -1115,6 +1167,21 @@ export default class TerminalManager {
     return String(providerId || '').trim().toLowerCase() === 'codex'
       && !!terminalMode
       && isWindowsLikeTerminal(terminalMode);
+  }
+
+  /**
+   * 中文说明：判断 Codex Windows 当前文本是否需要启用屏幕 ACK/静默等待的保守提交策略。
+   * @param providerId providerId
+   * @param terminalMode 当前标签页运行终端类型
+   * @param text 待发送正文
+   * @returns 是否启用大文本保守提交策略
+   */
+  private shouldUseCodexWindowsQuietSubmitStrategy(providerId?: string | null, terminalMode?: TerminalMode | null, text?: string): boolean {
+    if (!this.shouldUseCodexWindowsSubmitStrategy(providerId, terminalMode))
+      return false;
+    const normalized = this.normalizeSendProbeText(text || "");
+    const charCount = Array.from(normalized).length;
+    return charCount > CODEX_LARGE_PASTE_CHAR_THRESHOLD;
   }
 
   /**
@@ -1595,8 +1662,10 @@ export default class TerminalManager {
       ? "gemini-paste-quiet"
       : this.shouldUseClaudeWindowsSubmitStrategy(options?.providerId, options?.terminalMode, text)
         ? "claude-paste-quiet"
-      : this.shouldUseCodexWindowsSubmitStrategy(options?.providerId, options?.terminalMode)
+      : this.shouldUseCodexWindowsQuietSubmitStrategy(options?.providerId, options?.terminalMode, text)
         ? "codex-paste-quiet"
+      : this.shouldUseCodexWindowsSubmitStrategy(options?.providerId, options?.terminalMode)
+        ? "codex-fast-submit"
         : "default-outbound";
 
     this.logSendDiagnostic(
@@ -1620,8 +1689,12 @@ export default class TerminalManager {
       this.sendClaudeWindowsTextAndEnter(ptyId, text, adapter, options!.terminalMode!, traceId);
       return;
     }
-    if (this.shouldUseCodexWindowsSubmitStrategy(options?.providerId, options?.terminalMode)) {
+    if (this.shouldUseCodexWindowsQuietSubmitStrategy(options?.providerId, options?.terminalMode, text)) {
       this.sendCodexWindowsTextAndEnter(ptyId, text, adapter, options!.terminalMode!, traceId);
+      return;
+    }
+    if (this.shouldUseCodexWindowsSubmitStrategy(options?.providerId, options?.terminalMode)) {
+      this.sendCodexWindowsFastTextAndEnter(ptyId, text, adapter, options!.terminalMode!, traceId);
       return;
     }
 

--- a/web/src/lib/terminal-manager-send.test.ts
+++ b/web/src/lib/terminal-manager-send.test.ts
@@ -366,7 +366,7 @@ describe("TerminalManager（长文本发送策略）", () => {
     expect(hostPty.write).toHaveBeenCalledWith("pty-screen-ack-gated", "\r");
   });
 
-  it("Codex 在 PowerShell 多行文本场景下，会通过单次 bracketed paste 发送正文并在最小等待后提交", async () => {
+  it("Codex 在 PowerShell 长多行文本场景下，会通过单次 bracketed paste 发送正文并在最小等待后提交", async () => {
     vi.useFakeTimers();
     const adapter: any = createAdapterStub();
     const hostPty = createHostPtyStub();
@@ -390,7 +390,7 @@ describe("TerminalManager（长文本发送策略）", () => {
     tm.ensurePersistentContainer("tab-codex");
     tm.setPty("tab-codex", "pty-codex");
 
-    const text = [
+    const baseText = [
       "请完成：",
       "1. 检查 Serena、GitNexus、ast-grep 在当前会话是否可用；任一不可用，直接报告并停止。",
       "2. Serena分别检查源仓、当前仓的准备状态；若未完成 onboarding，则完成。若一次只能激活一个项目，请明确说明后续需在两仓间切换。",
@@ -399,6 +399,8 @@ describe("TerminalManager（长文本发送策略）", () => {
       "",
       "最后只输出：三者可用性、源仓准备状态、当前仓准备状态、需预处理项、是否可进入正式任务。",
     ].join("\n");
+    const text = Array.from({ length: 4 }, () => baseText).join("\n");
+    expect(text.length).toBeGreaterThan(1000);
     await tm.sendTextAndEnter("tab-codex", text, { providerId: "codex", terminalMode: "pwsh" as any });
     const minWaitMs = getPasteSubmitMinWaitMs({ providerId: "codex", terminalMode: "pwsh" as any, textLength: text.length });
 
@@ -426,24 +428,11 @@ describe("TerminalManager（长文本发送策略）", () => {
     tm.disposeAll(false);
   });
 
-  it("Codex 在 PowerShell 单行文本场景下，仍优先走 adapter.paste", async () => {
+  it("Codex 在 PowerShell 短单行文本场景下，会优先走 adapter.paste 并快速提交", async () => {
     vi.useFakeTimers();
     const adapter: any = createAdapterStub();
     const hostPty = createHostPtyStub();
     createTerminalAdapterMock.mockReturnValue(adapter);
-
-    let snapshotText = "";
-    adapter.readCursorTextSnapshot.mockImplementation(() => {
-      if (!snapshotText) return null;
-      return {
-        bufferType: "alternate",
-        cursorAbsY: 22,
-        startAbsY: 21,
-        endAbsY: 22,
-        lines: [snapshotText],
-        text: snapshotText,
-      };
-    });
 
     const ptyByTab: Record<string, string> = { "tab-codex-single": "pty-codex-single" };
     const tm = new TerminalManager((tabId) => ptyByTab[tabId], hostPty as any, {});
@@ -452,7 +441,6 @@ describe("TerminalManager（长文本发送策略）", () => {
 
     const text = "单行正文不会拆分";
     await tm.sendTextAndEnter("tab-codex-single", text, { providerId: "codex", terminalMode: "pwsh" as any });
-    const minWaitMs = getPasteSubmitMinWaitMs({ providerId: "codex", terminalMode: "pwsh" as any, textLength: text.length });
 
     expect(adapter.paste).toHaveBeenCalledWith(text);
     expect(hostPty.write).not.toHaveBeenCalledWith(
@@ -461,20 +449,39 @@ describe("TerminalManager（长文本发送策略）", () => {
     );
     expect(hostPty.write).not.toHaveBeenCalledWith("pty-codex-single", "\r");
 
-    snapshotText = text;
-    vi.advanceTimersByTime(40);
+    vi.advanceTimersByTime(31);
     expect(hostPty.write).not.toHaveBeenCalledWith("pty-codex-single", "\r");
-
-    vi.advanceTimersByTime(40);
-    const remainMinWaitMs = Math.max(0, minWaitMs - 80);
-    if (remainMinWaitMs > 0) {
-      expect(hostPty.write).not.toHaveBeenCalledWith("pty-codex-single", "\r");
-      vi.advanceTimersByTime(remainMinWaitMs - 1);
-      expect(hostPty.write).not.toHaveBeenCalledWith("pty-codex-single", "\r");
-      vi.advanceTimersByTime(1);
-    }
-
+    vi.advanceTimersByTime(1);
     expect(hostPty.write).toHaveBeenCalledWith("pty-codex-single", "\r");
+
+    tm.disposeAll(false);
+  });
+
+  it("Codex 在 PowerShell 短多行文本场景下，会通过 bracketed paste 快速提交", async () => {
+    vi.useFakeTimers();
+    const adapter: any = createAdapterStub();
+    const hostPty = createHostPtyStub();
+    createTerminalAdapterMock.mockReturnValue(adapter);
+
+    const ptyByTab: Record<string, string> = { "tab-codex-short-multi": "pty-codex-short-multi" };
+    const tm = new TerminalManager((tabId) => ptyByTab[tabId], hostPty as any, {});
+    tm.ensurePersistentContainer("tab-codex-short-multi");
+    tm.setPty("tab-codex-short-multi", "pty-codex-short-multi");
+
+    const text = "第一行\n第二行";
+    await tm.sendTextAndEnter("tab-codex-short-multi", text, { providerId: "codex", terminalMode: "pwsh" as any });
+
+    expect(adapter.paste).not.toHaveBeenCalled();
+    expect(hostPty.write).toHaveBeenCalledWith(
+      "pty-codex-short-multi",
+      `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}`,
+    );
+    expect(hostPty.write).not.toHaveBeenCalledWith("pty-codex-short-multi", "\r");
+
+    vi.advanceTimersByTime(31);
+    expect(hostPty.write).not.toHaveBeenCalledWith("pty-codex-short-multi", "\r");
+    vi.advanceTimersByTime(1);
+    expect(hostPty.write).toHaveBeenCalledWith("pty-codex-short-multi", "\r");
 
     tm.disposeAll(false);
   });


### PR DESCRIPTION
在 Windows/PowerShell 终端中，Codex 短文本发送不再走屏幕 ACK/PTY 静默等待， 避免短消息偶现数秒后才提交。

- 为 Codex Windows 短文本新增快速提交路径，正文写入后短暂 settle 即发送 Enter
- 长文本继续保留屏幕 ACK/PTY 静默等待策略，降低大粘贴抢跑风险
- 短多行正文仍强制使用 bracketed paste，避免换行被拆成多次提交
- 补充发送策略测试，覆盖短单行、短多行与长多行边界