### PR TITLE
fix(input): 放行输入区原生右键菜单

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -425,6 +425,15 @@ function isNodeInsideTerminal(node: EventTarget | null | undefined): boolean {
 }
 
 /**
+ * 中文说明：判断右键目标是否为可编辑元素，用于避免调试菜单截获系统编辑菜单。
+ */
+function isEditableContextMenuTarget(node: EventTarget | null | undefined): boolean {
+  const el = node && typeof (node as any).closest === "function" ? (node as HTMLElement) : null;
+  if (!el) return false;
+  return !!el.closest("input, textarea, select, [contenteditable='true']");
+}
+
+/**
  * 中文说明：归一化 worktree 备注基名（去首尾空白，并压缩连续空白为单个空格）。
  */
 function normalizeWorktreeRemarkBaseName(value: unknown): string {
@@ -1422,6 +1431,10 @@ export default function CodexFlowManagerUI() {
   const openTabContextMenu = React.useCallback((event: React.MouseEvent, tabId: string | null, source: string) => {
     const id = tabId || "none";
     notifyLog(`ctx.menu.request source=${source} tab=${id} enabled=${showNotifDebugMenu ? '1' : '0'}`);
+    if (isEditableContextMenuTarget(event.target)) {
+      notifyLog(`ctx.menu.editableSkip source=${source} tab=${id}`);
+      return;
+    }
     event.preventDefault();
     event.stopPropagation();
     if (!showNotifDebugMenu) {

--- a/web/src/components/ui/path-chips-input.test.tsx
+++ b/web/src/components/ui/path-chips-input.test.tsx
@@ -251,6 +251,18 @@ async function clickElement(target: HTMLElement): Promise<void> {
   });
 }
 
+/**
+ * 中文说明：派发右键菜单事件，返回事件是否未被 preventDefault。
+ */
+async function dispatchContextMenu(target: HTMLElement): Promise<{ allowed: boolean; defaultPrevented: boolean }> {
+  const event = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+  let allowed = false;
+  await act(async () => {
+    allowed = target.dispatchEvent(event);
+  });
+  return { allowed, defaultPrevented: event.defaultPrevented };
+}
+
 describe("PathChipsInput（复制文件名按钮）", () => {
   let cleanup: (() => void) | null = null;
 
@@ -507,5 +519,37 @@ describe("PathChipsInput 撤回历史", () => {
     });
 
     expect(image.getAttribute("src")).toBe("file:///C:/repo/image.png");
+  });
+});
+
+describe("PathChipsInput 右键菜单事件", () => {
+  let cleanup: (() => void) | null = null;
+
+  afterEach(() => {
+    try { cleanup?.(); } catch {}
+    cleanup = null;
+  });
+
+  it("输入区右键应放行原生菜单，并阻止父级右键菜单截获", async () => {
+    const mounted = createMountedRoot();
+    cleanup = mounted.unmount;
+    const parentContextMenu = vi.fn((event: React.MouseEvent<HTMLDivElement>) => {
+      event.preventDefault();
+    });
+
+    await act(async () => {
+      mounted.root.render(
+        <div onContextMenu={parentContextMenu}>
+          <Harness initialDraft="hello" />
+        </div>
+      );
+    });
+
+    const editor = getEditor(mounted.host);
+    const result = await dispatchContextMenu(editor);
+
+    expect(parentContextMenu).not.toHaveBeenCalled();
+    expect(result.allowed).toBe(true);
+    expect(result.defaultPrevented).toBe(false);
   });
 });

--- a/web/src/components/ui/path-chips-input.tsx
+++ b/web/src/components/ui/path-chips-input.tsx
@@ -544,7 +544,7 @@ export default function PathChipsInput({
     base,
     "transition-all duration-apple ease-apple select-none hover:border-[var(--cf-border-strong)] text-[var(--cf-text-primary)]",
     // 减小顶部内边距，靠近容器上边缘；保留底部内边距保证输入区呼吸感
-    multiline ? "min-h-[7.5rem] pt-0.5 pb-2" : "min-h-10 pt-0.5 pb-1",
+    multiline ? "flex flex-col min-h-[7.5rem] pt-0.5 pb-2" : "min-h-10 pt-0.5 pb-1",
     className
   );
 
@@ -1117,6 +1117,14 @@ export default function PathChipsInput({
   }, [resolveChipFileName]);
 
   /**
+   * 中文说明：放行输入框原生右键菜单，并阻止外层标签页右键处理吞掉默认编辑菜单。
+   */
+  const onEditableContextMenu = useCallback((event: React.MouseEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    event.stopPropagation();
+    setCtxMenu((menu) => menu.show ? { ...menu, show: false } : menu);
+  }, []);
+
+  /**
    * 中文说明：将当前草稿中的路径片段提交为 Chip，并清空草稿。
    */
   const commitDraftToChips = useCallback(() => {
@@ -1548,13 +1556,14 @@ export default function PathChipsInput({
             onBeforeInput={onBeforeInput}
             onKeyDown={onKeyDown}
             onPaste={onPaste}
+            onContextMenu={onEditableContextMenu}
             rows={3}
             // 说明：
             // - resize-none 禁用手动拖拽；whitespace-pre-wrap + break-words 实现中文/长词自动换行；
             // - leading-5 提升可读性；min-h 保持与容器协调；pb-10 给右下角发送按钮留出垂直空间；
             style={balancedScrollbarGutter ? ({ scrollbarGutter: 'stable both-edges' } as any) : undefined}
             className={cn(
-              "block w-full min-w-[8rem] outline-none bg-[var(--cf-surface-solid)] placeholder:text-[var(--cf-text-muted)] text-[var(--cf-text-primary)] select-text resize-none whitespace-pre-wrap break-words leading-5",
+              "block flex-1 w-full min-w-[8rem] outline-none bg-[var(--cf-surface-solid)] placeholder:text-[var(--cf-text-muted)] text-[var(--cf-text-primary)] select-text resize-none whitespace-pre-wrap break-words leading-5",
               "py-0.5 pb-10 min-h-[1.5rem]",
               draftInputClassName,
             )}
@@ -1568,6 +1577,7 @@ export default function PathChipsInput({
             onBeforeInput={onBeforeInput}
             onKeyDown={onKeyDown}
             onPaste={onPaste}
+            onContextMenu={onEditableContextMenu}
             onPointerDown={(e) => { try { (e.target as HTMLElement).setPointerCapture((e as any).pointerId); } catch {} }}
             placeholder={chips.length === 0 ? (rest as any)?.placeholder : undefined}
             style={balancedScrollbarGutter ? ({ scrollbarGutter: 'stable both-edges' } as any) : undefined}


### PR DESCRIPTION
右键输入区时，外层标签页调试菜单会截获 contextmenu 事件，导致系统原生剪切、复制、粘贴菜单不可用。

本次调整在标签页菜单入口识别可编辑目标并跳过调试菜单，同时让 PathChipsInput 的 textarea/input 阻止右键事件继续冒泡，保留输入控件的原生编辑菜单。

同时补充输入区右键事件测试，覆盖父级菜单不应被触发且默认菜单不应被阻止的场景。