### PR TITLE
fix(agents): 兼容新版 Gemini CLI / Claude 通知

### DIFF
--- a/electron/agentSessions/gemini/discovery.test.ts
+++ b/electron/agentSessions/gemini/discovery.test.ts
@@ -20,15 +20,17 @@ describe("discoverGeminiSessionFiles", () => {
   it("supports both hash and non-hash project directories", async () => {
     const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codexflow-gemini-discovery-"));
 
-    await touch(root, "codexflow/chats/session-2026-03-04T17-09-cc28c19a.json");
+    await touch(root, "codexflow/chats/session-2026-03-04T17-09-cc28c19a.jsonl");
     await touch(root, "567266847957ce43ba0e98d21b65cf333047f193f52e511da7be4fcbf53e53ba/chats/session-2026-03-04T17-10-aabbccdd.json");
+    await touch(root, "codexflow/session-2026-03-04T17-11-eeff0011.jsonl");
     await touch(root, "codexflow/chats/ignore.txt");
 
     const files = await discoverGeminiSessionFiles(root);
     const rel = files.map((f) => path.relative(root, f).replace(/\\/g, "/")).sort();
 
-    expect(rel).toContain("codexflow/chats/session-2026-03-04T17-09-cc28c19a.json");
+    expect(rel).toContain("codexflow/chats/session-2026-03-04T17-09-cc28c19a.jsonl");
     expect(rel).toContain("567266847957ce43ba0e98d21b65cf333047f193f52e511da7be4fcbf53e53ba/chats/session-2026-03-04T17-10-aabbccdd.json");
+    expect(rel).toContain("codexflow/session-2026-03-04T17-11-eeff0011.jsonl");
     expect(rel.find((x) => x.endsWith("ignore.txt"))).toBeUndefined();
   });
 });

--- a/electron/agentSessions/gemini/discovery.ts
+++ b/electron/agentSessions/gemini/discovery.ts
@@ -78,8 +78,8 @@ export async function getGeminiRootCandidatesFastAsync(): Promise<SessionsRootCa
 
 /**
  * 扫描 Gemini CLI 会话文件：
- * - 目录结构：`root/<projectKey>/chats/session-*.json`（优先）
- * - 兼容：`root/<projectKey>/session-*.json`
+ * - 新版目录结构：`root/<projectKey>/chats/session-*.jsonl`（优先）
+ * - 旧版兼容：`root/<projectKey>/chats/session-*.json` 与 `root/<projectKey>/session-*.json`
  *
  * 说明：
  * - `projectKey` 既可能是旧版 `projectHash`（32~64 hex），也可能是新版可读目录名（如项目名）。
@@ -98,26 +98,37 @@ export async function discoverGeminiSessionFiles(root: string): Promise<string[]
       if (!name) continue;
       const projDir = path.join(baseRoot, name);
 
-      // chats/session-*.json
+      // chats/session-*.jsonl / session-*.json
       const chatsDir = path.join(projDir, "chats");
       if (await directoryExists(chatsDir)) {
         const files = await fsp.readdir(chatsDir, { withFileTypes: true }).catch(() => [] as import("node:fs").Dirent[]);
         for (const f of files) {
           if (!f.isFile()) continue;
           const fn = f.name.toLowerCase();
-          if (fn.startsWith("session-") && fn.endsWith(".json")) out.push(path.join(chatsDir, f.name));
+          if (isGeminiSessionFileName(fn)) out.push(path.join(chatsDir, f.name));
         }
       }
 
-      // fallback: project dir session-*.json
+      // fallback: project dir session-*.jsonl / session-*.json
       const files2 = await fsp.readdir(projDir, { withFileTypes: true }).catch(() => [] as import("node:fs").Dirent[]);
       for (const f of files2) {
         if (!f.isFile()) continue;
         const fn = f.name.toLowerCase();
-        if (fn.startsWith("session-") && fn.endsWith(".json")) out.push(path.join(projDir, f.name));
+        if (isGeminiSessionFileName(fn)) out.push(path.join(projDir, f.name));
       }
     }
   } catch {}
   return out;
+}
+
+/**
+ * 判断文件名是否为 Gemini CLI 会话文件。
+ *
+ * @param fileName 小写或原始文件名
+ * @returns 是否为 Gemini 会话文件
+ */
+function isGeminiSessionFileName(fileName: string): boolean {
+  const fn = String(fileName || "").toLowerCase();
+  return fn.startsWith("session-") && (fn.endsWith(".jsonl") || fn.endsWith(".json"));
 }
 

