### PR TITLE
fix(notifications): 修复 Codex hook 探测失败与重复完成通知

### DIFF
--- a/electron/codex/config.test.ts
+++ b/electron/codex/config.test.ts
@@ -314,6 +314,38 @@ describe("electron/codex/config（tui 通知配置修复）", () => {
     }
   });
 
+  it("版本探测失败但已有 lifecycle hook：保留 hooks 并移除旧 notify", async () => {
+    const { home, cleanup } = createTempHome();
+    try {
+      writeCodexConfigToml(home, [
+        'notify = ["powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "C:\\\\Users\\\\example\\\\.codex\\\\codexflow_after_agent_notify.ps1"]',
+        "",
+        "[[hooks.Stop]]",
+        "[[hooks.Stop.hooks]]",
+        'type = "command"',
+        'command = "node C:\\\\Users\\\\example\\\\.codex\\\\codexflow_lifecycle_notify.cjs"',
+        "",
+        "[[hooks.SubagentStop]]",
+        "[[hooks.SubagentStop.hooks]]",
+        'type = "command"',
+        'command = "node C:\\\\Users\\\\example\\\\.codex\\\\codexflow_lifecycle_notify.cjs"',
+        "",
+      ].join("\n"));
+
+      const mod = await loadConfigModule("codex unknown");
+      await mod.ensureAllCodexNotifications();
+
+      const body = readCodexConfigToml(home);
+      expect(body).toContain("[[hooks.Stop]]");
+      expect(body).toContain("[[hooks.SubagentStop]]");
+      expect(body).toContain("codexflow_lifecycle_notify.cjs");
+      expect(body).not.toContain("codexflow_after_agent_notify.ps1");
+      expect(body).not.toContain("notify = ");
+    } finally {
+      cleanup();
+    }
+  });
+
   it("空配置：补齐 [tui] notifications + notification_method=osc9", async () => {
     const { home, cleanup } = createTempHome();
     try {

--- a/electron/codex/config.ts
+++ b/electron/codex/config.ts
@@ -1264,6 +1264,39 @@ function isCodexFlowLifecycleHookBlock(block: string): boolean {
 }
 
 /**
+ * 中文说明：探测现有配置中 CodexFlow lifecycle hook 的安装状态。
+ */
+function detectCodexFlowLifecycleHookSupport(normalized: string): Pick<CodexCliHookSupport, "supportsStop" | "supportsSubagentStop"> {
+  const lines = normalized.length > 0 ? normalized.split("\n") : [];
+  let supportsStop = false;
+  let supportsSubagentStop = false;
+  for (let i = 0; i < lines.length;) {
+    const line = String(lines[i] || "");
+    const match = line.match(/^\s*\[\[hooks\.(Stop|SubagentStop)\]\]\s*(?:#.*)?$/);
+    if (!match) {
+      i += 1;
+      continue;
+    }
+
+    let end = i + 1;
+    while (end < lines.length) {
+      const probe = String(lines[end] || "");
+      if (/^\s*\[\[hooks\.[A-Za-z0-9_]+\]\]\s*(?:#.*)?$/.test(probe)) break;
+      if (/^\s*\[hooks(?:\.|])/.test(probe) && !/^\s*\[\[hooks\.(Stop|SubagentStop)\.hooks\]\]\s*(?:#.*)?$/.test(probe)) break;
+      end += 1;
+    }
+
+    const block = lines.slice(i, end).join("\n");
+    if (isCodexFlowLifecycleHookBlock(block)) {
+      if (match[1] === "Stop") supportsStop = true;
+      else supportsSubagentStop = true;
+    }
+    i = end;
+  }
+  return { supportsStop, supportsSubagentStop };
+}
+
+/**
  * 中文说明：移除 CodexFlow 自己写入的 Stop/SubagentStop hook 块，保留用户其它 hooks。
  */
 function removeCodexFlowLifecycleHookBlocks(lines: string[]): { lines: string[]; changed: boolean; stateRefs: CodexLifecycleHookStateRef[] } {
@@ -1554,15 +1587,26 @@ async function ensureNotificationsAtConfigTarget(target: CodexConfigTarget): Pro
   const support = await probeCodexCliHookSupport(target);
   let updated = normalized;
   let changed = false;
+  let configMode = support.supportsStop ? "hooks" : "legacy";
 
-  if (support.supportsStop) {
+  const installedLifecycleSupport = detectCodexFlowLifecycleHookSupport(updated);
+  const shouldUseLifecycleHooks = support.supportsStop || (!support.version && installedLifecycleSupport.supportsStop);
+  if (shouldUseLifecycleHooks) {
+    configMode = support.supportsStop ? "hooks" : "hooks-existing";
+    const effectiveSupport: CodexCliHookSupport = support.supportsStop
+      ? support
+      : {
+        ...support,
+        supportsStop: true,
+        supportsSubagentStop: installedLifecycleSupport.supportsSubagentStop,
+      };
     const hookSpec = resolveCodexHookCommandSpec(configPath);
     const hookScriptReady = hookSpec ? ensureCodexHookScript(hookSpec, source) : false;
     const notifyCleanup = removeCodexFlowRootNotifyCommand(updated);
     updated = notifyCleanup.updated;
     changed = changed || notifyCleanup.changed;
     if (hookSpec && hookScriptReady) {
-      const hookResult = appendCodexLifecycleHookBlocks(updated, configPath, hookSpec, support);
+      const hookResult = appendCodexLifecycleHookBlocks(updated, configPath, hookSpec, effectiveSupport);
       updated = hookResult.updated;
       changed = changed || hookResult.changed;
     }
@@ -1590,7 +1634,7 @@ async function ensureNotificationsAtConfigTarget(target: CodexConfigTarget): Pro
   try {
     fs.writeFileSync(configPath, serialized, "utf8");
     try {
-      perfLogger.log(`[codex.config] ensure notifications path=${configPath} source=${source || "n/a"} mode=${support.supportsStop ? "hooks" : "legacy"} version=${support.version || "n/a"} changed=${changed ? "1" : "0"}`);
+      perfLogger.log(`[codex.config] ensure notifications path=${configPath} source=${source || "n/a"} mode=${configMode} version=${support.version || "n/a"} changed=${changed ? "1" : "0"}`);
     } catch {}
     return true;
   } catch (error) {

--- a/electron/git/featureService.operation.test.ts
+++ b/electron/git/featureService.operation.test.ts
@@ -1360,7 +1360,7 @@ describe("featureService dedicated file history", () => {
     } finally {
       await fixture.cleanup();
     }
-  });
+  }, { timeout: 90_000 });
 
   it("普通日志模式不应把 stash 三连记录混入提交历史", async () => {
     const fixture = await createRepoFixture("codexflow-log-stash-filter");
@@ -1561,7 +1561,7 @@ describe("featureService log filters", () => {
     } finally {
       await fixture.cleanup();
     }
-  });
+  }, { timeout: 90_000 });
 
   it("作者多选筛选应使用 OR 语义，并保持图谱与可见列表同源", async () => {
     const fixture = await createRepoFixture("codexflow-log-author-multi");

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -217,6 +217,7 @@ import {
   TAB_FOCUS_DELAY,
   TerminalView,
   WorktreeControlPad,
+  areEquivalentCompletionPreviews,
   areStringArraysEqual,
   buildAutoCommitMessage,
   buildProviderNotifyEnv,
@@ -244,7 +245,6 @@ import {
   normDir,
   normalizeCompletionPrefs,
   normalizeCompletionPreview,
-  normalizeDisplayedCompletionPreviewForDedupe,
   normalizeDirTreeStore,
   normalizeMsToIso,
   normalizeResumeMode,
@@ -256,6 +256,7 @@ import {
   pickUuidFromString,
   resolveHistoryTimelineMeta,
   shouldDedupeCrossSourceCompletion,
+  shouldDedupeRepeatedExternalCompletion,
   shouldDelayOscCompletionForExternalFallback,
   startOfLocalDay,
   summarizeForCommitMessage,
@@ -3043,15 +3044,7 @@ export default function CodexFlowManagerUI() {
    * - 兼容“一个是另一个前缀”的截断差异（例如 OSC 截断 vs hook 完整预览）。
    */
   function isEquivalentCompletionPreview(leftRaw: string, rightRaw: string): boolean {
-    const left = normalizeDisplayedCompletionPreviewForDedupe(leftRaw);
-    const right = normalizeDisplayedCompletionPreviewForDedupe(rightRaw);
-    if (!left && !right) return true;
-    if (!left || !right) return false;
-    if (left === right) return true;
-    const shorter = left.length <= right.length ? left : right;
-    const longer = shorter === left ? right : left;
-    if (shorter.length < 8) return false;
-    return longer.startsWith(shorter);
+    return areEquivalentCompletionPreviews(leftRaw, rightRaw);
   }
 
   /**
@@ -3070,11 +3063,20 @@ export default function CodexFlowManagerUI() {
     if (!last) return false;
     const delta = Date.now() - last.ts;
     if (delta < 0) return false;
+    if (hasWorkingTimer) return false;
     if (
       delta <= windowMs &&
       isEquivalentCompletionPreview(String(last.preview || ""), String(preview || ""))
     ) return true;
     const currentSource = source || "unknown";
+    if (last.source === "external" && currentSource === "external")
+      return shouldDedupeRepeatedExternalCompletion(
+        String(last.preview || ""),
+        String(preview || ""),
+        delta,
+        COMPLETION_CROSS_SOURCE_WINDOW_MS,
+        hasWorkingTimer,
+      );
     const crossSource =
       (last.source === "osc" && currentSource === "external") ||
       (last.source === "external" && currentSource === "osc");

--- a/web/src/app/app-shared.notify.test.ts
+++ b/web/src/app/app-shared.notify.test.ts
@@ -4,12 +4,14 @@ import {
   CLAUDE_NOTIFY_ENV_KEYS,
   GEMINI_NOTIFY_ENV_KEYS,
   buildProviderNotifyEnv,
+  areEquivalentCompletionPreviews,
   hasMeaningfulCompletionPreview,
   isAgentCompletionMessage,
   normalizeCompletionPreview,
   normalizeDisplayedCompletionPreviewForDedupe,
   normalizeCompletionPreviewForDedupe,
   shouldDedupeCrossSourceCompletion,
+  shouldDedupeRepeatedExternalCompletion,
   shouldDelayOscCompletionForExternalFallback,
   normalizeCompletionPrefs,
 } from "./app-shared";
@@ -82,6 +84,12 @@ describe("app-shared（完成通知：识别与环境变量注入）", () => {
     expect(normalizeDisplayedCompletionPreviewForDedupe("第一行\n  第二行  \\n 第三段")).toBe("第一行 第二行 \\n 第三段");
   });
 
+  it("areEquivalentCompletionPreviews：识别 hook 与 legacy notify 解码后的同一预览", () => {
+    const hookPreview = "已改好。\n\n当前分支：`fix/codex-subagent-notification-completion`";
+    const legacyPreview = "已改好。\n\n当前分支：`fix/codex-subagent-notification-completion`";
+    expect(areEquivalentCompletionPreviews(hookPreview, legacyPreview)).toBe(true);
+  });
+
   it("hasMeaningfulCompletionPreview：区分通用完成信号与真实摘要", () => {
     expect(hasMeaningfulCompletionPreview("")).toBe(false);
     expect(hasMeaningfulCompletionPreview("   ")).toBe(false);
@@ -98,6 +106,16 @@ describe("app-shared（完成通知：识别与环境变量注入）", () => {
 
   it("shouldDedupeCrossSourceCompletion：重新进入 working 后不吞掉新一轮完成事件", () => {
     expect(shouldDedupeCrossSourceCompletion("", "已处理 README", 1200, 5000, true)).toBe(false);
+  });
+
+  it("shouldDedupeRepeatedExternalCompletion：去重新版 Stop hook 与旧 notify 的延迟双写", () => {
+    const hookPreview = "测试正常。";
+    const legacyPreview = "测试正常。";
+    expect(shouldDedupeRepeatedExternalCompletion(hookPreview, legacyPreview, 2600, 5000, false)).toBe(true);
+  });
+
+  it("shouldDedupeRepeatedExternalCompletion：重新 working 后不吞掉新一轮同文案回复", () => {
+    expect(shouldDedupeRepeatedExternalCompletion("测试正常。", "测试正常。", 2600, 5000, true)).toBe(false);
   });
 
   it("shouldDelayOscCompletionForExternalFallback：仅 Codex 需要优先等待 external 预览", () => {

--- a/web/src/app/app-shared.tsx
+++ b/web/src/app/app-shared.tsx
@@ -1729,6 +1729,21 @@ function normalizeDisplayedCompletionPreviewForDedupe(raw: string): string {
 }
 
 /**
+ * 中文说明：判断两条完成预览是否可视为同一次完成事件。
+ */
+function areEquivalentCompletionPreviews(leftRaw: string, rightRaw: string): boolean {
+  const left = normalizeDisplayedCompletionPreviewForDedupe(leftRaw);
+  const right = normalizeDisplayedCompletionPreviewForDedupe(rightRaw);
+  if (!left && !right) return true;
+  if (!left || !right) return false;
+  if (left === right) return true;
+  const shorter = left.length <= right.length ? left : right;
+  const longer = shorter === left ? right : left;
+  if (shorter.length < 8) return false;
+  return longer.startsWith(shorter);
+}
+
+/**
  * 中文说明：判断归一化后的完成预览是否包含真实细节。
  * - 空串或纯空白视为“仅完成信号”，不应压制后续更完整的 external 预览；
  * - 供完成事件跨来源去重逻辑复用，避免新版 Codex 的通用完成文案吞掉真实摘要。
@@ -1757,6 +1772,22 @@ function shouldDedupeCrossSourceCompletion(
   const nextHasDetail = hasMeaningfulCompletionPreview(nextPreview);
   if (!lastHasDetail && nextHasDetail) return false;
   return true;
+}
+
+/**
+ * 中文说明：判断同为 external 的延迟重复完成事件是否应去重。
+ * 典型场景是新版 Codex Stop hook 与遗留 notify 同时写入 JSONL，第二条可能晚到数秒。
+ */
+function shouldDedupeRepeatedExternalCompletion(
+  lastPreview: string,
+  nextPreview: string,
+  deltaMs: number,
+  windowMs: number,
+  hasWorkingTimer: boolean,
+): boolean {
+  if (hasWorkingTimer) return false;
+  if (deltaMs < 0 || deltaMs > windowMs) return false;
+  return areEquivalentCompletionPreviews(lastPreview, nextPreview);
 }
 
 /**
@@ -2064,8 +2095,10 @@ export {
   normalizeCompletionPreview,
   normalizeCompletionPreviewForDedupe,
   normalizeDisplayedCompletionPreviewForDedupe,
+  areEquivalentCompletionPreviews,
   hasMeaningfulCompletionPreview,
   shouldDedupeCrossSourceCompletion,
+  shouldDedupeRepeatedExternalCompletion,
   shouldDelayOscCompletionForExternalFallback,
   canonicalFilterKey,
   keysOfItemCanonical,


### PR DESCRIPTION
- 版本探测失败但配置中已有 CodexFlow lifecycle hook 时继续使用 hook 模式，避免回退 legacy notify 造成重复或丢失通知
- 清理 hooks 模式下遗留 root notify，并按已安装 Stop/SubagentStop hook 推导有效支持范围
- 将完成预览等价判断抽到共享层，对延迟到达的 external 完成事件做跨窗口去重
- 标签页已重新进入 working 时跳过旧完成快照去重，避免吞掉新一轮同文案完成
- 为耗时 Git 日志分页用例补齐超时预算，保证完整测试稳定