### PR TITLE
fix(terminal): 优化 Codex 粘贴回显提交等待

### DIFF
--- a/web/src/lib/TerminalManager.ts
+++ b/web/src/lib/TerminalManager.ts
@@ -437,15 +437,15 @@ export default class TerminalManager {
     };
 
     const provider = String(providerId || "").trim().toLowerCase();
-    const placeholderMarkers =
-      provider === "codex"
-        ? [this.buildCodexScreenAckMarker(normalized)]
-        : provider === "gemini"
-          ? [this.buildGeminiScreenAckMarker(normalized)]
-          : provider === "claude"
-            ? this.buildClaudeScreenAckMarkers(normalized)
-            : [];
-    placeholderMarkers.forEach((marker) => pushMarker(marker));
+    if (provider === "codex") {
+      const codexMarker = this.buildCodexScreenAckMarker(normalized);
+      pushMarker(codexMarker);
+      if (codexMarker) pushMarker("[Pasted Content");
+    } else if (provider === "gemini") {
+      pushMarker(this.buildGeminiScreenAckMarker(normalized));
+    } else if (provider === "claude") {
+      this.buildClaudeScreenAckMarkers(normalized).forEach((marker) => pushMarker(marker));
+    }
 
     const lines = normalized
       .split("\n")
@@ -553,6 +553,7 @@ export default class TerminalManager {
     let unsub: (() => void) | undefined;
     let dataEventCount = 0;
     let screenAckStableCount = 0;
+    let ptyAckBuffer = "";
     let lastScreenAckMarker = "";
     let lastScreenAckBlockedMarker = "";
 
@@ -677,6 +678,19 @@ export default class TerminalManager {
     unsub = this.hostPty.onData(ptyId, (data) => {
       if (!data) return;
       dataEventCount += 1;
+      if (screenAckProbe?.markers.length) {
+        ptyAckBuffer = (ptyAckBuffer + data).slice(-4096);
+        const haystack = this.collapseSendProbeWhitespace(ptyAckBuffer);
+        const matchedPtyAckMarker = screenAckProbe.markers.find((marker) => haystack.includes(marker));
+        if (matchedPtyAckMarker) {
+          this.logSendDiagnostic(
+            traceId,
+            `pty-ack.hit elapsedMs=${Math.max(0, Date.now() - startedAt)} marker=${matchedPtyAckMarker}`
+          );
+          attemptFinish("pty-ack");
+          return;
+        }
+      }
       if (dataEventCount <= 3 || data.includes("[Pasted Content")) {
         this.logSendDiagnostic(
           traceId,

--- a/web/src/lib/terminal-manager-send.test.ts
+++ b/web/src/lib/terminal-manager-send.test.ts
@@ -479,6 +479,33 @@ describe("TerminalManager（长文本发送策略）", () => {
     tm.disposeAll(false);
   });
 
+  it("Codex 在屏幕 ACK 未命中但 PTY 已回显粘贴占位符时，会在最小等待后提交", async () => {
+    vi.useFakeTimers();
+    const adapter: any = createAdapterStub();
+    const hostPty = createHostPtyStub();
+    createTerminalAdapterMock.mockReturnValue(adapter);
+
+    adapter.readCursorTextSnapshot.mockReturnValue(null);
+
+    const ptyByTab: Record<string, string> = { "tab-codex-pty-ack": "pty-codex-pty-ack" };
+    const tm = new TerminalManager((tabId) => ptyByTab[tabId], hostPty as any, {});
+    tm.ensurePersistentContainer("tab-codex-pty-ack");
+    tm.setPty("tab-codex-pty-ack", "pty-codex-pty-ack");
+
+    const text = "x".repeat(1201);
+    const minWaitMs = getPasteSubmitMinWaitMs({ providerId: "codex", terminalMode: "pwsh" as any, textLength: text.length });
+    await tm.sendTextAndEnter("tab-codex-pty-ack", text, { providerId: "codex", terminalMode: "pwsh" as any });
+
+    hostPty.emitData("pty-codex-pty-ack", "[Pasted Content 1.2k chars]");
+    vi.advanceTimersByTime(minWaitMs - 1);
+    expect(hostPty.write).not.toHaveBeenCalledWith("pty-codex-pty-ack", "\r");
+
+    vi.advanceTimersByTime(1);
+    expect(hostPty.write).toHaveBeenCalledWith("pty-codex-pty-ack", "\r");
+
+    tm.disposeAll(false);
+  });
+
   it("Codex 在 PowerShell 多行文本的 write_only 场景下，会通过单次 bracketed paste 写入正文", async () => {
     const adapter: any = createAdapterStub();
     const hostPty = createHostPtyStub();


### PR DESCRIPTION
产品层面：
- 改善 Codex 在 Windows/PowerShell 下发送长文本后等待过久的问题；
- 当终端屏幕快照读不到输入区 ACK，但 PTY 已经回显粘贴占位符时，仍能在最小等待后自动提交。

技术层面：
- 为 Codex 粘贴 ACK 增加 `[Pasted Content` 前缀匹配，兼容 `1.2k chars` 这类压缩显示；
- 在发送等待流程中维护 PTY 回显尾部缓存，用同一组 ACK 标记识别 PTY 回显；
- 补充 Codex PTY ACK 命中后的最小等待提交测试。

Sign-off-by: Lulu <58587930+lulu-sk@users.noreply.github.com>