--- a/electron/agentSessions/gemini/parser.test.ts
+++ b/electron/agentSessions/gemini/parser.test.ts
@@ -36,6 +36,21 @@ async function writeTempJsonAtRelPath(obj: unknown, relPath: string): Promise<st
 }
 
 /**
+ * 在临时目录写入 Gemini JSONL 会话文件并返回路径。
+ *
+ * @param records JSONL 记录列表
+ * @param relPath 相对临时目录的目标路径
+ * @returns 临时文件路径
+ */
+async function writeTempJsonlAtRelPath(records: unknown[], relPath: string): Promise<string> {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codexflow-gemini-jsonl-"));
+  const fp = path.join(dir, relPath);
+  await fs.promises.mkdir(path.dirname(fp), { recursive: true });
+  await fs.promises.writeFile(fp, records.map((item) => JSON.stringify(item)).join("\n") + "\n", "utf8");
+  return fp;
+}
+
+/**
  * 创建临时图片文件占位，供 Gemini 图片路径优先逻辑测试使用。
  *
  * @param fileName 文件名
@@ -143,6 +158,178 @@ describe("parseGeminiSessionFile（超大文件 summaryOnly 预览兜底）", ()
     expect(imageItem?.localPath).toBe(localImagePath);
     expect(String(imageItem?.src || "")).toBe("data:image/png;base64,aGVsbG8=");
     expect(String(imageItem?.fallbackSrc || "")).toMatch(/^file:\/\//);
+  });
+
+  it("支持新版 Gemini JSONL 会话格式并保留助手回复", async () => {
+    const projectHash = "567266847957ce43ba0e98d21b65cf333047f193f52e511da7be4fcbf53e53ba";
+    const sessionId = "cc28c19a-73b0-470a-b8cf-738ec6a547a8";
+    const fp = await writeTempJsonlAtRelPath(
+      [
+        {
+          sessionId,
+          projectHash,
+          startTime: "2026-05-28T04:50:00.000Z",
+          lastUpdated: "2026-05-28T04:50:00.000Z",
+          directories: ["G:\\Projects\\CodexFlow"],
+        },
+        {
+          id: "user-1",
+          timestamp: "2026-05-28T04:50:01.000Z",
+          type: "user",
+          content: [{ text: "test" }],
+        },
+        {
+          id: "gemini-1",
+          timestamp: "2026-05-28T04:50:02.000Z",
+          type: "gemini",
+          content: [{ text: "你好，请问有什么我可以帮您的？" }],
+          model: "gemini-3.5-flash",
+        },
+        {
+          $set: {
+            lastUpdated: "2026-05-28T04:50:03.000Z",
+          },
+        },
+      ],
+      `${projectHash}/chats/session-2026-05-28T04-50-${sessionId.slice(0, 8)}.jsonl`,
+    );
+    const stat = await fs.promises.stat(fp);
+
+    const summary = await parseGeminiSessionFile(fp, stat, { summaryOnly: true, maxBytes: 128 * 1024 });
+    expect(summary.preview).toBe("test");
+    expect(summary.title).toBe("test");
+    expect(summary.resumeId).toBe(sessionId);
+    expect(summary.projectHash).toBe(projectHash);
+    expect(summary.cwd).toBe("G:\\Projects\\CodexFlow");
+    expect(summary.rawDate).toBe("2026-05-28T04:50:03.000Z");
+
+    const details = await parseGeminiSessionFile(fp, stat, { summaryOnly: false, maxBytes: 128 * 1024 });
+    expect(details.messages).toHaveLength(2);
+    expect(details.messages[0]).toEqual({
+      role: "user",
+      content: [{ type: "input_text", text: "test" }],
+    });
+    expect(details.messages[1]).toEqual({
+      role: "assistant",
+      content: [{ type: "output_text", text: "你好，请问有什么我可以帮您的？" }],
+    });
+  });
+
+  it("新版 Gemini JSONL 会跳过自动 session_context 预览并归类为 meta", async () => {
+    const fp = await writeTempJsonlAtRelPath(
+      [
+        {
+          sessionId: "session-context-case",
+          projectHash: "567266847957ce43ba0e98d21b65cf333047f193f52e511da7be4fcbf53e53ba",
+          startTime: "2026-05-28T05:10:00.000Z",
+          directories: ["G:\\Projects\\CodexFlow"],
+        },
+        {
+          id: "context-1",
+          type: "user",
+          content: [{ text: "<session_context>\nThis is the Gemini CLI. We are setting up the context for our chat." }],
+        },
+        {
+          id: "user-1",
+          type: "user",
+          content: [{ text: "真实问题" }],
+        },
+      ],
+      "project/chats/session-2026-05-28T05-10-context.jsonl",
+    );
+    const stat = await fs.promises.stat(fp);
+
+    const summary = await parseGeminiSessionFile(fp, stat, { summaryOnly: true, maxBytes: 128 * 1024 });
+    expect(summary.preview).toBe("真实问题");
+    expect(summary.title).toBe("真实问题");
+
+    const details = await parseGeminiSessionFile(fp, stat, { summaryOnly: false, maxBytes: 128 * 1024 });
+    expect(details.messages[0]).toEqual({
+      role: "system",
+      content: [{ type: "meta", text: "<session_context>\nThis is the Gemini CLI. We are setting up the context for our chat." }],
+    });
+    expect(details.messages[1]).toEqual({
+      role: "user",
+      content: [{ type: "input_text", text: "真实问题" }],
+    });
+  });
+
+  it("新版 Gemini JSONL 优先使用 metadata directories 推断项目目录", async () => {
+    const projectHash = "567266847957ce43ba0e98d21b65cf333047f193f52e511da7be4fcbf53e53ba";
+    const fp = await writeTempJsonlAtRelPath(
+      [
+        {
+          sessionId: "directory-priority-case",
+          projectHash,
+          startTime: "2026-05-28T05:20:00.000Z",
+          directories: ["G:\\Projects\\CodexFlow"],
+        },
+        {
+          id: "user-1",
+          type: "user",
+          content: [{ text: "请查看 C:\\Temp\\other-project\\note.txt 并继续" }],
+        },
+      ],
+      `${projectHash}/chats/session-2026-05-28T05-20-directory.jsonl`,
+    );
+    const stat = await fs.promises.stat(fp);
+
+    const summary = await parseGeminiSessionFile(fp, stat, { summaryOnly: true, maxBytes: 128 * 1024 });
+    expect(summary.cwd).toBe("G:\\Projects\\CodexFlow");
+    expect(summary.dirKey).toBe("/mnt/g/projects/codexflow");
+  });
+
+  it("支持新版 Gemini JSONL 的消息更新与工具结果展示", async () => {
+    const fp = await writeTempJsonlAtRelPath(
+      [
+        {
+          sessionId: "tool-session",
+          projectHash: "2c076481a534981f1d988b55053bccf053f1bec6932623a652d533211c63c763",
+          startTime: "2026-05-28T05:00:00.000Z",
+        },
+        {
+          id: "user-1",
+          type: "user",
+          content: [{ text: "列出文件" }],
+        },
+        {
+          id: "gemini-1",
+          type: "gemini",
+          content: "",
+          toolCalls: [
+            {
+              id: "call-1",
+              name: "ReadFolder",
+              args: { path: "." },
+              status: "executing",
+            },
+          ],
+        },
+        {
+          id: "gemini-1",
+          type: "gemini",
+          content: [{ text: "已经列出文件。" }],
+          toolCalls: [
+            {
+              id: "call-1",
+              name: "ReadFolder",
+              args: { path: "." },
+              status: "success",
+              result: [{ text: "package.json\nREADME.md" }],
+            },
+          ],
+        },
+      ],
+      "project/chats/session-2026-05-28T05-00-tool.jsonl",
+    );
+    const stat = await fs.promises.stat(fp);
+    const details = await parseGeminiSessionFile(fp, stat, { summaryOnly: false, maxBytes: 128 * 1024 });
+
+    expect(details.messages.map((message) => message.role)).toEqual(["user", "assistant", "assistant", "tool"]);
+    expect(details.messages[1].content[0]).toEqual({ type: "output_text", text: "已经列出文件。" });
+    expect(details.messages[2].content[0].type).toBe("tool_call");
+    expect(details.messages[2].content[0].text).toContain("ReadFolder");
+    expect(details.messages[3].content[0]).toEqual({ type: "tool_result", text: "package.json\nREADME.md" });
   });
 });
 

--- a/electron/agentSessions/gemini/parser.ts
+++ b/electron/agentSessions/gemini/parser.ts
@@ -142,6 +142,10 @@ export async function parseGeminiSessionFile(filePath: string, stat: Stats, opts
     messages.push(msg);
   };
 
+  if (isGeminiJsonlSessionFile(filePath)) {
+    return await parseGeminiJsonlSessionFile(filePath, stat, opts);
+  }
+
   if (sizeBytes > maxBytes) {
     // 文件过大时不做完整 JSON.parse；但索引列表仍需要 preview/title。
     try {
@@ -249,14 +253,15 @@ export async function parseGeminiSessionFile(filePath: string, stat: Stats, opts
       const text = extractGeminiText(it);
       const imageItems = extractGeminiImageContents(it);
       if (role === "user") {
-        if (!preview && text) {
+        const isSessionContext = isGeminiSessionContextText(text);
+        if (!preview && text && !isSessionContext) {
           const filtered = filterHistoryPreviewText(text);
           if (filtered) preview = clampPreview(filtered);
         }
         const content: Message["content"] = [];
-        if (text) content.push({ type: "input_text", text });
+        if (text) content.push({ type: isSessionContext ? "meta" : "input_text", text });
         if (imageItems.length > 0) content.push(...imageItems);
-        if (content.length > 0) pushMessage({ role: "user", content });
+        if (content.length > 0) pushMessage({ role: isSessionContext ? "system" : "user", content });
       } else if (role === "assistant") {
         const content: Message["content"] = [];
         if (text) content.push({ type: "output_text", text });
@@ -304,6 +309,366 @@ export async function parseGeminiSessionFile(filePath: string, stat: Stats, opts
 
 type GeminiExtractedMeta = { startTime?: unknown; lastUpdated?: unknown; firstTS?: unknown; lastTS?: unknown };
 type GeminiPrefixExtracted = { rawDate?: string; cwd?: string; preview?: string; resumeId?: string; projectHash?: string };
+type GeminiJsonlMessageRecord = {
+  id?: string;
+  type?: string;
+  timestamp?: string;
+  content?: unknown;
+  displayContent?: unknown;
+  toolCalls?: unknown;
+  model?: string;
+};
+
+/**
+ * 判断文件是否为新版 Gemini CLI 的 JSONL 会话文件。
+ *
+ * @param filePath 会话文件路径
+ * @returns 是否 JSONL 会话文件
+ */
+function isGeminiJsonlSessionFile(filePath: string): boolean {
+  return path.basename(String(filePath || "")).toLowerCase().endsWith(".jsonl");
+}
+
+/**
+ * 解析新版 Gemini CLI JSONL 会话文件。
+ *
+ * @param filePath 会话文件路径
+ * @param stat 文件状态
+ * @param opts 解析选项
+ * @returns 统一后的 Gemini 会话详情
+ */
+async function parseGeminiJsonlSessionFile(filePath: string, stat: Stats, opts?: GeminiParseOptions): Promise<GeminiSessionDetails> {
+  const summaryOnly = !!opts?.summaryOnly;
+  const maxBytes = Math.max(64 * 1024, Math.min(64 * 1024 * 1024, Number(opts?.maxBytes ?? (summaryOnly ? 2 * 1024 * 1024 : 32 * 1024 * 1024))));
+  const date = Number(stat?.mtimeMs || 0);
+  const sizeBytes = Number((stat as any)?.size ?? 0);
+  const id = `gemini:${sha256Hex(filePath)}`;
+  let runtimeShell: RuntimeShell = detectRuntimeShell(filePath);
+  let projectHash = extractGeminiProjectHashFromPath(filePath) || undefined;
+  let rawDate: string | undefined = undefined;
+  let cwd: string | undefined = undefined;
+  let resumeId: string | undefined = undefined;
+  let preview: string | undefined = undefined;
+  let skippedLines = 0;
+  const messages: Message[] = [];
+
+  const metadata: Record<string, unknown> = {};
+  const messageOrder: string[] = [];
+  const messagesById = new Map<string, GeminiJsonlMessageRecord>();
+
+  const readWholeFile = sizeBytes <= maxBytes;
+  const text = readWholeFile
+    ? await fs.readFile(filePath, { encoding: "utf8" }).catch(() => "")
+    : await readUtf8Prefix(filePath, maxBytes);
+  const lines = String(text || "").split(/\r?\n/);
+  if (!readWholeFile && lines.length > 0) lines.pop();
+
+  /**
+   * 合并 JSONL 元信息记录，并同步常用摘要字段。
+   *
+   * @param value 元信息对象或 `$set` 补丁
+   */
+  const mergeMetadata = (value: any) => {
+    if (!value || typeof value !== "object") return;
+    for (const [key, val] of Object.entries(value)) metadata[key] = val;
+    const nextResumeId = pickFirstStringOrNumberAsString(value.sessionId ?? value.session_id ?? value.session);
+    if (nextResumeId) resumeId = nextResumeId;
+    const nextRawDate = pickFirstStringOrNumberAsString(value.lastUpdated ?? value.updatedAt ?? value.last_updated ?? value.startTime ?? value.startedAt ?? value.start_time);
+    if (nextRawDate) rawDate = nextRawDate;
+    const nextHash = normalizeGeminiProjectHash(value.projectHash ?? value.project_hash);
+    if (nextHash) projectHash = nextHash;
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let record: any = null;
+    try {
+      record = JSON.parse(trimmed);
+    } catch {
+      skippedLines++;
+      continue;
+    }
+    if (!record || typeof record !== "object") continue;
+
+    if (typeof record.$rewindTo === "string") {
+      rewindGeminiJsonlMessages(messagesById, messageOrder, record.$rewindTo);
+      continue;
+    }
+
+    if (record.$set && typeof record.$set === "object") {
+      const patch = record.$set as Record<string, unknown>;
+      if (Array.isArray(patch.messages)) {
+        messagesById.clear();
+        messageOrder.length = 0;
+        for (const msg of patch.messages) {
+          if (isGeminiJsonlMessageRecord(msg)) upsertGeminiJsonlMessage(messagesById, messageOrder, msg);
+        }
+      }
+      mergeMetadata(patch);
+      continue;
+    }
+
+    if (isGeminiJsonlMessageRecord(record)) {
+      upsertGeminiJsonlMessage(messagesById, messageOrder, record);
+      continue;
+    }
+
+    mergeMetadata(record);
+    if (Array.isArray(record.messages)) {
+      for (const msg of record.messages) {
+        if (isGeminiJsonlMessageRecord(msg)) upsertGeminiJsonlMessage(messagesById, messageOrder, msg);
+      }
+    }
+  }
+
+  const rawMessages = messageOrder.map((messageId) => messagesById.get(messageId)).filter(Boolean) as GeminiJsonlMessageRecord[];
+  cwd = tryExtractGeminiCwdFromJsonl(metadata, rawMessages) || undefined;
+  if (cwd && projectHash) {
+    try {
+      const want = projectHash.toLowerCase();
+      const cands = deriveGeminiProjectHashCandidatesFromPath(cwd);
+      if (!cands.includes(want)) cwd = undefined;
+    } catch {
+      cwd = undefined;
+    }
+  }
+  if (runtimeShell === "unknown" && cwd) {
+    try {
+      const hint = detectRuntimeShell(cwd);
+      if (hint !== "unknown") runtimeShell = hint;
+    } catch {}
+  }
+
+  for (const msg of rawMessages) {
+    const text = extractGeminiText(msg);
+    if (!preview && normalizeGeminiJsonlRole(msg.type) === "user" && !isGeminiSessionContextText(text)) {
+      const filtered = filterHistoryPreviewText(text);
+      if (filtered) preview = clampPreview(filtered);
+    }
+    if (!summaryOnly) {
+      const converted = convertGeminiJsonlMessageToHistoryMessages(msg);
+      for (const item of converted) messages.push(item);
+    }
+    if (summaryOnly && preview && (cwd || projectHash)) break;
+  }
+
+  const dirKey = cwd ? dirKeyFromCwd(cwd) : dirKeyOfFilePath(filePath);
+  const title = preview ? preview : path.basename(filePath);
+  return {
+    providerId: "gemini",
+    id,
+    title,
+    date,
+    filePath,
+    messages,
+    skippedLines,
+    rawDate,
+    cwd,
+    dirKey,
+    preview,
+    projectHash,
+    resumeId,
+    runtimeShell,
+  };
+}
+
+/**
+ * 判断对象是否为新版 Gemini JSONL 的消息记录。
+ *
+ * @param value 原始对象
+ * @returns 是否消息记录
+ */
+function isGeminiJsonlMessageRecord(value: unknown): value is GeminiJsonlMessageRecord {
+  if (!value || typeof value !== "object") return false;
+  const any = value as any;
+  return typeof any.id === "string" && typeof any.type === "string";
+}
+
+/**
+ * 将 Gemini JSONL 消息写入有序 Map，重复 id 代表同一消息的后续补丁。
+ *
+ * @param messagesById 消息 Map
+ * @param messageOrder 消息顺序
+ * @param message 消息记录
+ */
+function upsertGeminiJsonlMessage(
+  messagesById: Map<string, GeminiJsonlMessageRecord>,
+  messageOrder: string[],
+  message: GeminiJsonlMessageRecord,
+): void {
+  const messageId = String(message.id || "").trim();
+  if (!messageId) return;
+  if (!messagesById.has(messageId)) messageOrder.push(messageId);
+  const previous = messagesById.get(messageId);
+  messagesById.set(messageId, previous ? { ...previous, ...message } : message);
+}
+
+/**
+ * 按 Gemini JSONL 的 rewind 记录回退消息列表。
+ *
+ * @param messagesById 消息 Map
+ * @param messageOrder 消息顺序
+ * @param rewindTo 需要移除的起始消息 id
+ */
+function rewindGeminiJsonlMessages(
+  messagesById: Map<string, GeminiJsonlMessageRecord>,
+  messageOrder: string[],
+  rewindTo: string,
+): void {
+  const rewindId = String(rewindTo || "").trim();
+  const start = rewindId ? messageOrder.indexOf(rewindId) : -1;
+  const removed = messageOrder.splice(start >= 0 ? start : 0);
+  for (const messageId of removed) messagesById.delete(messageId);
+}
+
+/**
+ * 将 Gemini JSONL 的消息类型映射到历史角色。
+ *
+ * @param raw 原始消息类型
+ * @returns 历史角色
+ */
+function normalizeGeminiJsonlRole(raw: unknown): "user" | "assistant" | "system" | "tool" | "" {
+  const t = String(raw || "").trim().toLowerCase();
+  if (t === "gemini") return "assistant";
+  if (t === "info" || t === "warning" || t === "error") return "system";
+  return normalizeGeminiRole(t);
+}
+
+/**
+ * 判断文本是否为 Gemini CLI 自动注入的会话上下文。
+ *
+ * @param text 候选消息文本
+ * @returns 是否自动会话上下文
+ */
+function isGeminiSessionContextText(text: unknown): boolean {
+  const value = String(text || "").trimStart().toLowerCase();
+  return value.startsWith("<session_context>");
+}
+
+/**
+ * 从 Gemini JSONL 元信息或消息中推断工作目录。
+ *
+ * @param metadata JSONL 累积元信息
+ * @param messages 消息列表
+ * @returns 推断出的工作目录
+ */
+function tryExtractGeminiCwdFromJsonl(metadata: Record<string, unknown>, messages: GeminiJsonlMessageRecord[]): string | null {
+  try {
+    const direct = tryExtractGeminiCwdFromAny(metadata, null);
+    if (direct) return direct;
+    const directories = metadata.directories;
+    if (Array.isArray(directories)) {
+      for (const dir of directories) {
+        if (typeof dir !== "string") continue;
+        const candidate = tidyPathCandidate(dir);
+        if (candidate) return candidate;
+      }
+    }
+    return tryExtractGeminiCwdFromAny({}, messages as any[]) || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 将一条 Gemini JSONL 消息转换为 CodexFlow 历史消息。
+ *
+ * @param message Gemini JSONL 消息
+ * @returns 历史消息列表
+ */
+function convertGeminiJsonlMessageToHistoryMessages(message: GeminiJsonlMessageRecord): Message[] {
+  try {
+    const role = normalizeGeminiJsonlRole(message.type);
+    const content: Message["content"] = [];
+    const text = extractGeminiText(message);
+    const imageItems = extractGeminiImageContents(message);
+    const outputRole = role === "user" && isGeminiSessionContextText(text) ? "system" : role;
+
+    if (text) {
+      if (outputRole === "user") content.push({ type: "input_text", text });
+      else if (outputRole === "assistant") content.push({ type: "output_text", text });
+      else if (outputRole === "tool") content.push({ type: "tool_result", text });
+      else if (outputRole === "system") content.push({ type: "meta", text });
+      else content.push({ type: "text", text });
+    }
+    if (imageItems.length > 0) content.push(...imageItems);
+    const out: Message[] = [];
+    if (content.length > 0) out.push({ role: outputRole || "assistant", content });
+
+    if (Array.isArray(message.toolCalls)) {
+      for (const toolCall of message.toolCalls) {
+        const toolText = buildGeminiJsonlToolCallText(toolCall);
+        if (toolText) out.push({ role: "assistant", content: [{ type: "tool_call", text: toolText }] });
+        const resultText = buildGeminiJsonlToolResultText(toolCall);
+        if (resultText) out.push({ role: "tool", content: [{ type: "tool_result", text: resultText }] });
+      }
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * 格式化 Gemini JSONL 工具调用，便于历史详情展示。
+ *
+ * @param toolCall 工具调用记录
+ * @returns 工具调用文本
+ */
+function buildGeminiJsonlToolCallText(toolCall: unknown): string {
+  try {
+    if (!toolCall || typeof toolCall !== "object") return "";
+    const any = toolCall as any;
+    const name = typeof any.name === "string" ? any.name : "";
+    const args = any.args && typeof any.args === "object" ? safeJsonStringify(any.args) : "";
+    const status = typeof any.status === "string" ? any.status : "";
+    return [name, args, status ? `status: ${status}` : ""].filter(Boolean).join("\n").trim();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * 格式化 Gemini JSONL 工具结果。
+ *
+ * @param toolCall 工具调用记录
+ * @returns 工具结果文本
+ */
+function buildGeminiJsonlToolResultText(toolCall: unknown): string {
+  try {
+    if (!toolCall || typeof toolCall !== "object") return "";
+    const any = toolCall as any;
+    if (!Object.prototype.hasOwnProperty.call(any, "result") || any.result == null) return "";
+    if (typeof any.result === "string") return any.result.trim();
+    if (Array.isArray(any.result)) {
+      const parts = any.result.map((part: unknown) => {
+        if (typeof part === "string") return part;
+        if (part && typeof part === "object" && typeof (part as any).text === "string") return (part as any).text;
+        return safeJsonStringify(part);
+      }).filter((part: unknown) => String(part || "").trim());
+      return parts.join("\n").trim();
+    }
+    return safeJsonStringify(any.result).trim();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * 将未知值安全转换为 JSON 文本。
+ *
+ * @param value 原始值
+ * @returns JSON 文本或 String 回退
+ */
+function safeJsonStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value ?? "");
+  }
+}
 
 /**
  * 在不读取完整文件的情况下，从 Gemini 会话 JSON 的“前缀内容”中提取摘要信息：

--- a/electron/claude/notifications.test.ts
+++ b/electron/claude/notifications.test.ts
@@ -52,6 +52,9 @@ describe("electron/claude/notifications（多行预览保真）", () => {
 
     const script = fs.readFileSync(path.join(root, "hooks", "codexflow_stop_notify.js"), "utf8");
     expect(script).toContain("function collapsePreviewForOsc(input)");
+    expect(script).toContain("function extractPreviewFromTranscriptWithRetry(transcriptPath)");
+    expect(script).toContain("const deadline = Date.now() + 1600;");
+    expect(script).toContain("sleepSync(160);");
     expect(script).toContain('const payload = collapsePreviewForOsc(preview) || "agent-turn-complete";');
     expect(script).toContain('return s.replace(/[\\u0000-\\u0008\\u000b\\u000c\\u000e-\\u001f\\u007f-\\u009f]/g, " ");');
     expect(script).not.toContain("function collapseWs(input)");

--- a/electron/claude/notifications.ts
+++ b/electron/claude/notifications.ts
@@ -235,6 +235,39 @@ function extractPreviewFromTranscript(transcriptPath) {
 }
 
 /**
+ * 中文说明：同步等待指定毫秒，供 hook 在 transcript 落盘稍慢时短暂重试。
+ */
+function sleepSync(ms) {
+  const waitMs = Math.max(0, Number(ms) || 0);
+  if (waitMs <= 0) return;
+  try {
+    if (typeof Atomics === "object" && typeof SharedArrayBuffer === "function") {
+      const buf = new SharedArrayBuffer(4);
+      const arr = new Int32Array(buf);
+      Atomics.wait(arr, 0, 0, waitMs);
+      return;
+    }
+  } catch {}
+  const end = Date.now() + waitMs;
+  while (Date.now() < end) {}
+}
+
+/**
+ * 中文说明：从 transcript 中读取回复；若首次为空，短暂重试等待 Claude 写完 JSONL。
+ */
+function extractPreviewFromTranscriptWithRetry(transcriptPath) {
+  const first = extractPreviewFromTranscript(transcriptPath);
+  if (first && String(first).trim()) return first;
+  const deadline = Date.now() + 1600;
+  while (Date.now() < deadline) {
+    sleepSync(160);
+    const next = extractPreviewFromTranscript(transcriptPath);
+    if (next && String(next).trim()) return next;
+  }
+  return "";
+}
+
+/**
  * 中文说明：尝试将 OSC 序列写入真实终端（而非 stdout/stderr）。
  */
 function writeOscToControllingTty(oscText) {
@@ -270,7 +303,7 @@ const directResponse =
   (typeof data.response === "string" ? data.response : "") ||
   (typeof data.output === "string" ? data.output : "");
 const transcriptPath = typeof data.transcript_path === "string" ? data.transcript_path : "";
-const fromTranscript = directResponse ? "" : extractPreviewFromTranscript(transcriptPath);
+const fromTranscript = directResponse ? "" : extractPreviewFromTranscriptWithRetry(transcriptPath);
 const previewSource = directResponse || fromTranscript;
 const preview = clip(stripControlChars(previewSource), 240);
 

--- a/electron/gemini/version.test.ts
+++ b/electron/gemini/version.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseGeminiCliVersion,
+  resolveGeminiExternalEditorShortcutFromVersion,
+} from "./version";
+
+describe("Gemini CLI 版本快捷键策略", () => {
+  it("从版本输出中提取版本号", () => {
+    expect(parseGeminiCliVersion("0.37.0")).toBe("0.37.0");
+    expect(parseGeminiCliVersion("gemini-cli v0.38.0-preview.0")).toBe("0.38.0-preview.0");
+  });
+
+  it("0.38.0 起使用 Ctrl+G，旧版本使用 Ctrl+X", () => {
+    expect(resolveGeminiExternalEditorShortcutFromVersion("0.37.0")).toBe("ctrlX");
+    expect(resolveGeminiExternalEditorShortcutFromVersion("0.38.0-preview.0")).toBe("ctrlG");
+    expect(resolveGeminiExternalEditorShortcutFromVersion("0.38.0")).toBe("ctrlG");
+    expect(resolveGeminiExternalEditorShortcutFromVersion("0.44.0")).toBe("ctrlG");
+    expect(resolveGeminiExternalEditorShortcutFromVersion("")).toBe("auto");
+  });
+});

--- a/electron/gemini/version.ts
+++ b/electron/gemini/version.ts
@@ -1,0 +1,257 @@
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import { execFile } from "node:child_process";
+import { normalizeTerminal, type TerminalMode } from "../shells";
+
+export type GeminiExternalEditorShortcut = "ctrlG" | "ctrlX" | "auto";
+
+export type GeminiVersionProbeOptions = {
+  terminal?: TerminalMode | string | null;
+  distro?: string | null;
+  startupCmd?: string | null;
+};
+
+export type GeminiVersionProbeResult = {
+  ok: boolean;
+  shortcut: GeminiExternalEditorShortcut;
+  version?: string;
+  command?: string;
+  error?: string;
+};
+
+const GEMINI_CTRL_G_MIN_VERSION = "0.38.0";
+const GEMINI_VERSION_PROBE_TIMEOUT_MS = 2500;
+const GEMINI_VERSION_PROBE_CACHE_TTL_MS = 60_000;
+
+const versionProbeCache = new Map<string, { checkedAt: number; result: GeminiVersionProbeResult }>();
+
+/**
+ * 解析 shell 风格命令的前段 token，覆盖 Gemini 启动命令常见写法。
+ *
+ * @param commandLine 原始启动命令
+ * @returns token 列表
+ */
+function tokenizeCommandPrefix(commandLine: string): string[] {
+  const input = String(commandLine || "").trim();
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | "\"" | "" = "";
+  let escaped = false;
+  for (const ch of input) {
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = "";
+      else current += ch;
+      continue;
+    }
+    if (ch === "'" || ch === "\"") {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    if (ch === ";" || ch === "|" || ch === "&") {
+      if (current) tokens.push(current);
+      break;
+    }
+    current += ch;
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * 从 Gemini 启动命令中提取可执行的版本探测命令。
+ *
+ * @param startupCmd Gemini 启动命令
+ * @returns 命令与参数
+ */
+function resolveGeminiVersionCommand(startupCmd?: string | null): { command: string; args: string[] } {
+  const tokens = tokenizeCommandPrefix(String(startupCmd || "gemini"));
+  const nonEnvTokens = tokens.filter((token) => !/^[A-Za-z_][A-Za-z0-9_]*=/.test(token));
+  if (nonEnvTokens.length === 0) return { command: "gemini", args: ["--version"] };
+
+  const first = nonEnvTokens[0];
+  const firstName = first.replace(/\\/g, "/").split("/").pop()?.toLowerCase() || "";
+  if (firstName === "npx" || firstName === "npx.cmd" || firstName === "npm" || firstName === "npm.cmd") {
+    const packageIndex = nonEnvTokens.findIndex((token) => /(^|\/)(@google\/)?gemini-cli($|@)/i.test(token) || /^gemini-cli($|@)/i.test(token));
+    if (packageIndex >= 0)
+      return { command: first, args: [...nonEnvTokens.slice(1, packageIndex + 1), "--version"] };
+  }
+
+  if (/^gemini(?:\.cmd|\.ps1|\.exe)?$/i.test(firstName))
+    return { command: first, args: ["--version"] };
+
+  return { command: "gemini", args: ["--version"] };
+}
+
+/**
+ * 将参数转为 cmd.exe 可安全传递的字符串。
+ *
+ * @param value 参数值
+ * @returns cmd 参数文本
+ */
+function quoteCmdArg(value: string): string {
+  const raw = String(value ?? "");
+  if (!raw) return "\"\"";
+  if (!/[\s"&<>|^]/.test(raw)) return raw;
+  return `"${raw.replace(/"/g, "\"\"")}"`;
+}
+
+/**
+ * 执行版本探测命令并返回输出。
+ *
+ * @param options 探测参数
+ * @returns 标准输出与错误输出合并文本
+ */
+async function execGeminiVersionCommand(options: GeminiVersionProbeOptions): Promise<{ output: string; command: string }> {
+  const terminal = normalizeTerminal(options.terminal);
+  const versionCommand = resolveGeminiVersionCommand(options.startupCmd);
+  const commandLabel = [versionCommand.command, ...versionCommand.args].join(" ");
+  if (terminal === "wsl" && process.platform === "win32") {
+    const distro = String(options.distro || "").trim();
+    const wslArgs = [
+      ...(distro ? ["-d", distro] : []),
+      "--",
+      versionCommand.command,
+      ...versionCommand.args,
+    ];
+    const output = await execFileText("wsl.exe", wslArgs);
+    return { output, command: commandLabel };
+  }
+
+  if (process.platform === "win32") {
+    const commandLine = [versionCommand.command, ...versionCommand.args].map(quoteCmdArg).join(" ");
+    const output = await execFileText("cmd.exe", ["/d", "/s", "/c", commandLine]);
+    return { output, command: commandLabel };
+  }
+
+  const output = await execFileText(versionCommand.command, versionCommand.args);
+  return { output, command: commandLabel };
+}
+
+/**
+ * 以受限超时执行命令并返回输出文本。
+ *
+ * @param file 可执行文件
+ * @param args 参数列表
+ * @returns 输出文本
+ */
+function execFileText(file: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      file,
+      args,
+      {
+        encoding: "utf8",
+        timeout: GEMINI_VERSION_PROBE_TIMEOUT_MS,
+        windowsHide: true,
+        maxBuffer: 256 * 1024,
+      },
+      (error, stdout, stderr) => {
+        const output = `${String(stdout || "")}\n${String(stderr || "")}`.trim();
+        if (error) {
+          const err = new Error(String((error as any)?.message || error));
+          (err as any).output = output;
+          reject(err);
+          return;
+        }
+        resolve(output);
+      },
+    );
+  });
+}
+
+/**
+ * 从版本命令输出中提取 Gemini CLI 版本号。
+ *
+ * @param output 命令输出
+ * @returns 版本号
+ */
+export function parseGeminiCliVersion(output: string): string | null {
+  const match = /\bv?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\b/.exec(String(output || ""));
+  return match ? match[1] : null;
+}
+
+/**
+ * 比较 Gemini CLI 版本号与基准版本。
+ *
+ * @param version 当前版本
+ * @param baseline 基准版本
+ * @returns 负数表示低于基准，0 表示同主次补丁版本，正数表示高于基准
+ */
+function compareGeminiVersionCore(version: string, baseline: string): number {
+  const parse = (value: string) => String(value || "").replace(/^v/i, "").split(/[+-]/)[0].split(".").map((part) => Number(part) || 0);
+  const left = parse(version);
+  const right = parse(baseline);
+  for (let i = 0; i < 3; i++) {
+    const diff = (left[i] || 0) - (right[i] || 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * 根据 Gemini CLI 版本解析外部编辑器快捷键。
+ *
+ * @param version Gemini CLI 版本
+ * @returns 快捷键策略
+ */
+export function resolveGeminiExternalEditorShortcutFromVersion(version: string | null | undefined): GeminiExternalEditorShortcut {
+  const normalized = String(version || "").trim();
+  if (!normalized) return "auto";
+  return compareGeminiVersionCore(normalized, GEMINI_CTRL_G_MIN_VERSION) >= 0 ? "ctrlG" : "ctrlX";
+}
+
+/**
+ * 探测当前 Gemini CLI 版本并解析外部编辑器快捷键策略。
+ *
+ * @param options 探测参数
+ * @returns 版本探测结果
+ */
+export async function resolveGeminiExternalEditorShortcut(options: GeminiVersionProbeOptions): Promise<GeminiVersionProbeResult> {
+  const terminal = normalizeTerminal(options.terminal);
+  const cacheKey = JSON.stringify({
+    terminal,
+    distro: terminal === "wsl" ? String(options.distro || "").trim() : "",
+    startupCmd: String(options.startupCmd || "gemini").trim(),
+  });
+  const cached = versionProbeCache.get(cacheKey);
+  if (cached && Date.now() - cached.checkedAt < GEMINI_VERSION_PROBE_CACHE_TTL_MS)
+    return cached.result;
+
+  try {
+    const executed = await execGeminiVersionCommand({ ...options, terminal });
+    const version = parseGeminiCliVersion(executed.output);
+    const result: GeminiVersionProbeResult = {
+      ok: !!version,
+      shortcut: resolveGeminiExternalEditorShortcutFromVersion(version),
+      version: version || undefined,
+      command: executed.command,
+      error: version ? undefined : "version not found",
+    };
+    versionProbeCache.set(cacheKey, { checkedAt: Date.now(), result });
+    return result;
+  } catch (error: any) {
+    const result: GeminiVersionProbeResult = {
+      ok: false,
+      shortcut: "auto",
+      error: String(error?.message || error),
+    };
+    versionProbeCache.set(cacheKey, { checkedAt: Date.now(), result });
+    return result;
+  }
+}

--- a/electron/gemini/windowsEditor.ts
+++ b/electron/gemini/windowsEditor.ts
@@ -326,7 +326,7 @@ export async function prepareGeminiWindowsEditorEnv(
 }
 
 /**
- * 中文说明：为下一次 `Ctrl+X` 外部编辑器发送写入 source/status 文件。
+ * 中文说明：为下一次 `Ctrl+G` 外部编辑器发送写入 source/status 文件。
  * - source 文件承载本次完整正文；
  * - status 文件会先被置为 `pending`，helper 完成后再改为 `done/error`。
  *

--- a/electron/history.ts
+++ b/electron/history.ts
@@ -585,7 +585,7 @@ type HistoryListCacheEntry = {
 };
 
 // 中文说明：历史归属语义变更后提升版本，强制失效旧的列表缓存，避免继续复用错误归属结果。
-const PARSER_VERSION = 'v12';
+const PARSER_VERSION = 'v13';
 const CACHE_SCHEMA_VERSION = '2';
 
 /**
@@ -598,7 +598,7 @@ function inferHistoryProviderIdFromPath(filePath: string): ProviderId {
     if (fp.includes('/.claude/')) return 'claude';
     if (fp.includes('/.gemini/')) return 'gemini';
     if (base.endsWith('.ndjson')) return 'claude';
-    if (base.startsWith('session-') && base.endsWith('.json')) return 'gemini';
+    if (base.startsWith('session-') && (base.endsWith('.jsonl') || base.endsWith('.json'))) return 'gemini';
   } catch {}
   return 'codex';
 }

--- a/electron/indexer.ts
+++ b/electron/indexer.ts
@@ -246,7 +246,7 @@ function stripDetailsForPersist(details: Details): Details {
 }
 
 // 中文说明：历史索引语义调整后提升版本，强制丢弃旧的 index/details 缓存，避免继续沿用错误 dirKey。
-const VERSION = "v12";
+const VERSION = "v13";
 
 /**
  * 读取 Claude Code 的 Agent 历史开关（默认 false）。
@@ -469,7 +469,7 @@ function shouldIndexProviderFile(providerId: ProviderId, filePath: string): bool
       if (!getIndexedClaudeAgentHistorySetting() && base.startsWith("agent-") && base.endsWith(".jsonl")) return false;
       return base.endsWith(".jsonl") || base.endsWith(".ndjson");
     }
-    if (providerId === "gemini") return base.endsWith(".json") && base.startsWith("session-");
+    if (providerId === "gemini") return base.startsWith("session-") && (base.endsWith(".jsonl") || base.endsWith(".json"));
     return false;
   } catch {
     return false;
@@ -1585,7 +1585,7 @@ export async function startHistoryIndexer(getWindow: () => BrowserWindow | null)
           if (!claudeCodeReadAgentHistory && base.startsWith("agent-") && base.endsWith(".jsonl")) return false;
           return base.endsWith(".jsonl") || base.endsWith(".ndjson");
         }
-        if (providerId === "gemini") return base.endsWith(".json") && base.startsWith("session-");
+        if (providerId === "gemini") return base.startsWith("session-") && (base.endsWith(".jsonl") || base.endsWith(".json"));
         return false;
       } catch {
         return false;
@@ -1968,7 +1968,7 @@ export async function startHistoryIndexer(getWindow: () => BrowserWindow | null)
         const patternsForProvider = (providerId: ProviderId): string[] => {
           if (providerId === "codex") return ["*.jsonl"];
           if (providerId === "claude") return ["*.jsonl", "*.ndjson"];
-          if (providerId === "gemini") return ["session-*.json"];
+          if (providerId === "gemini") return ["session-*.jsonl", "session-*.json"];
           return ["*.jsonl"];
         };
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -43,6 +43,7 @@ import { getClaudeUsageSnapshotAsync } from "./claude/usage";
 import { ensureAllGeminiNotifications, startGeminiNotificationBridge, stopGeminiNotificationBridge } from "./gemini/notifications";
 import geminiWindowsEditor from "./gemini/windowsEditor";
 import geminiWslEditor from "./gemini/wslEditor";
+import { resolveGeminiExternalEditorShortcut } from "./gemini/version";
 import { getGeminiQuotaSnapshotAsync } from "./gemini/usage";
 import storage from "./storage";
 import { registerNotificationIPC, unregisterNotificationIPC } from "./notifications";
@@ -3929,7 +3930,7 @@ function inferHistoryReadProviderFromPath(filePath?: string): HistoryReadProvide
   if (fp.includes("/.claude/")) return "claude";
   if (fp.includes("/.gemini/")) return "gemini";
   if (base.endsWith(".ndjson")) return "claude";
-  if (base.startsWith("session-") && base.endsWith(".json")) return "gemini";
+  if (base.startsWith("session-") && (base.endsWith(".jsonl") || base.endsWith(".json"))) return "gemini";
   return null;
 }
 
@@ -4097,7 +4098,7 @@ ipcMain.handle('history.findEmptySessions', async () => {
         if (fp.includes("/.claude/")) return "claude";
         if (fp.includes("/.gemini/")) return "gemini";
         if (base.endsWith(".ndjson")) return "claude";
-        if (base.startsWith("session-") && base.endsWith(".json")) return "gemini";
+        if (base.startsWith("session-") && (base.endsWith(".jsonl") || base.endsWith(".json"))) return "gemini";
       } catch {}
       return "codex";
     };
@@ -4488,6 +4489,25 @@ ipcMain.handle('utils.geminiWindowsEditor.readStatus', async (_e, args: {
     });
   } catch (e: any) {
     return { ok: false, error: String(e) };
+  }
+});
+
+/**
+ * 中文说明：探测当前 Gemini CLI 版本，并返回外部编辑器快捷键策略。
+ */
+ipcMain.handle('utils.gemini.versionShortcut', async (_e, args: {
+  terminal?: 'wsl' | 'windows' | 'pwsh';
+  distro?: string;
+  startupCmd?: string;
+}) => {
+  try {
+    return await resolveGeminiExternalEditorShortcut({
+      terminal: args?.terminal,
+      distro: String(args?.distro || ""),
+      startupCmd: String(args?.startupCmd || "gemini"),
+    });
+  } catch (e: any) {
+    return { ok: false, shortcut: "auto", error: String(e) };
   }
 });
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -732,6 +732,16 @@ contextBridge.exposeInMainWorld('host', {
       return await ipcRenderer.invoke('utils.geminiWindowsEditor.readStatus', args);
     },
     /**
+     * 中文说明：探测当前 Gemini CLI 版本对应的外部编辑器快捷键策略。
+     */
+    resolveGeminiExternalEditorShortcut: async (args: {
+      terminal?: 'wsl' | 'windows' | 'pwsh';
+      distro?: string;
+      startupCmd?: string;
+    }) => {
+      return await ipcRenderer.invoke('utils.gemini.versionShortcut', args);
+    },
+    /**
      * 中文说明：为 WSL 下的 Gemini 会话准备专用外部编辑器 env。
      * - 仅影响 CodexFlow 打开的当前 PTY；
      * - 仅在超长文本命中阈值时由渲染层启用。

--- a/scripts/assert-release-assets.cjs
+++ b/scripts/assert-release-assets.cjs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk)
+
+const fs = require("node:fs");
+const path = require("node:path");
+const asar = require("@electron/asar");
+
+const repoRoot = path.resolve(__dirname, "..");
+
+/**
+ * 将仓库相对路径解析为绝对路径。
+ */
+function resolveRepoPath(relativePath) {
+  return path.join(repoRoot, relativePath);
+}
+
+/**
+ * 判断文件是否存在且是普通文件。
+ */
+function isFile(filePath) {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 断言仓库内文件存在。
+ */
+function requireRepoFile(relativePath, label) {
+  const filePath = resolveRepoPath(relativePath);
+  if (isFile(filePath)) {
+    console.log(`[release-check] ${label}: ${relativePath}`);
+    return;
+  }
+  throw new Error(`${label} 缺失：${relativePath}`);
+}
+
+/**
+ * 断言 app.asar 内包含指定文件。
+ */
+function requireAsarFile(archivePath, archiveFilePath, label) {
+  try {
+    const content = asar.extractFile(archivePath, archiveFilePath);
+    if (content && content.length > 0) {
+      console.log(`[release-check] ${label}: app.asar/${archiveFilePath}`);
+      return;
+    }
+  } catch {}
+  throw new Error(`${label} 未打入 app.asar：${archiveFilePath}`);
+}
+
+/**
+ * 校验 electron-builder 打包输入产物。
+ */
+function checkBeforePack() {
+  requireRepoFile("dist/electron/main.js", "主进程入口");
+  requireRepoFile("dist/electron/preload.js", "预加载脚本");
+  requireRepoFile("web/dist/index.html", "前端入口");
+}
+
+/**
+ * 校验绿色版输出产物。
+ */
+function checkAfterPack() {
+  const archivePath = resolveRepoPath("dist/win-unpacked/resources/app.asar");
+  requireRepoFile("dist/win-unpacked/CodexFlow.exe", "绿色版可执行文件");
+  requireRepoFile("dist/win-unpacked/resources/app.asar", "应用归档");
+  requireAsarFile(archivePath, "dist\\electron\\main.js", "主进程入口");
+  requireAsarFile(archivePath, "dist\\electron\\preload.js", "预加载脚本");
+  requireAsarFile(archivePath, "web\\dist\\index.html", "前端入口");
+}
+
+/**
+ * 执行指定阶段的产物校验。
+ */
+function main() {
+  const phase = String(process.argv[2] || "before-pack").trim();
+  if (phase === "before-pack") {
+    checkBeforePack();
+    return;
+  }
+  if (phase === "after-pack") {
+    checkAfterPack();
+    return;
+  }
+  throw new Error(`未知校验阶段：${phase}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`[release-check] ${error && error.message ? error.message : String(error)}`);
+  process.exit(1);
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -352,6 +352,7 @@ type AgentTurnTimerState = {
 };
 
 type CompletionEventSource = "osc" | "external" | "manual" | "unknown";
+type GeminiExternalEditorShortcut = "ctrlG" | "ctrlX" | "auto";
 type CompletionPreviewNormalizeOptions = {
   previewEscapedWhitespace?: boolean;
 };
@@ -1588,6 +1589,7 @@ export default function CodexFlowManagerUI() {
   }, [restoredConsoleSession]);
   const geminiWindowsEditorReadyByTabRef = useRef<Record<string, boolean>>({});
   const geminiWslEditorReadyByTabRef = useRef<Record<string, boolean>>({});
+  const geminiExternalEditorShortcutByTabRef = useRef<Record<string, GeminiExternalEditorShortcut>>({});
   const terminalManagerRef = useRef<TerminalManager | null>(null);
   if (!terminalManagerRef.current) {
     terminalManagerRef.current = new TerminalManager(
@@ -2258,7 +2260,7 @@ export default function CodexFlowManagerUI() {
   }, [shouldDetachDraggedTabFromPoint, updateTabDragPreviewWindowForState]);
 
   /**
-   * 初始化一次标签指针拖拽候选，仅记录起点信息，真正进入拖拽态要等移动超过阈值。
+   * 初始化一次标签指针拖拽候选，仅记录起点信息；返回 true 表示本次按下是有效标签交互。
    */
   const beginTabPointerDrag = useCallback((
     event: React.PointerEvent,
@@ -2269,9 +2271,9 @@ export default function CodexFlowManagerUI() {
       isGitTab: boolean;
     },
   ) => {
-    if (event.button !== 0) return;
-    if (editingTabId === payload.tabId) return;
-    if (shouldIgnoreTabPointerDragStart(event.target)) return;
+    if (event.button !== 0) return false;
+    if (editingTabId === payload.tabId) return false;
+    if (shouldIgnoreTabPointerDragStart(event.target)) return false;
     try {
       (event.currentTarget as HTMLElement | null)?.setPointerCapture?.(event.pointerId);
     } catch {}
@@ -2288,6 +2290,7 @@ export default function CodexFlowManagerUI() {
       lastClientY: event.clientY,
       lastInsertIndex: null,
     };
+    return true;
   }, [editingTabId]);
 
   /**
@@ -4619,6 +4622,7 @@ export default function CodexFlowManagerUI() {
    * @param providerId providerId
    * @param envLabel 标签展示名
    * @param tabEnv 当前标签页实际执行环境
+   * @param startupCmd 当前标签页将执行的启动命令
    * @returns 打开 PTY 时要注入的 env，以及 Gemini Windows/WSL editor 的准备状态
    */
   const buildProviderLaunchEnv = useCallback(async (
@@ -4626,28 +4630,51 @@ export default function CodexFlowManagerUI() {
     providerId: string,
     envLabel: string,
     tabEnv: Required<ProviderEnv>,
-  ): Promise<{ env: Record<string, string>; geminiWindowsEditorReady: boolean; geminiWslEditorReady: boolean }> => {
+    startupCmd?: string,
+  ): Promise<{ env: Record<string, string>; geminiWindowsEditorReady: boolean; geminiWslEditorReady: boolean; geminiExternalEditorShortcut: GeminiExternalEditorShortcut }> => {
     const baseEnv = buildProviderNotifyEnv(tabId, providerId, envLabel);
     if (!isGeminiProvider(providerId))
-      return { env: baseEnv, geminiWindowsEditorReady: false, geminiWslEditorReady: false };
+      return { env: baseEnv, geminiWindowsEditorReady: false, geminiWslEditorReady: false, geminiExternalEditorShortcut: "auto" };
+    let geminiExternalEditorShortcut: GeminiExternalEditorShortcut = "auto";
+    try {
+      const shortcutRes = await window.host.utils.resolveGeminiExternalEditorShortcut({
+        terminal: tabEnv.terminal as any,
+        distro: tabEnv.terminal === "wsl" ? tabEnv.distro : undefined,
+        startupCmd: String(startupCmd || "gemini"),
+      });
+      const shortcut = String(shortcutRes?.shortcut || "");
+      if (shortcut === "ctrlG" || shortcut === "ctrlX" || shortcut === "auto")
+        geminiExternalEditorShortcut = shortcut;
+      try {
+        await (window as any).host?.utils?.perfLog?.(
+          `[ui] gemini.versionShortcut tab=${tabId} shortcut=${geminiExternalEditorShortcut} version=${String(shortcutRes?.version || "")} ok=${shortcutRes?.ok ? "1" : "0"} error=${String(shortcutRes?.error || "")}`,
+        );
+      } catch {}
+    } catch (error: any) {
+      try {
+        await (window as any).host?.utils?.perfLog?.(
+          `[ui] gemini.versionShortcut exception tab=${tabId} error=${String(error?.message || error)}`,
+        );
+      } catch {}
+    }
     try {
       if (tabEnv.terminal === "wsl") {
         const distro = String(tabEnv.distro || "").trim();
         if (!distro)
-          return { env: baseEnv, geminiWindowsEditorReady: false, geminiWslEditorReady: false };
+          return { env: baseEnv, geminiWindowsEditorReady: false, geminiWslEditorReady: false, geminiExternalEditorShortcut };
         const res = await window.host.utils.prepareGeminiWslEditorEnv({ tabId, distro });
         if (res && res.ok && res.env && typeof res.env === "object")
-          return { env: { ...baseEnv, ...res.env }, geminiWindowsEditorReady: false, geminiWslEditorReady: true };
+          return { env: { ...baseEnv, ...res.env }, geminiWindowsEditorReady: false, geminiWslEditorReady: true, geminiExternalEditorShortcut };
         try {
           await (window as any).host?.utils?.perfLog?.(
             `[ui] geminiWslEditor.prepareEnv skipped tab=${tabId} distro=${distro} error=${String(res?.error || "unknown")}`,
           );
         } catch {}
-        return { env: baseEnv, geminiWindowsEditorReady: false, geminiWslEditorReady: false };
+        return { env: baseEnv, geminiWindowsEditorReady: false, geminiWslEditorReady: false, geminiExternalEditorShortcut };
       }
       const res = await window.host.utils.prepareGeminiWindowsEditorEnv({ tabId });
       if (res && res.ok && res.env && typeof res.env === "object")
-        return { env: { ...baseEnv, ...res.env }, geminiWindowsEditorReady: true, geminiWslEditorReady: false };
+        return { env: { ...baseEnv, ...res.env }, geminiWindowsEditorReady: true, geminiWslEditorReady: false, geminiExternalEditorShortcut };
       try {
         await (window as any).host?.utils?.perfLog?.(
           `[ui] geminiWindowsEditor.prepareEnv skipped tab=${tabId} error=${String(res?.error || "unknown")}`,
@@ -4661,7 +4688,7 @@ export default function CodexFlowManagerUI() {
         );
       } catch {}
     }
-    return { env: baseEnv, geminiWindowsEditorReady: false, geminiWslEditorReady: false };
+    return { env: baseEnv, geminiWindowsEditorReady: false, geminiWslEditorReady: false, geminiExternalEditorShortcut };
   }, []);
 
   /**
@@ -5411,6 +5438,7 @@ export default function CodexFlowManagerUI() {
       delete tabExecEnvByTabRef.current[tabId];
       delete geminiWindowsEditorReadyByTabRef.current[tabId];
       delete geminiWslEditorReadyByTabRef.current[tabId];
+      delete geminiExternalEditorShortcutByTabRef.current[tabId];
       clearPendingForTab(tabId);
       unregisterTabProject(tabId);
       try { tm.disposeTab(tabId, true); } catch (err) { console.warn('tm.disposeTab failed', err); }
@@ -5573,8 +5601,8 @@ export default function CodexFlowManagerUI() {
     let ptyId: string | undefined;
     try {
       const env = getProviderEnv(activeProviderId);
-      const launchEnv = await buildProviderLaunchEnv(tab.id, tab.providerId, tab.name, env);
       const startupCmd = buildProviderStartupCmd(activeProviderId, env);
+      const launchEnv = await buildProviderLaunchEnv(tab.id, tab.providerId, tab.name, env, startupCmd);
       const { id } = await window.host.pty.openWSLConsole({
         terminal: env.terminal,
         distro: env.distro,
@@ -5588,6 +5616,7 @@ export default function CodexFlowManagerUI() {
       tabExecEnvByTabRef.current[tab.id] = env;
       geminiWindowsEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWindowsEditorReady;
       geminiWslEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWslEditorReady;
+      geminiExternalEditorShortcutByTabRef.current[tab.id] = launchEnv.geminiExternalEditorShortcut;
       ptyId = id;
     } catch (e) {
       console.error('Failed to open PTY for project', e);
@@ -5678,8 +5707,8 @@ export default function CodexFlowManagerUI() {
     try {
       try { await (window as any).host?.utils?.perfLog?.(`[ui] openNewConsole start project=${selectedProject?.name}`); } catch {}
       const env = getProviderEnv(activeProviderId);
-      const launchEnv = await buildProviderLaunchEnv(tab.id, tab.providerId, tab.name, env);
       const startupCmd = buildProviderStartupCmd(activeProviderId, env);
+      const launchEnv = await buildProviderLaunchEnv(tab.id, tab.providerId, tab.name, env, startupCmd);
       const { id } = await window.host.pty.openWSLConsole({
         terminal: env.terminal,
         distro: env.distro,
@@ -5694,6 +5723,7 @@ export default function CodexFlowManagerUI() {
       tabExecEnvByTabRef.current[tab.id] = env;
       geminiWindowsEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWindowsEditorReady;
       geminiWslEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWslEditorReady;
+      geminiExternalEditorShortcutByTabRef.current[tab.id] = launchEnv.geminiExternalEditorShortcut;
       ptyId = id;
     } catch (e) {
       console.error('Failed to open PTY', e);
@@ -5916,7 +5946,7 @@ export default function CodexFlowManagerUI() {
 
     let ptyId: string | undefined;
     try {
-      const launchEnv = await buildProviderLaunchEnv(tab.id, tab.providerId, tab.name, env);
+      const launchEnv = await buildProviderLaunchEnv(tab.id, tab.providerId, tab.name, env, startupCmd);
       const { id } = await window.host.pty.openWSLConsole({
         terminal: env.terminal,
         distro: env.distro,
@@ -5930,6 +5960,7 @@ export default function CodexFlowManagerUI() {
       tabExecEnvByTabRef.current[tab.id] = env;
       geminiWindowsEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWindowsEditorReady;
       geminiWslEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWslEditorReady;
+      geminiExternalEditorShortcutByTabRef.current[tab.id] = launchEnv.geminiExternalEditorShortcut;
       ptyId = id;
     } catch {
       return false;
@@ -6384,6 +6415,7 @@ export default function CodexFlowManagerUI() {
         distro: activeEnv.terminal === "wsl" ? activeEnv.distro : undefined,
         geminiWindowsEditorReady: !!geminiWindowsEditorReadyByTabRef.current[activeTab.id],
         geminiWslEditorReady: !!geminiWslEditorReadyByTabRef.current[activeTab.id],
+        geminiExternalEditorShortcut: geminiExternalEditorShortcutByTabRef.current[activeTab.id] || "auto",
       };
       if (sendMode === 'write_and_enter') await tm.sendTextAndEnter(activeTab.id, text, sendOptions);
       else await tm.sendText(activeTab.id, text, sendOptions);
@@ -6441,6 +6473,7 @@ export default function CodexFlowManagerUI() {
     delete tabExecEnvByTabRef.current[tabId];
     delete geminiWindowsEditorReadyByTabRef.current[tabId];
     delete geminiWslEditorReadyByTabRef.current[tabId];
+    delete geminiExternalEditorShortcutByTabRef.current[tabId];
     try { delete ptyAliveRef.current[tabId]; setPtyAlive((m) => { const n = { ...m }; delete n[tabId]; return n; }); } catch {}
     // let manager dispose the tab (adapter/container and optionally close PTY)
     try { tm.disposeTab(tabId, true); } catch (err) { console.warn('tm.disposeTab failed', err); }
@@ -7159,7 +7192,7 @@ export default function CodexFlowManagerUI() {
 
     let ptyId: string | undefined;
     try {
-      const launchEnv = await buildProviderLaunchEnv(tab.id, tab.providerId, tab.name, env);
+      const launchEnv = await buildProviderLaunchEnv(tab.id, tab.providerId, tab.name, env, args.startupCmd);
       const { id } = await window.host.pty.openWSLConsole({
         terminal: env.terminal,
         distro: env.distro,
@@ -7173,6 +7206,7 @@ export default function CodexFlowManagerUI() {
       tabExecEnvByTabRef.current[tab.id] = env;
       geminiWindowsEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWindowsEditorReady;
       geminiWslEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWslEditorReady;
+      geminiExternalEditorShortcutByTabRef.current[tab.id] = launchEnv.geminiExternalEditorShortcut;
       ptyId = id;
     } catch (e: any) {
       return { ok: false, error: String(e?.message || e) };
@@ -9717,7 +9751,11 @@ export default function CodexFlowManagerUI() {
         </div>
       </div>
 
-      <Tabs value={activeTabId || undefined} onValueChange={(v) => setActiveTab(v ?? null)} className="flex w-full flex-1 min-h-0 min-w-0 flex-col">
+      <Tabs
+        value={activeTabId || undefined}
+        onValueChange={(v) => setActiveTab(v ?? null, { focusMode: "immediate", allowDuringRename: true, delay: 0 })}
+        className="flex w-full flex-1 min-h-0 min-w-0 flex-col"
+      >
         <div className="min-w-0 rounded-md bg-white/90 border border-slate-100 px-2 py-1 dark:border-slate-700 dark:bg-slate-900/90">
           <TabsList ref={tabsListRef} className="w-full min-w-0 h-8 flex items-center justify-start overflow-visible whitespace-nowrap">
             {tabs.length === 0 ? (
@@ -9765,12 +9803,16 @@ export default function CodexFlowManagerUI() {
                       e.stopPropagation();
                     }
                   }}
-                  onPointerDown={(event) => beginTabPointerDrag(event, {
-                    tabId: tab.id,
-                    tabName: tab.name,
-                    providerIconSrc,
-                    isGitTab,
-                  })}
+                  onPointerDown={(event) => {
+                    const shouldActivateTab = beginTabPointerDrag(event, {
+                      tabId: tab.id,
+                      tabName: tab.name,
+                      providerIconSrc,
+                      isGitTab,
+                    });
+                    if (shouldActivateTab && activeTabIdRef.current !== tab.id)
+                      setActiveTab(tab.id, { focusMode: "immediate", allowDuringRename: true, delay: 0 });
+                  }}
                   onDoubleClick={(e) => { e.preventDefault(); e.stopPropagation(); startEditTab(tab.id, tab.name); }}
                   onContextMenu={(e) => openTabContextMenu(e, tab.id, "tabs-header")}
                 >
@@ -10229,7 +10271,7 @@ export default function CodexFlowManagerUI() {
           await (window as any).host?.utils?.perfLog?.(`[ui] history.resume openWSLConsole start tab=${tab.id}`);
         } catch {}
 	        try {
-          const launchEnv = await buildProviderLaunchEnv(tab.id, tab.providerId, tab.name, execEnv);
+          const launchEnv = await buildProviderLaunchEnv(tab.id, tab.providerId, tab.name, execEnv, startupCmd);
           const { id } = await window.host.pty.openWSLConsole({
             terminal: execEnv.terminal as any,
             distro: execEnv.distro,
@@ -10246,6 +10288,7 @@ export default function CodexFlowManagerUI() {
           tabExecEnvByTabRef.current[tab.id] = execEnv;
           geminiWindowsEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWindowsEditorReady;
           geminiWslEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWslEditorReady;
+          geminiExternalEditorShortcutByTabRef.current[tab.id] = launchEnv.geminiExternalEditorShortcut;
           ptyId = id;
         } catch (err) {
           console.warn('executeResume failed', err);

--- a/web/src/lib/TerminalManager.ts
+++ b/web/src/lib/TerminalManager.ts
@@ -42,6 +42,7 @@ type GeminiPasteChunkPlan = {
 };
 
 type GeminiExternalEditorKind = "windows" | "wsl";
+type GeminiExternalEditorShortcut = "ctrlG" | "ctrlX" | "auto";
 
 type GeminiExternalEditorTransport = {
   kind: GeminiExternalEditorKind;
@@ -58,6 +59,7 @@ type TerminalSendOptions = {
   distro?: string;
   geminiWindowsEditorReady?: boolean;
   geminiWslEditorReady?: boolean;
+  geminiExternalEditorShortcut?: GeminiExternalEditorShortcut;
 };
 
 const TERMINAL_SEND_SCREEN_ACK_POLL_MS = 40;
@@ -77,6 +79,7 @@ const GEMINI_HUGE_PASTE_CHUNK_YIELD_EVERY = 4;
 const GEMINI_HUGE_PASTE_CHUNK_YIELD_MS = 384;
 const GEMINI_WINDOWS_EDITOR_STATUS_POLL_MS = 40;
 const GEMINI_WINDOWS_EDITOR_STATUS_TIMEOUT_MS = 15000;
+const GEMINI_EXTERNAL_EDITOR_AUTO_PROBE_TIMEOUT_MS = 3000;
 const GEMINI_WSL_EDITOR_TRIGGER_CHAR_THRESHOLD = 12000;
 const GEMINI_WSL_EDITOR_TRIGGER_DISPATCH_THRESHOLD_MS = 2500;
 
@@ -983,6 +986,7 @@ export default class TerminalManager {
    * @param tabId 标签页 id
    * @param requestId 本次发送 requestId
    * @param traceId 诊断 trace id
+   * @param timeoutMs 本次等待超时时间
    * @returns 命中的状态；超时时返回 `timeout`
    */
   private async waitForGeminiExternalEditorStatus(
@@ -990,9 +994,11 @@ export default class TerminalManager {
     tabId: string,
     requestId: string,
     traceId?: string | null,
+    timeoutMs = GEMINI_WINDOWS_EDITOR_STATUS_TIMEOUT_MS,
   ): Promise<{ state: "done" | "error" | "timeout"; message?: string }> {
     const startedAt = Date.now();
-    while (Date.now() - startedAt < GEMINI_WINDOWS_EDITOR_STATUS_TIMEOUT_MS) {
+    const waitTimeoutMs = Math.max(GEMINI_WINDOWS_EDITOR_STATUS_POLL_MS, Number(timeoutMs) || GEMINI_WINDOWS_EDITOR_STATUS_TIMEOUT_MS);
+    while (Date.now() - startedAt < waitTimeoutMs) {
       try {
         const res = await transport.readStatus({ tabId });
         if (res && res.ok) {
@@ -1020,13 +1026,52 @@ export default class TerminalManager {
 
     this.logSendDiagnostic(
       traceId,
-      `gemini.editor.status timeout kind=${transport.kind} requestId=${requestId} timeoutMs=${GEMINI_WINDOWS_EDITOR_STATUS_TIMEOUT_MS}`,
+      `gemini.editor.status timeout kind=${transport.kind} requestId=${requestId} timeoutMs=${waitTimeoutMs}`,
     );
     return { state: "timeout" };
   }
 
   /**
-   * 中文说明：Gemini 通过 `Ctrl+X + 外部编辑器` 发送正文。
+   * 中文说明：按版本策略选择外部编辑器快捷键序列。
+   * @param shortcut 已解析的快捷键策略
+   * @returns 需要依次尝试的快捷键序列
+   */
+  private getGeminiExternalEditorShortcutSequence(shortcut?: GeminiExternalEditorShortcut | null): GeminiExternalEditorShortcut[] {
+    if (shortcut === "ctrlX") return ["ctrlX"];
+    if (shortcut === "auto") return ["ctrlG", "ctrlX"];
+    return ["ctrlG"];
+  }
+
+  /**
+   * 中文说明：向 PTY 写入指定的 Gemini 外部编辑器快捷键。
+   * @param ptyId 当前 PTY id
+   * @param transport 已绑定参数的桥接读写通道
+   * @param shortcut 快捷键类型
+   * @param traceId 诊断 trace id
+   * @returns 是否写入成功
+   */
+  private triggerGeminiExternalEditorShortcut(
+    ptyId: string,
+    transport: GeminiExternalEditorTransport,
+    shortcut: Exclude<GeminiExternalEditorShortcut, "auto">,
+    traceId?: string | null,
+  ): boolean {
+    try {
+      const data = shortcut === "ctrlX" ? "\x18" : "\x07";
+      this.hostPty.write(ptyId, data);
+      this.logSendDiagnostic(traceId, `trigger.mode=host.write ${shortcut}=1 kind=${transport.kind}`);
+      return true;
+    } catch (error: any) {
+      this.logSendDiagnostic(
+        traceId,
+        `gemini.editor.${shortcut}.failed kind=${transport.kind} error=${String(error?.message || error)}`,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * 中文说明：Gemini 通过版本匹配的快捷键打开外部编辑器后发送正文。
    * - Windows 下用于彻底绕开 PowerShell/ConPTY 的超长 paste 链路；
    * - WSL 下仅在超长文本命中阈值时启用，用于降低超大分块 paste 的等待成本；
    * - 失败时统一自动回退到当前的 paste 策略。
@@ -1067,19 +1112,22 @@ export default class TerminalManager {
           `gemini.editor.writeSource.ok kind=${transport.kind} requestId=${requestId} chars=${text.length}`,
         );
 
-        try {
-          this.hostPty.write(ptyId, "\x18");
-          this.logSendDiagnostic(traceId, `trigger.mode=host.write ctrlX=1 kind=${transport.kind}`);
-        } catch (error: any) {
-          this.logSendDiagnostic(
-            traceId,
-            `gemini.editor.ctrlX.failed kind=${transport.kind} error=${String(error?.message || error)}`,
-          );
-          await this.sendGeminiTextAndEnter(ptyId, text, adapter, options, traceId);
-          return;
+        let status: { state: "done" | "error" | "timeout"; message?: string } = { state: "timeout" };
+        const shortcutSequence = this.getGeminiExternalEditorShortcutSequence(options?.geminiExternalEditorShortcut);
+        for (let index = 0; index < shortcutSequence.length; index++) {
+          const shortcut = shortcutSequence[index] as Exclude<GeminiExternalEditorShortcut, "auto">;
+          if (!this.triggerGeminiExternalEditorShortcut(ptyId, transport, shortcut, traceId)) {
+            await this.sendGeminiTextAndEnter(ptyId, text, adapter, options, traceId);
+            return;
+          }
+          const timeoutMs = shortcutSequence.length > 1 && index === 0
+            ? GEMINI_EXTERNAL_EDITOR_AUTO_PROBE_TIMEOUT_MS
+            : GEMINI_WINDOWS_EDITOR_STATUS_TIMEOUT_MS;
+          status = await this.waitForGeminiExternalEditorStatus(transport, tabId, requestId, traceId, timeoutMs);
+          if (status.state === "done" || status.state === "error")
+            break;
+          this.logSendDiagnostic(traceId, `gemini.editor.shortcut.timeout kind=${transport.kind} shortcut=${shortcut}`);
         }
-
-        const status = await this.waitForGeminiExternalEditorStatus(transport, tabId, requestId, traceId);
         if (status.state === "error") {
           this.logSendDiagnostic(
             traceId,
@@ -1088,8 +1136,10 @@ export default class TerminalManager {
           await this.sendGeminiTextAndEnter(ptyId, text, adapter, options, traceId);
           return;
         }
-        if (status.state !== "done")
+        if (status.state !== "done") {
+          await this.sendGeminiTextAndEnter(ptyId, text, adapter, options, traceId);
           return;
+        }
 
         const settleMs = Math.max(16, getPasteEnterDelayMs(options?.providerId));
         await this.sleep(settleMs);
@@ -1228,7 +1278,7 @@ export default class TerminalManager {
    * @param providerId providerId
    * @param terminalMode 当前标签页运行终端类型
    * @param geminiWindowsEditorReady 当前 tab 是否已成功注入专用 `EDITOR/VISUAL`
-   * @returns 是否启用 `Ctrl+X + 外部编辑器` 发送
+   * @returns 是否启用 `Ctrl+G + 外部编辑器` 发送
    */
   private shouldUseGeminiWindowsEditorStrategy(
     providerId?: string | null,
@@ -1249,7 +1299,7 @@ export default class TerminalManager {
    * @param terminalMode 当前标签页运行终端类型
    * @param geminiWslEditorReady 当前 tab 是否已成功注入专用 `EDITOR/VISUAL`
    * @param text 待发送正文
-   * @returns 是否启用 `Ctrl+X + 外部编辑器` 发送
+   * @returns 是否启用 `Ctrl+G + 外部编辑器` 发送
    */
   private shouldUseGeminiWslEditorStrategy(
     providerId?: string | null,

--- a/web/src/lib/terminal-manager-send.test.ts
+++ b/web/src/lib/terminal-manager-send.test.ts
@@ -122,7 +122,7 @@ describe("TerminalManager（长文本发送策略）", () => {
     tm.disposeAll(false);
   });
 
-  it("Gemini 在 Windows/Pwsh 下会优先走 Ctrl+X 外部编辑器桥接后再发送 Enter", async () => {
+  it("Gemini 在 Windows/Pwsh 下会优先走 Ctrl+G 外部编辑器桥接后再发送 Enter", async () => {
     vi.useFakeTimers();
     const adapter: any = createAdapterStub();
     const hostPty = createHostPtyStub();
@@ -160,7 +160,7 @@ describe("TerminalManager（长文本发送策略）", () => {
 
     expect(writeSource).toHaveBeenCalledWith({ tabId: "tab-gemini-win", content: text });
     expect(adapter.paste).not.toHaveBeenCalled();
-    expect(hostPty.write).toHaveBeenCalledWith("pty-gemini-win", "\x18");
+    expect(hostPty.write).toHaveBeenCalledWith("pty-gemini-win", "\x07");
     expect(hostPty.write).not.toHaveBeenCalledWith("pty-gemini-win", "\r");
 
     await vi.advanceTimersByTimeAsync(40);
@@ -173,7 +173,7 @@ describe("TerminalManager（长文本发送策略）", () => {
     tm.disposeAll(false);
   });
 
-  it("Gemini 在 WSL 超长文本命中阈值时会优先走 Ctrl+X 外部编辑器桥接后再发送 Enter", async () => {
+  it("Gemini 在 WSL 超长文本命中阈值时会优先走 Ctrl+G 外部编辑器桥接后再发送 Enter", async () => {
     vi.useFakeTimers();
     const adapter: any = createAdapterStub();
     const hostPty = createHostPtyStub();
@@ -216,7 +216,7 @@ describe("TerminalManager（长文本发送策略）", () => {
       content: text,
     });
     expect(adapter.paste).not.toHaveBeenCalled();
-    expect(hostPty.write).toHaveBeenCalledWith("pty-gemini-wsl", "\x18");
+    expect(hostPty.write).toHaveBeenCalledWith("pty-gemini-wsl", "\x07");
     expect(hostPty.write).not.toHaveBeenCalledWith("pty-gemini-wsl", "\r");
 
     await vi.advanceTimersByTimeAsync(40);
@@ -259,6 +259,98 @@ describe("TerminalManager（长文本发送策略）", () => {
     expect(writeSource).not.toHaveBeenCalled();
     expect(readStatus).not.toHaveBeenCalled();
     expect(adapter.paste).toHaveBeenCalledWith("短文本");
+
+    tm.disposeAll(false);
+  });
+
+  it("Gemini 旧版本策略会只发送 Ctrl+X 打开外部编辑器", async () => {
+    vi.useFakeTimers();
+    const adapter: any = createAdapterStub();
+    const hostPty = createHostPtyStub();
+    createTerminalAdapterMock.mockReturnValue(adapter);
+
+    const readStatus = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: { state: "pending", requestId: "req-old-1" } })
+      .mockResolvedValue({ ok: true, status: { state: "done", requestId: "req-old-1" } });
+    const writeSource = vi.fn().mockResolvedValue({
+      ok: true,
+      requestId: "req-old-1",
+      sourcePath: "C:\\temp\\source.txt",
+      statusPath: "C:\\temp\\status.json",
+    });
+    (window as any).host = {
+      utils: {
+        writeGeminiWindowsEditorSource: writeSource,
+        readGeminiWindowsEditorStatus: readStatus,
+      },
+    };
+
+    const ptyByTab: Record<string, string> = { "tab-gemini-old": "pty-gemini-old" };
+    const tm = new TerminalManager((tabId) => ptyByTab[tabId], hostPty as any, {});
+    tm.ensurePersistentContainer("tab-gemini-old");
+    tm.setPty("tab-gemini-old", "pty-gemini-old");
+
+    await tm.sendTextAndEnter("tab-gemini-old", `${"旧版".repeat(800)}尾巴`, {
+      providerId: "gemini",
+      terminalMode: "pwsh" as any,
+      geminiWindowsEditorReady: true,
+      geminiExternalEditorShortcut: "ctrlX",
+    });
+
+    await Promise.resolve();
+    expect(hostPty.write).toHaveBeenCalledWith("pty-gemini-old", "\x18");
+    expect(hostPty.write).not.toHaveBeenCalledWith("pty-gemini-old", "\x07");
+
+    await vi.advanceTimersByTimeAsync(40 + GEMINI_PASTE_ENTER_DELAY_MS);
+    expect(hostPty.write).toHaveBeenCalledWith("pty-gemini-old", "\r");
+
+    tm.disposeAll(false);
+  });
+
+  it("Gemini 版本未知时 Ctrl+G 超时后会回退 Ctrl+X", async () => {
+    vi.useFakeTimers();
+    const adapter: any = createAdapterStub();
+    const hostPty = createHostPtyStub();
+    createTerminalAdapterMock.mockReturnValue(adapter);
+
+    const readStatus = vi.fn().mockImplementation(() => {
+      const usedCtrlX = hostPty.write.mock.calls.some((call) => call[0] === "pty-gemini-auto" && call[1] === "\x18");
+      return Promise.resolve({ ok: true, status: { state: usedCtrlX ? "done" : "pending", requestId: "req-auto-1" } });
+    });
+    const writeSource = vi.fn().mockResolvedValue({
+      ok: true,
+      requestId: "req-auto-1",
+      sourcePath: "C:\\temp\\source.txt",
+      statusPath: "C:\\temp\\status.json",
+    });
+    (window as any).host = {
+      utils: {
+        writeGeminiWindowsEditorSource: writeSource,
+        readGeminiWindowsEditorStatus: readStatus,
+      },
+    };
+
+    const ptyByTab: Record<string, string> = { "tab-gemini-auto": "pty-gemini-auto" };
+    const tm = new TerminalManager((tabId) => ptyByTab[tabId], hostPty as any, {});
+    tm.ensurePersistentContainer("tab-gemini-auto");
+    tm.setPty("tab-gemini-auto", "pty-gemini-auto");
+
+    await tm.sendTextAndEnter("tab-gemini-auto", `${"未知版本".repeat(800)}尾巴`, {
+      providerId: "gemini",
+      terminalMode: "pwsh" as any,
+      geminiWindowsEditorReady: true,
+      geminiExternalEditorShortcut: "auto",
+    });
+
+    await Promise.resolve();
+    expect(hostPty.write).toHaveBeenCalledWith("pty-gemini-auto", "\x07");
+    expect(hostPty.write).not.toHaveBeenCalledWith("pty-gemini-auto", "\x18");
+
+    await vi.advanceTimersByTimeAsync(3040);
+    expect(hostPty.write).toHaveBeenCalledWith("pty-gemini-auto", "\x18");
+
+    await vi.advanceTimersByTimeAsync(GEMINI_PASTE_ENTER_DELAY_MS);
+    expect(hostPty.write).toHaveBeenCalledWith("pty-gemini-auto", "\r");
 
     tm.disposeAll(false);
   });

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -869,6 +869,18 @@ export interface NotificationsAPI {
 }
 
 export interface UtilsAPI {
+  /** 探测当前 Gemini CLI 版本对应的外部编辑器快捷键策略。 */
+  resolveGeminiExternalEditorShortcut(args: {
+    terminal?: "wsl" | "windows" | "pwsh";
+    distro?: string;
+    startupCmd?: string;
+  }): Promise<{
+    ok: boolean;
+    shortcut?: "ctrlG" | "ctrlX" | "auto";
+    version?: string;
+    command?: string;
+    error?: string;
+  }>;
   /**
    * 中文说明：为当前 tab 预创建 Gemini Windows 外部编辑器所需 env 与会话文件。
    * - 仅影响 CodexFlow 打开的当前 PTY；


### PR DESCRIPTION
支持发现和解析 Gemini CLI JSONL 会话，保留助手回复、工具调用结果与 session_context 元信息。
新增 Gemini CLI 版本探测，按版本选择外部编辑器快捷键，并在未知版本时提供 Ctrl+G 到 Ctrl+X 的回退。（修复Gemini输入框失效） 
增强 Claude Stop hook 对 transcript 落盘延迟的重试读取，减少完成通知预览丢失。 
同步历史索引、history.read、Host API 与发送链路，并补充发布资产校验脚本。
修复 JSONL cwd 推断优先级，避免消息正文中的其他路径覆盖 metadata directories。

Sign-off-by: Lulu <58587930+lulu-sk@users.noreply.github.com>