### PR TITLE
feat(notifications): 优化任务栏角标状态展示

### DIFF
--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -9,7 +9,12 @@ import settings from './settings';
 import { perfLogger } from './log';
 import { activateWindowPreservingState } from './windowActivation';
 
-type BadgePayload = { count?: number };
+type BadgePayload = {
+  count?: number;
+  completedCount?: number;
+  runningCount?: number;
+  hasRunningTask?: boolean;
+};
 
 type CompletionPayload = {
   tabId: string;
@@ -21,6 +26,7 @@ type CompletionPayload = {
   appTitle?: string;
 };
 
+const RUNNING_OVERLAY_LABEL = 'running';
 const OVERLAY_CACHE = new Map<string, Electron.NativeImage>();
 const BADGE_CANVAS_SIZE = 32;
 const GLYPH_WIDTH = 5;
@@ -289,6 +295,26 @@ function renderBadgeBitmap(text: string): Buffer {
   return buffer;
 }
 
+/**
+ * 渲染运行中任务使用的蓝色圆点覆盖图位图。
+ */
+function renderRunningBitmap(): Buffer {
+  const buffer = Buffer.alloc(BADGE_CANVAS_SIZE * BADGE_CANVAS_SIZE * 4, 0);
+  const radius = 9;
+  const cx = BADGE_CANVAS_SIZE / 2 - 0.5;
+  const cy = BADGE_CANVAS_SIZE / 2 - 0.5;
+  for (let y = 0; y < BADGE_CANVAS_SIZE; y += 1) {
+    for (let x = 0; x < BADGE_CANVAS_SIZE; x += 1) {
+      const dx = x - cx;
+      const dy = y - cy;
+      if (dx * dx + dy * dy <= radius * radius) {
+        setPixel(buffer, x, y, 37, 99, 235, 255);
+      }
+    }
+  }
+  return buffer;
+}
+
 function logNotification(message: string) {
   try { perfLogger.log(`[notifications] ${message}`); } catch {}
 }
@@ -307,7 +333,7 @@ function createOverlayIcon(label: string): Electron.NativeImage {
   const cached = OVERLAY_CACHE.get(label);
   if (cached) return cached;
   const text = label.length > 3 ? label.slice(0, 3) : label;
-  const bitmap = renderBadgeBitmap(text);
+  const bitmap = label === RUNNING_OVERLAY_LABEL ? renderRunningBitmap() : renderBadgeBitmap(text);
   let image = nativeImage.createFromBitmap(bitmap, {
     width: BADGE_CANVAS_SIZE,
     height: BADGE_CANVAS_SIZE,
@@ -380,22 +406,34 @@ export function registerNotificationIPC(getWindow: () => BrowserWindow | null, o
     return p;
   })();
   logNotification(`register IPC appUserModelId=${appUserModelId || 'none'}`);
-  const updateBadge = (count: number) => {
+  /**
+   * 按完成数优先、运行中次之的规则同步系统任务栏角标。
+   */
+  const updateBadge = (completedCount: number, runningCount: number) => {
     const enabled = shouldEnableBadge();
-    const safe = enabled ? count : 0;
-    logNotification(`updateBadge count=${count} effective=${safe} enabled=${enabled} platform=${process.platform}`);
-    try { app.setBadgeCount(safe); } catch {}
+    const safeCompleted = enabled ? completedCount : 0;
+    const safeRunning = enabled && safeCompleted <= 0 ? runningCount : 0;
+    logNotification(`updateBadge completed=${completedCount} running=${runningCount} effectiveCompleted=${safeCompleted} effectiveRunning=${safeRunning} enabled=${enabled} platform=${process.platform}`);
+    try { app.setBadgeCount(safeCompleted); } catch {}
     if (process.platform === 'win32') {
       const win = getWindow();
       if (!win) return;
-      if (safe > 0) {
-        const label = labelForCount(safe);
+      if (safeCompleted > 0) {
+        const label = labelForCount(safeCompleted);
         const icon = createOverlayIcon(label);
         try {
           win.setOverlayIcon(icon, `${label}`);
           logNotification(`setOverlayIcon label=${label}`);
         } catch (error) {
           logNotification(`setOverlayIcon failed: ${String(error)}`);
+        }
+      } else if (safeRunning > 0) {
+        const icon = createOverlayIcon(RUNNING_OVERLAY_LABEL);
+        try {
+          win.setOverlayIcon(icon, 'running');
+          logNotification('setOverlayIcon label=running');
+        } catch (error) {
+          logNotification(`setOverlayIcon running failed: ${String(error)}`);
         }
       } else {
         try {
@@ -408,10 +446,14 @@ export function registerNotificationIPC(getWindow: () => BrowserWindow | null, o
     }
   };
 
+  /**
+   * 接收渲染进程推送的任务栏角标状态。
+   */
   const onSetBadge = (_event: Electron.IpcMainEvent, payload: BadgePayload) => {
-    const count = coerceCount(payload?.count);
-    logNotification(`setBadge IPC count=${count}`);
-    updateBadge(count);
+    const completedCount = coerceCount(typeof payload?.completedCount === 'number' ? payload.completedCount : payload?.count);
+    const runningCount = payload?.hasRunningTask ? Math.max(1, coerceCount(payload?.runningCount)) : coerceCount(payload?.runningCount);
+    logNotification(`setBadge IPC completed=${completedCount} running=${runningCount}`);
+    updateBadge(completedCount, runningCount);
   };
 
   const onAgentComplete = (_event: Electron.IpcMainEvent, payload: CompletionPayload) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -557,6 +557,10 @@ contextBridge.exposeInMainWorld('host', {
     setBadgeCount: (count: number) => {
       ipcRenderer.send('notifications:setBadge', { count });
     },
+    // 同步任务栏角标状态，完成数量优先于运行中提示。
+    setTaskbarBadgeState: (state: { completedCount?: number; runningCount?: number; hasRunningTask?: boolean }) => {
+      ipcRenderer.send('notifications:setBadge', state);
+    },
     showAgentCompletion: (payload: { tabId: string; tabName?: string; projectName?: string; preview?: string; title: string; body: string; appTitle?: string }) => {
       ipcRenderer.send('notifications:agentComplete', payload);
     },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2122,13 +2122,33 @@ export default function CodexFlowManagerUI() {
     return total;
   }
 
+  /**
+   * 统计当前仍处于工作中的任务数量，用于驱动系统任务栏运行中角标。
+   */
+  function computeRunningTaskTotal(map: Record<string, AgentTurnTimerState>): number {
+    let total = 0;
+    for (const state of Object.values(map)) {
+      if (state?.status === "working") total += 1;
+    }
+    return total;
+  }
+
+  /**
+   * 同步任务栏角标状态：完成任务数量优先，未完成数量为 0 时才显示运行中角标。
+   */
   function syncTaskbarBadge(map: Record<string, number>, prefs?: CompletionPreferences) {
     try {
       const effective = prefs ?? notificationPrefsRef.current;
       const rawTotal = computePendingTotal(map);
       const total = effective.badge ? rawTotal : 0;
-      notifyLog(`syncTaskbarBadge raw=${rawTotal} effective=${total} enabled=${effective.badge}`);
-      window.host.notifications?.setBadgeCount?.(total);
+      const rawRunning = computeRunningTaskTotal(agentTurnTimerByTabRef.current);
+      const running = effective.badge && total <= 0 ? rawRunning : 0;
+      notifyLog(`syncTaskbarBadge raw=${rawTotal} runningRaw=${rawRunning} effective=${total} running=${running} enabled=${effective.badge}`);
+      if (window.host.notifications?.setTaskbarBadgeState) {
+        window.host.notifications.setTaskbarBadgeState({ completedCount: total, runningCount: running, hasRunningTask: running > 0 });
+      } else {
+        window.host.notifications?.setBadgeCount?.(total);
+      }
     } catch {}
   }
 
@@ -4220,6 +4240,10 @@ export default function CodexFlowManagerUI() {
   useEffect(() => {
     syncTaskbarBadge(pendingCompletionsRef.current, notificationPrefs);
   }, [notificationPrefs]);
+
+  useEffect(() => {
+    syncTaskbarBadge(pendingCompletionsRef.current);
+  }, [agentTurnTimerByTab]);
 
   useEffect(() => {
     const aliveTabs = new Set<string>();

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -811,6 +811,8 @@ export type ProjectPreferredIde = BuiltinIdeId;
 
 export interface NotificationsAPI {
   setBadgeCount(count: number): void;
+  /** 同步任务栏角标状态；完成数量优先于运行中提示。 */
+  setTaskbarBadgeState?(state: { completedCount?: number; runningCount?: number; hasRunningTask?: boolean }): void;
   showAgentCompletion(payload: { tabId: string; tabName?: string; projectName?: string; preview?: string; title: string; body: string; appTitle?: string }): void;
   /** 监听主进程转发的外部完成通知（如 Codex/Gemini/Claude hook -> JSONL 桥接）。 */
   onExternalAgentComplete?(handler: (payload: { providerId?: "codex" | "gemini" | "claude"; tabId?: string; envLabel?: string; preview?: string; previewEscapedWhitespace?: boolean; timestamp?: string; eventId?: string }) => void): () => void;


### PR DESCRIPTION
完成任务数量仍作为任务栏角标的最高优先级；当没有完成任务但存在运行中的 agent 任务时，改为显示运行中提示。

- 渲染端统计完成数量与运行中任务数量，并同步到 Host 通知接口
- 预加载层新增任务栏角标状态接口，同时保留旧计数接口兼容
- 主进程按完成数优先、运行中次之的规则更新角标，并在 Windows 上使用蓝色圆点展示运行中状态