### PR TITLE
fix(tabs): 修复分离窗口 Git 工作台项目切换

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -130,6 +130,7 @@ import {
   findFirstProjectIdForWindowTabs,
   isTabOwnedByWindow,
   MAIN_APP_WINDOW_ID,
+  moveTabBetweenProjects,
   moveTabBetweenWindows,
   moveWindowOwnedTabs,
   parseAppWindowContext,
@@ -1516,7 +1517,7 @@ export default function CodexFlowManagerUI() {
   });
   const allProjectTabs = tabsByProject[selectedProjectId] || [];
   const tabs = useMemo(() => allProjectTabs.filter((tab) => isTabOwnedByWindow(tab, currentWindowId)), [allProjectTabs, currentWindowId]);
-  const hasGitWorkbenchTab = tabs.some((tab) => tab.kind === "git");
+  const hasProjectGitWorkbenchTab = allProjectTabs.some((tab) => tab.kind === "git");
   const [activeTabId, setActiveTabId] = useState<string | null>(() => {
     const state = restoredConsoleSession?.windowUiStateById?.[currentWindowId];
     return state?.activeTabIdByProject?.[selectedProjectId] || null;
@@ -1627,6 +1628,7 @@ export default function CodexFlowManagerUI() {
   const tabsByProjectRef = useRef<Record<string, ConsoleTab[]>>(tabsByProject);
   const detachedWindowHasOwnedTabsRef = useRef(false);
   const detachedWindowClosingAfterEmptyRef = useRef(false);
+  const skipConsoleSessionSaveRef = useRef(false);
   const projectsRef = useRef<Project[]>(projects);
   const audioContextRef = useRef<AudioContext | null>(null);
   const userInputCountByTabIdRef = useRef<Record<string, number>>({});
@@ -1695,6 +1697,7 @@ export default function CodexFlowManagerUI() {
       try {
         const nextSnapshot = loadConsoleSession({ currentBootId: appBootId });
         if (!nextSnapshot) return;
+        skipConsoleSessionSaveRef.current = true;
         const nextTabsByProject: Record<string, ConsoleTab[]> = {};
         for (const [projectId, list] of Object.entries(nextSnapshot.tabsByProject || {})) {
           nextTabsByProject[projectId] = (list || []).map((tab) => ({
@@ -1815,6 +1818,10 @@ export default function CodexFlowManagerUI() {
     if (consoleSessionSaveTimerRef.current) {
       window.clearTimeout(consoleSessionSaveTimerRef.current);
       consoleSessionSaveTimerRef.current = null;
+    }
+    if (skipConsoleSessionSaveRef.current) {
+      skipConsoleSessionSaveRef.current = false;
+      return;
     }
     consoleSessionSaveTimerRef.current = window.setTimeout(() => {
       try {
@@ -5036,6 +5043,8 @@ export default function CodexFlowManagerUI() {
 
   useEffect(() => {
     if (!isDetachedTabWindow) return;
+    const selectedOwnedTabs = (tabsByProject[selectedProjectId] || []).filter((tab) => isTabOwnedByWindow(tab, currentWindowId));
+    if (selectedProjectId && selectedOwnedTabs.length > 0) return;
     const visibleProjectId = findFirstProjectIdForWindowTabs(tabsByProject, currentWindowId);
     if (!visibleProjectId) return;
     if (selectedProjectId === visibleProjectId) return;
@@ -5783,11 +5792,71 @@ export default function CodexFlowManagerUI() {
   const openGitWorkbenchTabForProjectId = useCallback((projectId: string): void => {
     const id = String(projectId || "").trim();
     if (!id) return;
-    const projectTabs = tabsByProjectRef.current[id] || [];
+    const currentTabsByProject = tabsByProjectRef.current;
+    const projectTabs = currentTabsByProject[id] || [];
     const existing = projectTabs.find((tab) => tab.kind === "git" && isTabOwnedByWindow(tab, currentWindowId));
     if (existing) {
-      setActiveTab(existing.id, { focusMode: "immediate", allowDuringRename: true, delay: 0 });
+      setActiveTab(existing.id, { projectId: id, focusMode: "immediate", allowDuringRename: true, delay: 0 });
       try { setCenterMode("console"); } catch {}
+      markProjectUsed(id);
+      return;
+    }
+    const existingAnyWindow = projectTabs.find((tab) => tab.kind === "git") || null;
+    const detachedOwnedGitEntry = isDetachedTabWindow
+      ? Object.entries(currentTabsByProject).flatMap(([ownedProjectId, list]) => {
+          if (!Array.isArray(list) || list.length <= 0) return [];
+          return list
+            .filter((tab) => tab.kind === "git" && isTabOwnedByWindow(tab, currentWindowId))
+            .map((tab) => ({ projectId: ownedProjectId, tab }));
+        })[0] || null
+      : null;
+    if (isDetachedTabWindow && existingAnyWindow && !isTabOwnedByWindow(existingAnyWindow, currentWindowId)) {
+      const returned = detachedOwnedGitEntry
+        ? moveTabBetweenWindows(currentTabsByProject, detachedOwnedGitEntry.tab.id, MAIN_APP_WINDOW_ID)
+        : { nextTabsByProject: currentTabsByProject, movedProjectId: "", changed: false };
+      const moved = moveTabBetweenWindows(returned.nextTabsByProject, existingAnyWindow.id, currentWindowId);
+      if (moved.changed) {
+        tabsByProjectRef.current = moved.nextTabsByProject;
+        setTabsByProject(moved.nextTabsByProject);
+        setActiveTabByProject((prev) => {
+          const next = { ...prev, [id]: existingAnyWindow.id };
+          if (detachedOwnedGitEntry?.projectId && detachedOwnedGitEntry.projectId !== id) {
+            const remainingSourceTabs = (moved.nextTabsByProject[detachedOwnedGitEntry.projectId] || []).filter(
+              (tab) => isTabOwnedByWindow(tab, currentWindowId),
+            );
+            next[detachedOwnedGitEntry.projectId] = remainingSourceTabs[0]?.id || null;
+          }
+          return next;
+        });
+        setActiveTab(existingAnyWindow.id, { projectId: id, focusMode: "immediate", allowDuringRename: true, delay: 0 });
+        try { setCenterMode("console"); } catch {}
+        markProjectUsed(id);
+        return;
+      }
+    }
+    if (isDetachedTabWindow && detachedOwnedGitEntry) {
+      const moved = moveTabBetweenProjects(currentTabsByProject, detachedOwnedGitEntry.tab.id, id);
+      if (moved.changed) {
+        tabsByProjectRef.current = moved.nextTabsByProject;
+        registerTabProject(detachedOwnedGitEntry.tab.id, id);
+        setTabsByProject(moved.nextTabsByProject);
+        setActiveTabByProject((prev) => {
+          const next = { ...prev, [id]: detachedOwnedGitEntry.tab.id };
+          if (moved.sourceProjectId && moved.sourceProjectId !== id) {
+            const remainingSourceTabs = (moved.nextTabsByProject[moved.sourceProjectId] || []).filter(
+              (tab) => isTabOwnedByWindow(tab, currentWindowId),
+            );
+            next[moved.sourceProjectId] = remainingSourceTabs[0]?.id || null;
+          }
+          return next;
+        });
+        setActiveTab(detachedOwnedGitEntry.tab.id, { projectId: id, focusMode: "immediate", allowDuringRename: true, delay: 0 });
+        try { setCenterMode("console"); } catch {}
+        markProjectUsed(id);
+        return;
+      }
+    }
+    if (existingAnyWindow) {
       markProjectUsed(id);
       return;
     }
@@ -5802,10 +5871,10 @@ export default function CodexFlowManagerUI() {
     };
     registerTabProject(tab.id, id);
     setTabsByProject((m) => ({ ...m, [id]: [tab, ...(m[id] || [])] }));
-    setActiveTab(tab.id, { focusMode: "immediate", allowDuringRename: true, delay: 0 });
+    setActiveTab(tab.id, { projectId: id, focusMode: "immediate", allowDuringRename: true, delay: 0 });
     try { setCenterMode("console"); } catch {}
     markProjectUsed(id);
-  }, [currentWindowId, markProjectUsed, t]);
+  }, [currentWindowId, isDetachedTabWindow, markProjectUsed, t]);
 
   /**
    * 统一处理 Git 工作台打开请求，先切换项目/标签，再把意图广播给具体工作台实例。
@@ -9359,6 +9428,8 @@ export default function CodexFlowManagerUI() {
                   // 点击项目时默认进入控制台，并清除历史选择（避免自动跳到历史详情）
                   suppressAutoSelectRef.current = true;
                   setSelectedProjectId(p.id);
+                  if (isDetachedTabWindow)
+                    openGitWorkbenchTabForProjectId(p.id);
                   setCenterMode("console");
                   setSelectedHistoryDir(null);
                   setSelectedHistoryId(null);
@@ -9726,7 +9797,7 @@ export default function CodexFlowManagerUI() {
 
   const shouldShowGitWorkbenchTabButton = !!selectedProject
     && !isDetachedTabWindow
-    && !hasGitWorkbenchTab
+    && !hasProjectGitWorkbenchTab
     && !(tabs.length === 0 && projPathExists === false);
 
   const GitWorkbenchTabButton = shouldShowGitWorkbenchTabButton ? (
@@ -9792,7 +9863,7 @@ export default function CodexFlowManagerUI() {
                 <div
                   key={tab.id}
                   className={cn(
-                    "group/tab relative flex h-6 min-w-[44px] max-w-[10rem] flex-[0_1_10rem] items-center select-none",
+                    "group/tab relative flex h-6 min-w-[44px] max-w-[10rem] flex-[0_1_auto] items-center select-none",
                     draggingTabId === tab.id ? "opacity-35" : "",
                   )}
                   data-state={isActiveTab ? 'active' : 'inactive'}

--- a/web/src/lib/tab-window.test.ts
+++ b/web/src/lib/tab-window.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { MAIN_APP_WINDOW_ID, moveTabBetweenProjects } from "./tab-window";
+
+describe("tab-window", () => {
+  it("moveTabBetweenProjects：应把标签迁移到目标项目首位并保留窗口归属", () => {
+    const input = {
+      alpha: [
+        { id: "git-alpha", windowId: "detached-git" },
+        { id: "term-alpha", windowId: MAIN_APP_WINDOW_ID },
+      ],
+      beta: [
+        { id: "term-beta", windowId: MAIN_APP_WINDOW_ID },
+      ],
+    };
+
+    const result = moveTabBetweenProjects(input, "git-alpha", "beta");
+
+    expect(result.changed).toBe(true);
+    expect(result.sourceProjectId).toBe("alpha");
+    expect(result.nextTabsByProject.alpha).toEqual([
+      { id: "term-alpha", windowId: MAIN_APP_WINDOW_ID },
+    ]);
+    expect(result.nextTabsByProject.beta).toEqual([
+      { id: "git-alpha", windowId: "detached-git" },
+      { id: "term-beta", windowId: MAIN_APP_WINDOW_ID },
+    ]);
+  });
+
+  it("moveTabBetweenProjects：目标项目与源项目相同时不应改动", () => {
+    const input = {
+      alpha: [
+        { id: "git-alpha", windowId: MAIN_APP_WINDOW_ID },
+      ],
+    };
+
+    const result = moveTabBetweenProjects(input, "git-alpha", "alpha");
+
+    expect(result.changed).toBe(false);
+    expect(result.sourceProjectId).toBe("alpha");
+    expect(result.nextTabsByProject).toBe(input);
+  });
+
+  it("moveTabBetweenProjects：缺少标签或目标项目时应直接返回原状态", () => {
+    const input = {
+      alpha: [
+        { id: "git-alpha", windowId: MAIN_APP_WINDOW_ID },
+      ],
+    };
+
+    expect(moveTabBetweenProjects(input, "missing", "beta")).toEqual({
+      nextTabsByProject: input,
+      sourceProjectId: "",
+      changed: false,
+    });
+    expect(moveTabBetweenProjects(input, "git-alpha", "")).toEqual({
+      nextTabsByProject: input,
+      sourceProjectId: "",
+      changed: false,
+    });
+  });
+});

--- a/web/src/lib/tab-window.ts
+++ b/web/src/lib/tab-window.ts
@@ -208,6 +208,52 @@ export function moveTabBetweenWindows<T extends WindowScopedTabLike>(
 }
 
 /**
+ * 将单个标签页迁移到目标项目，并保留标签自身内容与窗口归属。
+ */
+export function moveTabBetweenProjects<T extends WindowScopedTabLike>(
+  tabsByProject: Record<string, T[]>,
+  tabId: string,
+  targetProjectId: string,
+  options?: { insertIndex?: number },
+): { nextTabsByProject: Record<string, T[]>; sourceProjectId: string; changed: boolean } {
+  const safeTabId = String(tabId || "").trim();
+  const safeTargetProjectId = String(targetProjectId || "").trim();
+  if (!safeTabId || !safeTargetProjectId) {
+    return { nextTabsByProject: tabsByProject, sourceProjectId: "", changed: false };
+  }
+
+  let sourceProjectId = "";
+  let movedTab: T | null = null;
+  const nextTabsByProject: Record<string, T[]> = { ...tabsByProject };
+  for (const [projectId, tabs] of Object.entries(tabsByProject || {})) {
+    if (!Array.isArray(tabs) || tabs.length <= 0) continue;
+    const tabIndex = tabs.findIndex((tab) => String(tab.id || "").trim() === safeTabId);
+    if (tabIndex < 0) continue;
+    sourceProjectId = projectId;
+    if (projectId === safeTargetProjectId) {
+      return { nextTabsByProject: tabsByProject, sourceProjectId, changed: false };
+    }
+    movedTab = tabs[tabIndex] || null;
+    nextTabsByProject[projectId] = tabs.filter((tab) => String(tab.id || "").trim() !== safeTabId);
+    break;
+  }
+
+  if (!sourceProjectId || !movedTab) {
+    return { nextTabsByProject: tabsByProject, sourceProjectId: "", changed: false };
+  }
+
+  const currentTargetTabs = Array.isArray(nextTabsByProject[safeTargetProjectId])
+    ? [...nextTabsByProject[safeTargetProjectId]]
+    : [];
+  const normalizedInsertIndex = Number.isFinite(options?.insertIndex)
+    ? Math.max(0, Math.min(currentTargetTabs.length, Math.trunc(Number(options?.insertIndex))))
+    : 0;
+  currentTargetTabs.splice(normalizedInsertIndex, 0, movedTab);
+  nextTabsByProject[safeTargetProjectId] = currentTargetTabs;
+  return { nextTabsByProject, sourceProjectId, changed: true };
+}
+
+/**
  * 将指定窗口承载的全部标签页迁移到另一个窗口；未命中的项目数组保持引用不变。
  */
 export function moveWindowOwnedTabs<T extends WindowScopedTabLike>(


### PR DESCRIPTION
产品层面：
- 分离出来的 Git 工作台窗口点击左侧项目时，会复用当前分离窗口中的 Git 标签并切换到目标项目。
- 主窗口已有目标项目 Git 工作台时，分离窗口会接管该标签，避免同一项目重复出现多个 Git 工作台入口。
- 主窗口的 Git 工作台按钮按项目维度去重，即使标签当前归属其他窗口也不再重复创建。

技术层面：
- 新增标签跨项目迁移工具，保留标签内容与窗口归属，并补充单元测试覆盖迁移、同项目无改动和无效输入场景。
- 调整分离窗口项目选择、会话同步和活跃标签映射逻辑，避免跨窗口同步被旧的延迟保存覆盖。
- 收窄底部标签宽度弹性，避免 Git 工作台标签占用过多空间。