### PR TITLE
fix(history): 修复 Codex 历史预览与 USER Input 跳转

### DIFF
--- a/electron/agentSessions/shared/preview.ts
+++ b/electron/agentSessions/shared/preview.ts
@@ -80,6 +80,39 @@ export function filterHistoryPreviewText(raw: string): string {
   }
 }
 
+type CodexInternalContextParts = {
+  rest: string;
+  objective: string;
+};
+
+/**
+ * 从 Codex goal 内部上下文中提取用户目标摘要。
+ */
+function extractCodexGoalObjectiveText(inner: string): string {
+  try {
+    const matched = String(inner || "").match(/<objective>\s*([\s\S]*?)(?:<\/objective>|$)/i);
+    if (!matched?.[1]) return "";
+    return filterHistoryPreviewText(matched[1]);
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * 拆分 Codex goal 模式注入的内部上下文前缀，保留后续真实用户内容并记录 objective 兜底摘要。
+ */
+function extractLeadingCodexInternalContext(raw: string): CodexInternalContextParts {
+  const text = String(raw || "").replace(/\r\n/g, "\n");
+  const trimmed = text.trimStart();
+  if (!/^<codex_internal_context\b/i.test(trimmed)) return { rest: text, objective: "" };
+  const matched = trimmed.match(/^<codex_internal_context\b[^>]*>([\s\S]*?)<\/codex_internal_context>\s*/i);
+  if (!matched) return { rest: "", objective: "" };
+  return {
+    rest: trimmed.slice(matched[0].length),
+    objective: extractCodexGoalObjectiveText(matched[1] || ""),
+  };
+}
+
 /**
  * 过滤 Codex 历史预览文本：
  * - 优先提取官方 Codex “Files mentioned” 模板里的真实请求段；
@@ -87,7 +120,8 @@ export function filterHistoryPreviewText(raw: string): string {
  */
 export function filterCodexHistoryPreviewText(raw: string): string {
   try {
-    const text = String(raw || "").replace(/\r\n/g, "\n");
+    const internalContext = extractLeadingCodexInternalContext(String(raw || "").replace(/\r\n/g, "\n"));
+    const text = internalContext.rest.trim() ? internalContext.rest : internalContext.objective;
     const marker = text.match(/^##\s*My request for Codex:?\s*$/im);
     if (marker && typeof marker.index === "number") {
       const request = text.slice(marker.index + marker[0].length).trim();
@@ -97,7 +131,9 @@ export function filterCodexHistoryPreviewText(raw: string): string {
     if (/^#\s*Files mentioned by the user:/i.test(text.trim())) return "";
     if (/^#\s*AGENTS\.md instructions\b/i.test(text.trim())) return "";
     if (/^<environment_context>/i.test(text.trim())) return "";
-    return filterHistoryPreviewText(text);
+    if (/^<turn_aborted>/i.test(text.trim())) return "";
+    if (/^Another language model started to solve this problem\b/i.test(text.trim())) return "";
+    return filterHistoryPreviewText(text) || internalContext.objective;
   } catch {
     return filterHistoryPreviewText(String(raw || ""));
   }

--- a/electron/agentSessions/shared/taggedPrefix.test.ts
+++ b/electron/agentSessions/shared/taggedPrefix.test.ts
@@ -22,5 +22,23 @@ describe("extractTaggedPrefix", () => {
     expect(res.rest).toBe("NEXT");
     expect(res.picked).toEqual([{ type: "instructions", text: "AAA" }]);
   });
+
+  it("识别 subagent_notification 并格式化 JSON 字符串换行", () => {
+    const src = [
+      "<subagent_notification>",
+      "{\"agent_path\":\"agent-1\",\"status\":{\"completed\":\"第一行\\n\\n第二行\"}}",
+      "</subagent_notification>",
+    ].join("\n");
+    const res = extractTaggedPrefix(src);
+
+    expect(res.rest).toBe("");
+    expect(res.picked[0]?.type).toBe("subagent_notification");
+    expect(res.picked[0]?.tags).toEqual(["subagent_notification"]);
+    expect(res.picked[0]?.text).toContain("agent_path: agent-1");
+    expect(res.picked[0]?.text).toContain("completed:");
+    expect(res.picked[0]?.text).toContain("第一行");
+    expect(res.picked[0]?.text).toContain("第二行");
+    expect(res.picked[0]?.text).not.toContain("\\n");
+  });
 });
 

--- a/electron/agentSessions/shared/taggedPrefix.ts
+++ b/electron/agentSessions/shared/taggedPrefix.ts
@@ -1,12 +1,59 @@
 export type TaggedPrefixPick = { type: string; text: string; tags?: string[] };
 
 /**
+ * 为多行值补齐缩进，避免 JSON 字符串中的换行继续以 `\n` 形式展示。
+ */
+function indentSubagentNotificationText(value: string, indentLevel: number): string {
+  const pad = "  ".repeat(Math.max(0, indentLevel));
+  return String(value || "").replace(/\r\n/g, "\n").split("\n").map((line) => `${pad}${line}`).join("\n");
+}
+
+/**
+ * 将 subagent 通知的 JSON payload 格式化为可读文本。
+ */
+function formatSubagentNotificationValue(value: unknown, indentLevel = 0): string {
+  const pad = "  ".repeat(Math.max(0, indentLevel));
+  if (Array.isArray(value)) {
+    if (value.length === 0) return `${pad}[]`;
+    return value.map((item) => {
+      if (item && typeof item === "object") return `${pad}-\n${formatSubagentNotificationValue(item, indentLevel + 1)}`;
+      return `${pad}- ${String(item ?? "").replace(/\r\n/g, "\n")}`;
+    }).join("\n");
+  }
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) return `${pad}{}`;
+    return entries.map(([key, item]) => {
+      if (item && typeof item === "object") return `${pad}${key}:\n${formatSubagentNotificationValue(item, indentLevel + 1)}`;
+      const text = String(item ?? "").replace(/\r\n/g, "\n");
+      if (text.includes("\n")) return `${pad}${key}:\n${indentSubagentNotificationText(text, indentLevel + 1)}`;
+      return `${pad}${key}: ${text}`;
+    }).join("\n");
+  }
+  return `${pad}${String(value ?? "").replace(/\r\n/g, "\n")}`;
+}
+
+/**
+ * 解析 subagent 通知文本；JSON 解析失败时仅还原换行转义，保留原始内容。
+ */
+function formatSubagentNotificationText(raw: string): string {
+  const text = String(raw || "").trim();
+  if (!text) return "";
+  try {
+    return formatSubagentNotificationValue(JSON.parse(text)).trim();
+  } catch {
+    return text.replace(/\\r\\n/g, "\n").replace(/\\n/g, "\n").trim();
+  }
+}
+
+/**
  * 从输入文本的“前缀”提取内嵌标签块（为性能考虑，不做全文搜索）。
  *
  * 目前支持：
  * - `<user_instructions>...</user_instructions>` -> `instructions`
  * - `<permissions instructions>...</permissions instructions>` -> `instructions`
  * - `<environment_context>...</environment_context>` -> `environment_context`
+ * - `<subagent_notification>...</subagent_notification>` -> `subagent_notification`
  * - `# AGENTS.md instructions for ...`（含可选 `<instructions>...</instructions>`）-> `instructions`
  */
 export function extractTaggedPrefix(source: string): { rest: string; picked: TaggedPrefixPick[] } {
@@ -22,6 +69,22 @@ export function extractTaggedPrefix(source: string): { rest: string; picked: Tag
   const closeP = "</permissions instructions>";
   const openE = "<environment_context>";
   const closeE = "</environment_context>";
+  const openS = "<subagent_notification>";
+  const closeS = "</subagent_notification>";
+
+  // 匹配 subagent_notification 前缀，转成可读通知块，避免 JSON 字符串换行以 \n 展示
+  if (lower.startsWith(openS)) {
+    const endTag = lower.indexOf(closeS);
+    if (endTag >= 0) {
+      const inner = s2.slice(openS.length, endTag);
+      picked.push({ type: "subagent_notification", text: formatSubagentNotificationText(inner), tags: ["subagent_notification"] });
+      const rest = s2.slice(endTag + closeS.length);
+      return { rest: rest.trim(), picked };
+    }
+    const inner = s2.slice(openS.length);
+    picked.push({ type: "subagent_notification", text: formatSubagentNotificationText(inner), tags: ["subagent_notification"] });
+    return { rest: "", picked };
+  }
 
   // 优先匹配 user_instructions 前缀
   if (lower.startsWith(openU)) {

--- a/electron/history.test.ts
+++ b/electron/history.test.ts
@@ -200,9 +200,158 @@ describe("electron/history.listHistory", () => {
     expect(sessions[0].preview).toBe("工作流包 alp-auto-current-ops 节点的位置调整优化，重叠的地方调整间距");
     expect(sessions[0].preview || "").not.toContain("# Files mentioned by the user");
   });
+
+  it("goal 内部上下文不会被当成标题，并继续跳过前置路径行", async () => {
+    await createHistoryListJsonlFile([
+      {
+        timestamp: "2026-04-29T03:35:01.000Z",
+        type: "session_meta",
+        payload: {
+          id: "session-goal-context",
+          cwd: "/workspace/project",
+        },
+      },
+      {
+        timestamp: "2026-04-29T03:35:02.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: [
+                "<codex_internal_context source=\"goal\">",
+                "内部目标上下文不应作为标题",
+                "</codex_internal_context>",
+                "src/features/history/detail.ts",
+                "修复历史详情标题提取",
+              ].join("\n"),
+            },
+          ],
+        },
+      },
+    ]);
+
+    const sessions = await listHistory({});
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].title).toBe("修复历史详情标题提取");
+    expect(sessions[0].preview).toBe("修复历史详情标题提取");
+  });
+
+  it("goal objective 可作为首条标题候选且 turn_aborted 不会抢占标题", async () => {
+    await createHistoryListJsonlFile([
+      {
+        timestamp: "2026-04-29T03:35:01.000Z",
+        type: "session_meta",
+        payload: {
+          id: "session-goal-objective",
+          cwd: "/workspace/project",
+        },
+      },
+      {
+        timestamp: "2026-04-29T03:35:02.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: [
+                "<codex_internal_context source=\"goal\">",
+                "Continue working toward the active thread goal.",
+                "<objective>",
+                "你作为调度者，最终目标是完整推进测试与验收工作",
+                "`alp-auto-v3-lan-three-task-test.zh-CN.md`",
+                "</objective>",
+                "</codex_internal_context>",
+              ].join("\n"),
+            },
+          ],
+        },
+      },
+      {
+        timestamp: "2026-04-29T03:35:03.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: [
+                "<turn_aborted>",
+                "The user interrupted the previous turn on purpose.",
+                "</turn_aborted>",
+              ].join("\n"),
+            },
+          ],
+        },
+      },
+      {
+        timestamp: "2026-04-29T03:35:04.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "预检我不是提醒你了吗，只执行一个任务就行" }],
+        },
+      },
+    ]);
+
+    const sessions = await listHistory({});
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].title).toBe("你作为调度者，最终目标是完整推进测试与验收工作");
+    expect(sessions[0].preview).toBe("你作为调度者，最终目标是完整推进测试与验收工作");
+  });
 });
 
 describe("electron/history.readHistoryFile", () => {
+  it("将 subagent_notification 解析为通知消息并格式化换行", async () => {
+    const filePath = await createHistoryJsonlFile([
+      {
+        timestamp: "2026-03-06T00:00:00.000Z",
+        type: "session_meta",
+        payload: {
+          id: "session-subagent-notification",
+          cwd: "/workspace/project",
+        },
+      },
+      {
+        timestamp: "2026-03-06T00:00:01.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: [
+                "<subagent_notification>",
+                "{\"agent_path\":\"agent-1\",\"status\":{\"completed\":\"第一行\\n\\n第二行\"}}",
+                "</subagent_notification>",
+              ].join("\n"),
+            },
+          ],
+        },
+      },
+    ]);
+
+    const parsed = await readHistoryFile(filePath, { maxLines: 0 });
+    const notification = parsed.messages.find((message) => message.content?.some((item) => item.type === "subagent_notification"));
+    const text = notification?.content?.find((item) => item.type === "subagent_notification")?.text || "";
+
+    expect(notification?.role).toBe("notification");
+    expect(text).toContain("agent_path: agent-1");
+    expect(text).toContain("completed:");
+    expect(text).toContain("第一行");
+    expect(text).toContain("第二行");
+    expect(text).not.toContain("\\n");
+  });
+
   it("maxLines<=0 时会读取 5000 行之后的 response_item.output_text", async () => {
     const filePath = await createHistoryJsonlFile([
       {

--- a/electron/history.ts
+++ b/electron/history.ts
@@ -15,6 +15,7 @@ import settings from './settings';
 import { extractTaggedPrefix } from './agentSessions/shared/taggedPrefix';
 import { createHistoryImageContent, extractImagePathCandidatesFromText } from './agentSessions/shared/historyImage';
 import { deriveGeminiProjectHashCandidatesFromPath, extractGeminiProjectHashFromPath } from './agentSessions/gemini/parser';
+import { filterCodexHistoryPreviewText } from './agentSessions/shared/preview';
 import { pathMatchesDirKeyScope, tidyPathCandidate } from "./agentSessions/shared/path";
 
 /**
@@ -358,6 +359,7 @@ function isSyntheticCodexContextText(value: string): boolean {
   if (!text) return true;
   if (/^#\s*AGENTS\.md instructions\b/i.test(text)) return true;
   if (/^<environment_context>/i.test(text)) return true;
+  if (/^<turn_aborted>/i.test(text)) return true;
   if (/^Another language model started to solve this problem\b/i.test(text)) return true;
   if (/^#\s*Files mentioned by the user:/i.test(text) && !/^##\s*My request for Codex:?\s*$/im.test(text)) return true;
   return false;
@@ -368,13 +370,9 @@ function isSyntheticCodexContextText(value: string): boolean {
  */
 function extractCodexRequestText(value: string): string {
   const raw = String(value || '').replace(/\r\n/g, '\n');
-  const marker = raw.match(/^##\s*My request for Codex:?\s*$/im);
-  if (marker && typeof marker.index === 'number') {
-    const request = raw.slice(marker.index + marker[0].length);
-    return normalizeHistoryPreviewText(request);
-  }
-  if (isSyntheticCodexContextText(raw)) return '';
-  return normalizeHistoryPreviewText(raw);
+  const filtered = filterCodexHistoryPreviewText(raw);
+  if (!filtered || isSyntheticCodexContextText(filtered)) return '';
+  return normalizeHistoryPreviewText(filtered);
 }
 
 /**
@@ -585,7 +583,7 @@ type HistoryListCacheEntry = {
 };
 
 // 中文说明：历史归属语义变更后提升版本，强制失效旧的列表缓存，避免继续复用错误归属结果。
-const PARSER_VERSION = 'v13';
+const PARSER_VERSION = 'v15';
 const CACHE_SCHEMA_VERSION = '2';
 
 /**
@@ -1864,6 +1862,24 @@ export async function readHistoryFile(filePath: string, opts?: { chunkSize?: num
   }
 
   /**
+   * 中文说明：判断消息内容是否只包含子代理通知，避免把通知当成真实用户输入。
+   */
+  function isSubagentNotificationOnlyContent(contentArr: MessageContent[] | null | undefined): boolean {
+    const items = Array.isArray(contentArr) ? contentArr : [];
+    if (items.length === 0) return false;
+    return items.every((item) => String(item?.type || '').trim().toLowerCase() === 'subagent_notification');
+  }
+
+  /**
+   * 中文说明：将纯子代理通知的历史角色规整为 notification，避免详情页和锚点逻辑误判为用户输入。
+   */
+  function normalizeHistoryMessageRoleForContent(role: unknown, contentArr: MessageContent[]): string {
+    const rawRole = String(role || '').trim() || 'user';
+    if (rawRole.toLowerCase() === 'user' && isSubagentNotificationOnlyContent(contentArr)) return 'notification';
+    return rawRole;
+  }
+
+  /**
    * 中文说明：将 `event_msg.user_message` 恢复出的图片并入上一条等价 user 消息，避免详情页重复显示同一块输入。
    * - 仅匹配“最后一条消息就是同文本 user”的近邻场景，保持判定简单且不误伤真实重复提问；
    * - 若上一条已存在同签名图片，则仅抑制重复块，不重复附加图片项。
@@ -2118,7 +2134,7 @@ export async function readHistoryFile(filePath: string, opts?: { chunkSize?: num
             }
           }
         } catch {}
-        if (contentArr.length > 0) messages.push({ role, content: contentArr });
+        if (contentArr.length > 0) messages.push({ role: normalizeHistoryMessageRoleForContent(role, contentArr), content: contentArr });
       } else if (userMessageEventContent) {
         try {
           rememberImagePathsFromText(typeof obj.payload?.message === 'string' ? obj.payload.message : '');

--- a/electron/indexer.test.ts
+++ b/electron/indexer.test.ts
@@ -178,7 +178,117 @@ describe("electron/indexer Codex preview", () => {
     const summaries = getIndexedSummaries().filter((item) => item.filePath === filePath);
 
     expect(summaries).toHaveLength(1);
+    expect(summaries[0].title).toBe("工作流包 alp-auto-current-ops 节点的位置调整优化，重叠的地方调整间距");
     expect(summaries[0].preview).toBe("工作流包 alp-auto-current-ops 节点的位置调整优化，重叠的地方调整间距");
     expect(summaries[0].preview || "").not.toContain("# Files mentioned by the user");
+  });
+
+  it("索引摘要会跳过 goal 内部上下文和前置路径行生成标题", async () => {
+    const filePath = await createCodexSessionFile([
+      {
+        timestamp: "2026-04-29T03:35:01.000Z",
+        type: "session_meta",
+        payload: {
+          id: "session-index-goal-context",
+          cwd: "/workspace/project",
+        },
+      },
+      {
+        timestamp: "2026-04-29T03:35:02.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: [
+                "<codex_internal_context source=\"goal\">",
+                "内部目标上下文不应作为标题",
+                "</codex_internal_context>",
+                "src/features/history/detail.ts",
+                "修复历史详情标题提取",
+              ].join("\n"),
+            },
+          ],
+        },
+      },
+    ]);
+
+    await startHistoryIndexer(() => null);
+    const summaries = getIndexedSummaries().filter((item) => item.filePath === filePath);
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].title).toBe("修复历史详情标题提取");
+    expect(summaries[0].preview).toBe("修复历史详情标题提取");
+  });
+
+  it("索引摘要会使用首条 goal objective 且忽略 turn_aborted", async () => {
+    const filePath = await createCodexSessionFile([
+      {
+        timestamp: "2026-04-29T03:35:01.000Z",
+        type: "session_meta",
+        payload: {
+          id: "session-index-goal-objective",
+          cwd: "/workspace/project",
+        },
+      },
+      {
+        timestamp: "2026-04-29T03:35:02.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: [
+                "<codex_internal_context source=\"goal\">",
+                "Continue working toward the active thread goal.",
+                "<objective>",
+                "你作为调度者，最终目标是完整推进测试与验收工作",
+                "`alp-auto-v3-lan-three-task-test.zh-CN.md`",
+                "</objective>",
+                "</codex_internal_context>",
+              ].join("\n"),
+            },
+          ],
+        },
+      },
+      {
+        timestamp: "2026-04-29T03:35:03.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: [
+                "<turn_aborted>",
+                "The user interrupted the previous turn on purpose.",
+                "</turn_aborted>",
+              ].join("\n"),
+            },
+          ],
+        },
+      },
+      {
+        timestamp: "2026-04-29T03:35:04.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "预检我不是提醒你了吗，只执行一个任务就行" }],
+        },
+      },
+    ]);
+
+    await startHistoryIndexer(() => null);
+    const summaries = getIndexedSummaries().filter((item) => item.filePath === filePath);
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].title).toBe("你作为调度者，最终目标是完整推进测试与验收工作");
+    expect(summaries[0].preview).toBe("你作为调度者，最终目标是完整推进测试与验收工作");
   });
 });

--- a/electron/indexer.ts
+++ b/electron/indexer.ts
@@ -10,13 +10,14 @@ import { getDebugConfig } from "./debugConfig";
 import { getSessionsRootCandidatesFastAsync, isUNCPath, uncToWsl, wslToUNC } from "./wsl";
 import { safeWindowSend } from "./ipcSafe";
 import { detectResumeInfo, detectRuntimeShell, detectRuntimeShellFromContent } from "./history";
-import type { HistorySummary, Message, RuntimeShell } from "./history";
+import type { HistorySummary, Message, MessageContent, RuntimeShell } from "./history";
 import settings from "./settings";
 import { getClaudeRootCandidatesFastAsync, discoverClaudeSessionFiles } from "./agentSessions/claude/discovery";
 import { getGeminiRootCandidatesFastAsync, discoverGeminiSessionFiles } from "./agentSessions/gemini/discovery";
 import { parseClaudeSessionFile } from "./agentSessions/claude/parser";
 import { parseGeminiSessionFile, deriveGeminiProjectHashCandidatesFromPath } from "./agentSessions/gemini/parser";
 import { filterCodexHistoryPreviewText } from "./agentSessions/shared/preview";
+import { extractTaggedPrefix } from "./agentSessions/shared/taggedPrefix";
 import {
   dirKeyFromCwd as dirKeyFromCwdShared,
   dirKeyOfFilePath as dirKeyOfFilePathShared,
@@ -246,7 +247,7 @@ function stripDetailsForPersist(details: Details): Details {
 }
 
 // 中文说明：历史索引语义调整后提升版本，强制丢弃旧的 index/details 缓存，避免继续沿用错误 dirKey。
-const VERSION = "v13";
+const VERSION = "v15";
 
 /**
  * 读取 Claude Code 的 Agent 历史开关（默认 false）。
@@ -987,6 +988,32 @@ async function parseCodexDetails(fp: string, stat: fs.Stats, opts?: { summaryOnl
   const pushMessage = (msg: Message) => {
     if (!summaryOnly) messages.push(msg);
   };
+  /**
+   * 生成 Codex 详情标题：没有线程名或显式标题时，用已过滤的首条用户预览替代文件名。
+   */
+  const resolveCodexDetailsTitle = (): string => {
+    const fallbackTitle = titleFromFilename(fp);
+    if (preview && (!title || title === fallbackTitle)) {
+      return preview.length > 96 ? `${preview.slice(0, 95)}…` : preview;
+    }
+    return title;
+  };
+  /**
+   * 判断消息内容是否只包含子代理通知。
+   */
+  const isSubagentNotificationOnlyContent = (contentArr: MessageContent[] | null | undefined): boolean => {
+    const items = Array.isArray(contentArr) ? contentArr : [];
+    if (items.length === 0) return false;
+    return items.every((item) => String(item?.type || "").trim().toLowerCase() === "subagent_notification");
+  };
+  /**
+   * 将纯子代理通知的 Codex 历史角色规整为 notification。
+   */
+  const normalizeCodexDetailsRoleForContent = (role: unknown, contentArr: MessageContent[]): string => {
+    const rawRole = String(role || "").trim() || "user";
+    if (rawRole.toLowerCase() === "user" && isSubagentNotificationOnlyContent(contentArr)) return "notification";
+    return rawRole;
+  };
   return await new Promise<Details>((resolve) => {
     try {
       const rs = fs.createReadStream(fp, { encoding: "utf8", highWaterMark: chunk });
@@ -994,76 +1021,6 @@ async function parseCodexDetails(fp: string, stat: fs.Stats, opts?: { summaryOnl
       let buf = "";
 
       const pretty = (v: any) => { try { return JSON.stringify(v, null, 2); } catch { return String(v); } };
-	      const extractTaggedPrefix = (s: string) => {
-	        const src = String(s || '');
-	        const picked: { type: string; text: string; tags?: string[] }[] = [];
-	        const leading = (src.match(/^\s*/) || [''])[0].length;
-	        const s2 = src.slice(leading);
-	        const lower = s2.toLowerCase();
-	        const openU = '<user_instructions>';
-	        const closeU = '</user_instructions>';
-	        const openP = '<permissions instructions>';
-	        const closeP = '</permissions instructions>';
-	        const openE = '<environment_context>';
-	        const closeE = '</environment_context>';
-	        if (lower.startsWith(openU)) {
-	          const idx = lower.indexOf(closeU);
-	          if (idx >= 0) {
-	            const inner = s2.slice(openU.length, idx);
-	            picked.push({ type: 'instructions', text: inner });
-	            const rest = s2.slice(idx + closeU.length);
-	            return { rest: rest.trim(), picked };
-	          }
-	          picked.push({ type: 'instructions', text: s2.slice(openU.length) });
-	          return { rest: '', picked };
-	        }
-	        // 匹配 permissions instructions 前缀（用于沙盒/审批策略等运行权限说明）
-	        if (lower.startsWith(openP)) {
-	          const idx = lower.indexOf(closeP);
-	          if (idx >= 0) {
-	            const inner = s2.slice(openP.length, idx);
-	            picked.push({ type: 'instructions', text: inner });
-	            const rest = s2.slice(idx + closeP.length);
-	            return { rest: rest.trim(), picked };
-	          }
-	          picked.push({ type: 'instructions', text: s2.slice(openP.length) });
-	          return { rest: '', picked };
-	        }
-	        if (lower.startsWith(openE)) {
-	          const idx = lower.indexOf(closeE);
-	          if (idx >= 0) {
-	            const inner = s2.slice(openE.length, idx);
-	            picked.push({ type: 'environment_context', text: inner });
-            const rest = s2.slice(idx + closeE.length);
-            return { rest: rest.trim(), picked };
-          }
-          picked.push({ type: 'environment_context', text: s2.slice(openE.length) });
-          return { rest: '', picked };
-        }
-        const agentsPrefix = '# agents.md instructions for';
-        if (lower.startsWith(agentsPrefix)) {
-          const openTag = '<instructions>';
-          const closeTag = '</instructions>';
-          const openIdx = lower.indexOf(openTag);
-          if (openIdx >= 0) {
-            const closeIdx = lower.indexOf(closeTag, openIdx + openTag.length);
-            if (closeIdx >= 0) {
-              const inner = s2.slice(openIdx + openTag.length, closeIdx);
-              picked.push({ type: 'instructions', text: inner });
-              const rest = s2.slice(closeIdx + closeTag.length);
-              return { rest: rest.trim(), picked };
-            }
-          }
-          const afterHeader = s2.split(/\r?\n/).slice(1).join('\n').trim();
-          if (afterHeader) {
-            picked.push({ type: 'instructions', text: afterHeader });
-            return { rest: '', picked };
-          }
-          picked.push({ type: 'instructions', text: s2 });
-          return { rest: '', picked };
-        }
-        return { rest: src, picked };
-      };
       const flushLines = (text: string) => {
         const lines = text.split(/\r?\n/);
         for (const line of lines) {
@@ -1238,7 +1195,7 @@ async function parseCodexDetails(fp: string, stat: fs.Stats, opts?: { summaryOnl
                     }
                   } catch {}
                 }
-                pushMessage({ role, content: items });
+                pushMessage({ role: normalizeCodexDetailsRoleForContent(role, items), content: items });
               }
             } else if (obj.type === 'function_call' || obj.record_type === 'tool_call' || ((obj as any).type === 'response_item' && (obj as any).payload && (((obj as any).payload.type === 'function_call') || ((obj as any).payload.record_type === 'tool_call')))) {
               const src: any = ((obj as any).type === 'response_item' && (obj as any).payload) ? (obj as any).payload : obj;
@@ -1347,17 +1304,17 @@ async function parseCodexDetails(fp: string, stat: fs.Stats, opts?: { summaryOnl
         if (cwd) dirKey = dirKeyFromCwd(cwd); else dirKey = dirKeyOf(fp);
         if (runtimeShell === 'unknown') runtimeShell = detectRuntimeShell(fp);
         const finalResumeId = resumeId || id;
-        resolve({ providerId: "codex", id, title, date, filePath: fp, messages, skippedLines: skipped, rawDate, cwd, dirKey, preview, resumeMode, resumeId: finalResumeId, runtimeShell });
+        resolve({ providerId: "codex", id, title: resolveCodexDetailsTitle(), date, filePath: fp, messages, skippedLines: skipped, rawDate, cwd, dirKey, preview, resumeMode, resumeId: finalResumeId, runtimeShell });
       });
       rs.on('error', () => {
         if (runtimeShell === 'unknown') runtimeShell = detectRuntimeShell(fp);
         const finalResumeId = resumeId || id;
-        resolve({ providerId: "codex", id, title, date, filePath: fp, messages, skippedLines: skipped, rawDate, cwd, dirKey, preview, resumeMode, resumeId: finalResumeId, runtimeShell });
+        resolve({ providerId: "codex", id, title: resolveCodexDetailsTitle(), date, filePath: fp, messages, skippedLines: skipped, rawDate, cwd, dirKey, preview, resumeMode, resumeId: finalResumeId, runtimeShell });
       });
     } catch {
       if (runtimeShell === 'unknown') runtimeShell = detectRuntimeShell(fp);
       const finalResumeId = resumeId || id;
-      resolve({ providerId: "codex", id, title, date, filePath: fp, messages, skippedLines: skipped, resumeMode, resumeId: finalResumeId, runtimeShell });
+      resolve({ providerId: "codex", id, title: resolveCodexDetailsTitle(), date, filePath: fp, messages, skippedLines: skipped, resumeMode, resumeId: finalResumeId, runtimeShell });
     }
   });
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -85,6 +85,7 @@ import {
   type HistoryInlineImageRenderState,
 } from "@/features/history/history-inline-images";
 import { VirtualizedList, type VirtualizedListHandle } from "@/features/history/virtualized-list";
+import { buildHistoryUserInputMessageKeys } from "@/features/history/user-input-anchors";
 import { applyHistoryFindHighlights, clearHistoryFindHighlights, setActiveHistoryFindMatch } from "@/features/history/find/history-find";
 import { toWSLForInsert } from "@/lib/wsl";
 import { extractGeminiProjectHashFromPath, deriveGeminiProjectHashCandidatesFromPath } from "@/lib/gemini-hash";
@@ -14024,6 +14025,13 @@ const HISTORY_DETAIL_VIRTUAL_OVERSCAN = 1600;
 const HISTORY_DETAIL_SEARCH_DEBOUNCE_MS = 120;
 const HISTORY_DETAIL_PRE_CLASS_NAME = "mt-2 max-w-full overflow-x-auto whitespace-pre-wrap font-apple-regular";
 
+type HistoryUserInputScrollRequest = {
+  id: number;
+  messageKey: string;
+  messageIndex: number;
+  userInputIndex: number;
+};
+
 /**
  * 中文说明：渲染历史详情中的图片块。
  * - 主视图改为“路径 + 小图”紧凑排布，避免历史详情被大图撑开；
@@ -14228,6 +14236,19 @@ function ContentRenderer({
             </div>
           );
         }
+        if (ty === 'subagent_notification') {
+          return (
+            <div key={`${kprefix || 'itm'}-subagent-${i}`} className="min-w-0 rounded-apple border border-[var(--cf-border)] bg-[var(--cf-surface-muted)] p-2 text-xs text-[var(--cf-text-primary)]">
+              <div className="flex min-w-0 items-center justify-between gap-2 text-[var(--cf-text-secondary)] font-apple-semibold">
+                <div>subagent_notification</div>
+                <HistoryCopyButton text={text} />
+              </div>
+              <pre className={HISTORY_DETAIL_PRE_CLASS_NAME}>
+                <code data-history-search-scope>{text}</code>
+              </pre>
+            </div>
+          );
+        }
         if (ty === 'summary') {
           return (
             <div key={`${kprefix || 'itm'}-sum-${i}`} className="relative min-w-0 rounded-apple border border-[var(--cf-border)] bg-[var(--cf-purple-light)] p-2 text-xs text-[var(--cf-text-primary)] font-apple-regular">
@@ -14367,14 +14388,6 @@ type HistoryRenderOptions = {
  */
 function buildHistoryMessageKey(sessionId: string, originalIndex: number): string {
   return `${sessionId}-${originalIndex}`;
-}
-
-/**
- * 中文说明：判断某条历史消息是否属于 USER Input 锚点。
- * 约定：以 role === "user" 作为详情页中的用户输入定位基准。
- */
-function isHistoryUserInputMessage(message: HistoryMessage): boolean {
-  return String(message?.role || "").trim().toLowerCase() === "user";
 }
 
 /**
@@ -14654,7 +14667,7 @@ function buildHistoryTypeFilter(messages: HistoryMessage[]): Record<string, bool
   filtered.sort();
 
   const next: Record<string, boolean> = {};
-  for (const key of filtered) next[key] = (key === 'input_text' || key === 'output_text' || key === 'image');
+  for (const key of filtered) next[key] = (key === 'input_text' || key === 'output_text' || key === 'image' || key === 'subagent_notification');
   return next;
 }
 
@@ -14834,8 +14847,15 @@ function HistoryDetail({ sessions, selectedHistoryId, projectWinPath, onBack, on
   }, []);
 
   useEffect(() => {
-    messageRefs.current = {};
-  }, [detailSession, filteredMessages.length]);
+    const aliveKeys = new Set<string>();
+    for (const view of filteredMessages) {
+      const key = String(view?.messageKey || "");
+      if (key) aliveKeys.add(key);
+    }
+    for (const key of Object.keys(messageRefs.current)) {
+      if (!aliveKeys.has(key)) delete messageRefs.current[key];
+    }
+  }, [detailSession, filteredMessages]);
 
   useEffect(() => {
     const root = historyFindRootRef.current;
@@ -14899,26 +14919,36 @@ function HistoryDetail({ sessions, selectedHistoryId, projectWinPath, onBack, on
   const normalizedMatchIndex = matches.length === 0 ? 0 : Math.min(activeMatchIndex, matches.length - 1);
   const activeMatch = matches[normalizedMatchIndex] || null;
   const userInputMessageKeys = useMemo(
-    () => filteredMessages.filter((view) => isHistoryUserInputMessage(view.message)).map((view) => view.messageKey),
+    () => buildHistoryUserInputMessageKeys(filteredMessages),
     [filteredMessages],
   );
   const userInputMessageKeySignature = userInputMessageKeys.join("|");
   const [activeUserInputIndex, setActiveUserInputIndex] = useState<number | null>(null);
+  const activeUserInputIndexRef = useRef<number | null>(null);
+  const userInputScrollRequestIdRef = useRef(0);
+  const [activeUserInputScrollRequest, setActiveUserInputScrollRequest] = useState<HistoryUserInputScrollRequest | null>(null);
 
   useEffect(() => {
+    activeUserInputIndexRef.current = null;
     setActiveUserInputIndex(null);
   }, [selectedHistoryId, userInputMessageKeySignature]);
 
   useEffect(() => {
     if (activeUserInputIndex === null) return;
     if (userInputMessageKeys.length === 0) {
+      activeUserInputIndexRef.current = null;
       setActiveUserInputIndex(null);
       return;
     }
     if (activeUserInputIndex >= userInputMessageKeys.length) {
+      activeUserInputIndexRef.current = userInputMessageKeys.length - 1;
       setActiveUserInputIndex(userInputMessageKeys.length - 1);
     }
   }, [activeUserInputIndex, userInputMessageKeys.length]);
+
+  useEffect(() => {
+    activeUserInputIndexRef.current = activeUserInputIndex;
+  }, [activeUserInputIndex]);
 
   const normalizedUserInputIndex = activeUserInputIndex === null || userInputMessageKeys.length === 0
     ? -1
@@ -14986,45 +15016,101 @@ function HistoryDetail({ sessions, selectedHistoryId, projectWinPath, onBack, on
   }, [detailSearchActive, activeMatch, messageIndexByKey]);
 
   useEffect(() => {
-    if (!activeUserInputMessageKey) return;
-    const matchIndex = messageIndexByKey.get(activeUserInputMessageKey);
-    if (typeof matchIndex === "number") {
-      historyVirtualListRef.current?.scrollToIndex(matchIndex, { align: "start", behavior: "smooth" });
-    }
+    const request = activeUserInputScrollRequest;
+    if (!request) return;
+    const { messageKey, messageIndex, userInputIndex } = request;
+    historyVirtualListRef.current?.scrollToIndex(messageIndex, { align: "start", behavior: "auto" });
 
     let cancelled = false;
+    let rafId = 0;
     let attempts = 0;
+    let resizeVersion = 0;
+    let lastResizeVersion = -1;
+    let lastDelta: number | null = null;
+    let stableFrames = 0;
+    const maxAttempts = 120;
+    const topPadding = userInputIndex === 0 ? 28 : 8;
+    let observedMessageNode: HTMLDivElement | null = null;
+
+    const scheduleCalibration = () => {
+      if (cancelled || rafId || attempts >= maxAttempts) return;
+      rafId = requestAnimationFrame(calibrateUserInputAnchor);
+    };
+
+    const resizeObserver = typeof ResizeObserver !== "undefined"
+      ? new ResizeObserver(() => {
+        resizeVersion += 1;
+        stableFrames = 0;
+        scheduleCalibration();
+      })
+      : null;
+
+    const cleanupTimer = window.setTimeout(() => {
+      cancelled = true;
+      if (rafId) cancelAnimationFrame(rafId);
+      try { resizeObserver?.disconnect(); } catch {}
+    }, 2500);
+
+    try {
+      const viewport = detailScrollAreaRef.current;
+      const root = historyFindRootRef.current;
+      if (resizeObserver && viewport) resizeObserver.observe(viewport);
+      if (resizeObserver && root) resizeObserver.observe(root);
+    } catch {}
 
     /**
-     * 中文说明：等待虚拟列表完成挂载后，再将当前 USER Input 锚点滚到靠近视口顶部但保留少量上边距的位置。
+     * 持续校准当前 USER Input 锚点，直到目标 DOM 和上方内容高度连续稳定。
      */
-    const tryActivateUserInput = () => {
+    function calibrateUserInputAnchor() {
+      rafId = 0;
       if (cancelled) return;
+      attempts += 1;
 
       const viewport = detailScrollAreaRef.current;
-      const messageNode = messageRefs.current[activeUserInputMessageKey];
+      const messageNode = messageRefs.current[messageKey];
       if (viewport && messageNode) {
         try {
+          if (resizeObserver && observedMessageNode !== messageNode) {
+            if (observedMessageNode) {
+              try { resizeObserver.unobserve(observedMessageNode); } catch {}
+            }
+            resizeObserver.observe(messageNode);
+            observedMessageNode = messageNode;
+          }
           const viewportRect = viewport.getBoundingClientRect();
           const nodeRect = messageNode.getBoundingClientRect();
-          // 第一条用户输入上方要给日期预留更多空间，后续条目只保留最小安全边距即可。
-          const topPadding = matchIndex === 0 ? 28 : 8;
-          const nextTop = Math.max(0, viewport.scrollTop + (nodeRect.top - viewportRect.top) - topPadding);
-          viewport.scrollTo({ top: nextTop, behavior: "smooth" });
+          const delta = (nodeRect.top - viewportRect.top) - topPadding;
+          const roundedDelta = Math.round(delta * 10) / 10;
+          if (Math.abs(delta) > 2) {
+            stableFrames = 0;
+            lastDelta = roundedDelta;
+            lastResizeVersion = resizeVersion;
+            const nextTop = Math.max(0, viewport.scrollTop + delta);
+            viewport.scrollTo({ top: nextTop, behavior: "auto" });
+          } else {
+            const deltaStable = lastDelta !== null && Math.abs(roundedDelta - lastDelta) <= 0.5;
+            const resizeStable = lastResizeVersion === resizeVersion;
+            stableFrames = deltaStable && resizeStable ? stableFrames + 1 : 0;
+            lastDelta = roundedDelta;
+            lastResizeVersion = resizeVersion;
+            if (stableFrames >= 2) return;
+          }
         } catch {}
-        return;
+      } else if (attempts % 3 === 0) {
+        historyVirtualListRef.current?.scrollToIndex(messageIndex, { align: "start", behavior: "auto" });
       }
 
-      attempts += 1;
-      if (attempts < 6) requestAnimationFrame(tryActivateUserInput);
-    };
+      scheduleCalibration();
+    }
 
-    const rafId = requestAnimationFrame(tryActivateUserInput);
+    scheduleCalibration();
     return () => {
       cancelled = true;
-      cancelAnimationFrame(rafId);
+      window.clearTimeout(cleanupTimer);
+      if (rafId) cancelAnimationFrame(rafId);
+      try { resizeObserver?.disconnect(); } catch {}
     };
-  }, [activeUserInputMessageKey, messageIndexByKey]);
+  }, [activeUserInputScrollRequest]);
 
   const goToNextMatch = useCallback(() => {
     if (!matches.length) return;
@@ -15038,20 +15124,47 @@ function HistoryDetail({ sessions, selectedHistoryId, projectWinPath, onBack, on
   }, [matches.length]);
 
   /**
+   * 激活指定 USER Input，并把滚动目标快照写入请求，避免滚动 effect 再读取可能滞后的派生状态。
+   */
+  const activateUserInputIndex = useCallback((nextIndex: number) => {
+    const messageKey = userInputMessageKeys[nextIndex];
+    if (!messageKey) return;
+    const messageIndex = messageIndexByKey.get(messageKey);
+    if (typeof messageIndex !== "number") return;
+    activeUserInputIndexRef.current = nextIndex;
+    userInputScrollRequestIdRef.current += 1;
+    setActiveUserInputIndex(nextIndex);
+    setActiveUserInputScrollRequest({
+      id: userInputScrollRequestIdRef.current,
+      messageKey,
+      messageIndex,
+      userInputIndex: nextIndex,
+    });
+  }, [messageIndexByKey, userInputMessageKeys]);
+
+  /**
    * 中文说明：在当前可见的 USER Input 锚点之间循环切换。
    */
   const goToNextUserInput = useCallback(() => {
     if (!userInputMessageKeys.length) return;
-    setActiveUserInputIndex((prev) => (prev === null ? 0 : (prev + 1) % userInputMessageKeys.length));
-  }, [userInputMessageKeys.length]);
+    const currentIndex = activeUserInputIndexRef.current;
+    const nextIndex = currentIndex === null || currentIndex < 0 || currentIndex >= userInputMessageKeys.length
+      ? 0
+      : (currentIndex + 1) % userInputMessageKeys.length;
+    activateUserInputIndex(nextIndex);
+  }, [activateUserInputIndex, userInputMessageKeys.length]);
 
   /**
    * 中文说明：在当前可见的 USER Input 锚点之间反向循环切换。
    */
   const goToPrevUserInput = useCallback(() => {
     if (!userInputMessageKeys.length) return;
-    setActiveUserInputIndex((prev) => (prev === null ? userInputMessageKeys.length - 1 : (prev - 1 + userInputMessageKeys.length) % userInputMessageKeys.length));
-  }, [userInputMessageKeys.length]);
+    const currentIndex = activeUserInputIndexRef.current;
+    const nextIndex = currentIndex === null || currentIndex < 0 || currentIndex >= userInputMessageKeys.length
+      ? userInputMessageKeys.length - 1
+      : (currentIndex - 1 + userInputMessageKeys.length) % userInputMessageKeys.length;
+    activateUserInputIndex(nextIndex);
+  }, [activateUserInputIndex, userInputMessageKeys.length]);
 
   const activeDetailMessageKey = activeUserInputIndex !== null
     ? activeUserInputMessageKey || undefined
@@ -15329,12 +15442,16 @@ function HistoryDetail({ sessions, selectedHistoryId, projectWinPath, onBack, on
 
           {userInputMessageKeys.length > 0 ? (
             <div className="flex items-center justify-self-center">
-              <div className="flex items-center gap-1">
-                {activeUserInputIndex !== null && (
-                  <div className="mr-0.5 whitespace-nowrap text-[0.65rem] font-apple-medium text-[var(--cf-text-muted)]">
-                    {normalizedUserInputIndex + 1} / {userInputMessageKeys.length}
-                  </div>
-                )}
+              <div className="grid grid-cols-[3.75rem_1.25rem_1.25rem] items-center gap-1">
+                <div
+                  className={cn(
+                    "whitespace-nowrap text-right text-[0.65rem] font-apple-medium tabular-nums text-[var(--cf-text-muted)]",
+                    activeUserInputIndex === null && "invisible",
+                  )}
+                  aria-hidden={activeUserInputIndex === null}
+                >
+                  {normalizedUserInputIndex + 1} / {userInputMessageKeys.length}
+                </div>
                 <button
                   type="button"
                   onClick={goToPrevUserInput}
@@ -15506,6 +15623,7 @@ function HistoryDetail({ sessions, selectedHistoryId, projectWinPath, onBack, on
                         items={filteredMessages}
                         scrollContainerRef={detailScrollAreaRef}
                         estimateItemHeight={HISTORY_DETAIL_VIRTUAL_ESTIMATED_HEIGHT}
+                        getEstimatedItemHeight={estimateHistoryMessageHeight}
                         overscan={HISTORY_DETAIL_VIRTUAL_OVERSCAN}
                         getItemKey={(view) => view.messageKey}
                         renderItem={(view) => <HistoryMessageCard view={view} options={detailRenderOptions} />}

--- a/web/src/features/history/user-input-anchors.test.ts
+++ b/web/src/features/history/user-input-anchors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { buildHistoryUserInputMessageKeys } from "@/features/history/user-input-anchors";
+import type { HistoryMessage } from "@/types/host";
+
+/**
+ * 构造历史消息测试项。
+ */
+function historyView(messageKey: string, message: HistoryMessage) {
+  return { messageKey, message };
+}
+
+/**
+ * 构造文本消息。
+ */
+function textMessage(role: string, text: string, type = "input_text"): HistoryMessage {
+  return { role, content: [{ type, text }] };
+}
+
+describe("history user input anchors", () => {
+  it("首个 goal context 计入 USER Input，后续重复 goal context 不计入", () => {
+    const keys = buildHistoryUserInputMessageKeys([
+      historyView("goal-1", textMessage("user", "<codex_internal_context source=\"goal\">\n<objective>目标</objective>\n</codex_internal_context>")),
+      historyView("turn-aborted", textMessage("user", "<turn_aborted>\nThe user interrupted the previous turn.\n</turn_aborted>")),
+      historyView("real-user", textMessage("user", "继续处理真实用户输入")),
+      historyView("goal-2", textMessage("user", "<codex_internal_context source = \"goal\">\n<objective>目标</objective>\n</codex_internal_context>")),
+      historyView("subagent", { role: "user", content: [{ type: "subagent_notification", text: "completed" }] }),
+      historyView("assistant", textMessage("assistant", "助手回复", "output_text")),
+    ]);
+
+    expect(keys).toEqual(["goal-1", "real-user"]);
+  });
+});

--- a/web/src/features/history/user-input-anchors.ts
+++ b/web/src/features/history/user-input-anchors.ts
@@ -1,0 +1,63 @@
+import type { HistoryMessage } from "@/types/host";
+
+export type HistoryUserInputAnchorMessageView = {
+  messageKey: string;
+  message: HistoryMessage;
+};
+
+/**
+ * 提取历史消息里的文本内容，用于识别 Codex 合成输入。
+ */
+function getHistoryMessageText(message: HistoryMessage): string {
+  const items = Array.isArray(message?.content) ? message.content : [];
+  return items.map((item) => String(item?.text || "")).filter((text) => text.trim().length > 0).join("\n").trim();
+}
+
+/**
+ * 判断历史消息是否只包含子代理通知。
+ */
+function isHistorySubagentNotificationMessage(message: HistoryMessage): boolean {
+  const items = Array.isArray(message?.content) ? message.content : [];
+  if (items.length === 0) return false;
+  return items.every((item) => String(item?.type || "").trim().toLowerCase() === "subagent_notification");
+}
+
+/**
+ * 判断历史消息是否为 Codex goal 内部上下文。
+ */
+function isHistoryGoalContextMessage(message: HistoryMessage): boolean {
+  return /^<codex_internal_context\b(?=[^>]*\bsource\s*=\s*["']?goal["']?)/i.test(getHistoryMessageText(message).trim());
+}
+
+/**
+ * 判断历史消息是否为 Codex 中断标记。
+ */
+function isHistoryTurnAbortedMessage(message: HistoryMessage): boolean {
+  return /^<turn_aborted>/i.test(getHistoryMessageText(message).trim());
+}
+
+/**
+ * 判断某条历史消息是否属于 USER Input 锚点候选。
+ */
+function isHistoryUserInputMessage(message: HistoryMessage): boolean {
+  return String(message?.role || "").trim().toLowerCase() === "user"
+    && !isHistorySubagentNotificationMessage(message)
+    && !isHistoryTurnAbortedMessage(message);
+}
+
+/**
+ * 构造 USER Input 锚点序列；首个 goal context 代表线程目标，后续重复 goal context 不再计入跳转。
+ */
+export function buildHistoryUserInputMessageKeys(messages: HistoryUserInputAnchorMessageView[]): string[] {
+  const keys: string[] = [];
+  let hasGoalContextInput = false;
+  for (const view of messages) {
+    if (!isHistoryUserInputMessage(view.message)) continue;
+    if (isHistoryGoalContextMessage(view.message)) {
+      if (hasGoalContextInput) continue;
+      hasGoalContextInput = true;
+    }
+    keys.push(view.messageKey);
+  }
+  return keys;
+}

--- a/web/src/features/history/virtualized-list.test.ts
+++ b/web/src/features/history/virtualized-list.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { findVisibleStartIndex } from "@/features/history/virtualized-list";
+import { buildVirtualizedLayout, findVisibleStartIndex } from "@/features/history/virtualized-list";
 
 describe("history virtualized list window calculation", () => {
   it("滚动窗口超过总高度时定位到最后一项而不是首项", () => {
@@ -9,5 +9,37 @@ describe("history virtualized list window calculation", () => {
 
   it("滚动窗口落在中间内容时定位到第一个进入窗口的项目", () => {
     expect(findVisibleStartIndex([0, 100, 260], [100, 160, 120], 180)).toBe(1);
+  });
+
+  it("未测量项目使用逐项估算高度构建位移表", () => {
+    const layout = buildVirtualizedLayout(
+      [{ id: "a", height: 80 }, { id: "b", height: 180 }, { id: "c", height: 60 }],
+      (item) => item.id,
+      {},
+      240,
+      (item) => item.height,
+    );
+
+    expect(layout).toEqual({
+      tops: [0, 80, 260],
+      heights: [80, 180, 60],
+      totalHeight: 320,
+    });
+  });
+
+  it("真实测量高度优先覆盖逐项估算高度", () => {
+    const layout = buildVirtualizedLayout(
+      [{ id: "a", height: 80 }, { id: "b", height: 180 }],
+      (item) => item.id,
+      { b: 220 },
+      240,
+      (item) => item.height,
+    );
+
+    expect(layout).toEqual({
+      tops: [0, 80],
+      heights: [80, 220],
+      totalHeight: 300,
+    });
   });
 });

--- a/web/src/features/history/virtualized-list.tsx
+++ b/web/src/features/history/virtualized-list.tsx
@@ -4,6 +4,7 @@ type VirtualizedListProps<TItem> = {
   items: TItem[];
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
   estimateItemHeight?: number;
+  getEstimatedItemHeight?: (item: TItem, index: number) => number;
   overscan?: number;
   getItemKey: (item: TItem, index: number) => string;
   renderItem: (item: TItem, index: number) => React.ReactNode;
@@ -20,6 +21,12 @@ type VirtualizedViewportState = {
   height: number;
 };
 
+export type VirtualizedLayout = {
+  tops: number[];
+  heights: number[];
+  totalHeight: number;
+};
+
 type VirtualizedMeasuredRowProps = {
   itemKey: string;
   top: number;
@@ -32,6 +39,33 @@ type VirtualizedMeasuredRowProps = {
  */
 function normalizeMeasuredHeight(height: number): number {
   return Math.max(1, Math.ceil(Number(height) || 0));
+}
+
+/**
+ * 为虚拟列表构建稳定的 top/height 位移表；已测量高度优先，未测量项可使用逐项估算。
+ */
+export function buildVirtualizedLayout<TItem>(
+  items: TItem[],
+  getItemKey: (item: TItem, index: number) => string,
+  measuredHeights: Record<string, number>,
+  estimateItemHeight: number,
+  getEstimatedItemHeight?: (item: TItem, index: number) => number,
+): VirtualizedLayout {
+  const tops: number[] = new Array(items.length);
+  const heights: number[] = new Array(items.length);
+  let totalHeight = 0;
+  for (let index = 0; index < items.length; index += 1) {
+    const item = items[index];
+    const itemKey = getItemKey(item, index);
+    const fallbackHeight = getEstimatedItemHeight
+      ? getEstimatedItemHeight(item, index)
+      : estimateItemHeight;
+    const itemHeight = measuredHeights[itemKey] ?? normalizeMeasuredHeight(fallbackHeight);
+    tops[index] = totalHeight;
+    heights[index] = itemHeight;
+    totalHeight += itemHeight;
+  }
+  return { tops, heights, totalHeight };
 }
 
 /**
@@ -204,6 +238,7 @@ function VirtualizedListInner<TItem>({
   items,
   scrollContainerRef,
   estimateItemHeight = 240,
+  getEstimatedItemHeight,
   overscan,
   getItemKey,
   renderItem,
@@ -230,20 +265,10 @@ function VirtualizedListInner<TItem>({
     setLayoutVersion((value) => value + 1);
   }, []);
 
-  const layout = useMemo(() => {
-    const tops: number[] = new Array(items.length);
-    const heights: number[] = new Array(items.length);
-    let totalHeight = 0;
-    for (let index = 0; index < items.length; index += 1) {
-      const item = items[index];
-      const itemKey = getItemKey(item, index);
-      const itemHeight = heightsRef.current[itemKey] ?? estimateItemHeight;
-      tops[index] = totalHeight;
-      heights[index] = itemHeight;
-      totalHeight += itemHeight;
-    }
-    return { tops, heights, totalHeight };
-  }, [items, estimateItemHeight, getItemKey, layoutVersion]);
+  const layout = useMemo(
+    () => buildVirtualizedLayout(items, getItemKey, heightsRef.current, estimateItemHeight, getEstimatedItemHeight),
+    [items, estimateItemHeight, getEstimatedItemHeight, getItemKey, layoutVersion],
+  );
 
   useLayoutEffect(() => {
     const container = scrollContainerRef.current;


### PR DESCRIPTION
统一 Codex 历史摘要、索引摘要与详情解析中的预览提取规则，避免 goal 内部上下文、turn_aborted 标记、路径行和 Files mentioned 模板污染标题。

将 subagent_notification 解析为通知消息并格式化 JSON/换行内容，避免详情页把子代理通知误判为真实用户输入。

补充 USER Input 锚点过滤与虚拟列表逐项高度估算/滚动校准，使历史详情在大日志和虚拟化场景下跳转到正确输入位置。

验证：
- npm run test
- npm run i18n:check