### PR TITLE
fix(terminal): 稳定 resize 期间的滚动锚点

### DIFF
--- a/electron/git/featureService.operation.test.ts
+++ b/electron/git/featureService.operation.test.ts
@@ -1481,7 +1481,7 @@ describe("featureService log filters", () => {
   it("文本筛选分页应按过滤后结果推进，而不是按原始 git log 游标错位", async () => {
     const fixture = await createRepoFixture("codexflow-log-filtered-pagination");
     try {
-      for (let index = 1; index <= 50; index += 1) {
+      for (let index = 1; index <= 42; index += 1) {
         const subject = index % 2 === 0 ? `keep ${index}` : `skip ${index}`;
         await commitFileChangeAsync(fixture.repo, "conflict.txt", `${subject}\n`, subject);
       }
@@ -1520,8 +1520,8 @@ describe("featureService log filters", () => {
         ? firstRes.data.graphItems.map((item: { subject?: string }) => String(item?.subject || ""))
         : [];
       expect(firstSubjects).toHaveLength(20);
-      expect(firstSubjects[0]).toBe("keep 50");
-      expect(firstSubjects[19]).toBe("keep 12");
+      expect(firstSubjects[0]).toBe("keep 42");
+      expect(firstSubjects[19]).toBe("keep 4");
       expect(firstGraphSubjects).toEqual(firstSubjects);
 
       const secondRes = await dispatchGitFeatureAction({
@@ -1556,7 +1556,7 @@ describe("featureService log filters", () => {
       const secondGraphSubjects = Array.isArray(secondRes.data?.graphItems)
         ? secondRes.data.graphItems.map((item: { subject?: string }) => String(item?.subject || ""))
         : [];
-      expect(secondSubjects).toEqual(["keep 10", "keep 8", "keep 6", "keep 4", "keep 2"]);
+      expect(secondSubjects).toEqual(["keep 2"]);
       expect(secondGraphSubjects).toEqual(secondSubjects);
     } finally {
       await fixture.cleanup();

--- a/electron/git/update/config.test.ts
+++ b/electron/git/update/config.test.ts
@@ -135,7 +135,7 @@ describe("update config options", () => {
       mode: "merge",
       options: [],
     });
-  });
+  }, 10_000);
 
   it("历史 branch-default 配置在读取时应降级并回写为 Merge", async () => {
     const ctx = await createConfigTestContextAsync("legacy-branch-default");
@@ -222,5 +222,5 @@ describe("update config options", () => {
     expect(snapshot.scopePreview.roots.some((root) => root.repoRoot === linkedRepo && root.source === "linked" && !root.included)).toBe(true);
     expect(snapshot.scopePreview.roots.some((root) => root.repoRoot === nestedRepo && root.source === "nested" && root.included)).toBe(true);
     expect(snapshot.scopePreview.skippedRoots.some((root) => root.repoRoot === linkedRepo && root.reasonCode === "requested")).toBe(true);
-  });
+  }, 10_000);
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -447,6 +447,13 @@ type CloseWorkingTabConfirmState = {
   hasPromptInput: boolean;
 };
 
+/**
+ * 中文说明：读取终端前端诊断日志开关，默认关闭。
+ */
+function isTerminalFrontendDebugEnabled(): boolean {
+  try { return !!(globalThis as any).__cf_term_debug__; } catch { return false; }
+}
+
 const STARTUP_GIT_STATUS_BATCH_SIZE = 8;
 
 /**
@@ -6525,6 +6532,13 @@ export default function CodexFlowManagerUI() {
     const pid = ptyByTabRef.current[activeTab.id];
     if (!pid) return;
     const activeEnv = tabExecEnvByTabRef.current[activeTab.id] || getProviderEnv(activeTab.providerId);
+    if (isTerminalFrontendDebugEnabled()) {
+      try {
+        await (window as any).host?.utils?.perfLogCritical?.(
+          `[terminal.scroll-debug app] send.start tab=${activeTab.id} provider=${activeTab.providerId} mode=${sendMode} textLen=${text.length} chips=${(chipsByTab[activeTab.id] || []).length} draftLen=${String(draftByTab[activeTab.id] || "").length}`,
+        );
+      } catch {}
+    }
     // 用户开始新一轮输入后，立即取消恢复期守卫，避免影响真实完成通知。
     delete resumeCompletionGuardByTabRef.current[activeTab.id];
     if (shouldEnableAgentTimerForProvider(activeTab.providerId)) startAgentTurnTimer(activeTab.id);
@@ -6561,6 +6575,13 @@ export default function CodexFlowManagerUI() {
     setChipsByTab((m) => ({ ...m, [activeTab.id]: [] }));
     setDraftByTab((m) => ({ ...m, [activeTab.id]: "" }));
     setInputFullscreenState(activeTab.id, false);
+    if (isTerminalFrontendDebugEnabled()) {
+      try {
+        await (window as any).host?.utils?.perfLogCritical?.(
+          `[terminal.scroll-debug app] send.cleared tab=${activeTab.id} provider=${activeTab.providerId} mode=${sendMode}`,
+        );
+      } catch {}
+    }
 
     // worktree 自动提交：用户第 2 条输入开始，每次输入后若有变更则提交一次
     try {
@@ -10155,12 +10176,12 @@ export default function CodexFlowManagerUI() {
               <TabsContent
                 key={tab.id}
                 value={tab.id}
-                className="mt-1 flex flex-1 min-h-0 flex-col space-y-1"
+                className="mt-1 flex flex-1 min-h-0 min-w-0 flex-col overflow-hidden space-y-1"
                 onContextMenu={(e: React.MouseEvent) => openTabContextMenu(e, tab.id, "tab-content")}
               >
-                <Card className="flex flex-1 min-h-0 flex-col">
-                  <CardContent className="relative flex flex-1 min-h-0 flex-col p-0">
-                    <div className={`relative flex-1 min-h-0 transition-opacity ${isInputFullscreen ? 'pointer-events-none select-none opacity-35' : ''}`}>
+                <Card className="flex flex-1 min-h-0 min-w-0 flex-col overflow-hidden">
+                  <CardContent className="relative flex flex-1 min-h-0 min-w-0 flex-col overflow-hidden p-0">
+                    <div className={`relative flex-1 min-h-0 min-w-0 overflow-hidden transition-opacity ${isInputFullscreen ? 'pointer-events-none select-none opacity-35' : ''}`}>
                       <TerminalView
                         logs={tab.logs}
                         tabId={tab.id}

--- a/web/src/adapters/TerminalAdapter.tsx
+++ b/web/src/adapters/TerminalAdapter.tsx
@@ -22,12 +22,26 @@ export type TerminalAdapterAPI = {
   paste: (data: string) => void;
   onData: (cb: (data: string) => void) => () => void;
   resize: () => { cols: number; rows: number };
+  /** 只测量当前 DOM 可容纳的终端行列，不改变 xterm 当前行列。 */
+  measureResize?: () => { cols: number; rows: number };
+  /** 按 Manager 已提交给 PTY 的行列更新本地 xterm，保证输出解析尺寸一致。 */
+  resizeTo?: (size: { cols: number; rows: number }, source?: string) => { cols: number; rows: number };
+  /** 判断是否仍有 PTY 输出等待写入 xterm。 */
+  hasPendingWriteWork?: () => boolean;
   /** 中文说明：读取当前滚动快照（用于标签切换/隐藏恢复滚动条位置）。 */
   getScrollSnapshot: () => TerminalScrollSnapshot | null;
   /** 中文说明：同步滚动条指示与缓冲区视图；传空则以当前视图执行一次“对齐修复”（不强制滚动内容）。 */
   restoreScrollSnapshot: (snapshot?: TerminalScrollSnapshot | null) => void;
   /** 中文说明：读取光标附近的逻辑文本快照，用于发送后判断输入区是否已真正接住粘贴内容。 */
   readCursorTextSnapshot?: (options?: TerminalCursorTextSnapshotOptions) => TerminalCursorTextSnapshot | null;
+  /** 中文说明：通知适配器真实 PTY resize 已排队，resize 锚点需等到 PTY resize 下发或取消后再释放。 */
+  notifyPtyResizePending?: (size: { cols: number; rows: number }, source: string) => void;
+  /** 中文说明：通知适配器真实 PTY resize 已下发或取消，用于关闭 pending 窗口并重新启动释放检查。 */
+  notifyPtyResizeComplete?: (size: { cols: number; rows: number }, source: string, result: "sent" | "skipped" | "failed") => void;
+  /** 中文说明：通知适配器宿主布局 resize 已开始，提前保存底部跟随意图，避免浏览器 viewport clamp 污染锚点。 */
+  notifyLayoutResizeStart?: (source: string) => void;
+  /** 订阅因 pending reset 输出而延后的 resize 重试信号。 */
+  onDeferredResizeReady?: (cb: () => void) => () => void;
   focus?: () => void;
   blur?: () => void;
   setAppearance: (appearance: Partial<TerminalAppearance>) => void;
@@ -40,6 +54,53 @@ export type TerminalScrollSnapshot = {
   viewportY: number;
   baseY: number;
   isAtBottom: boolean;
+};
+
+type TerminalDomScrollState = {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  maxScrollTop: number;
+};
+
+type TerminalBufferDebugState = {
+  type: string;
+  length: number;
+  cursorY: number;
+};
+
+type ViewportReadAnchor = {
+  viewportY: number;
+  baseY: number;
+  cols: number;
+  rows: number;
+  distanceFromBottom: number;
+  ratio: number;
+  isAtBottom: boolean;
+  createdAt: number;
+  source: string;
+};
+
+type ViewportResizeMode = "follow-bottom" | "read-anchor";
+
+type ViewportResizeTransaction = {
+  id: number;
+  mode: ViewportResizeMode;
+  anchor: ViewportReadAnchor;
+  startedAt: number;
+  lastActivityAt: number;
+  observedBaseY: number;
+  observedBaseYChangedAt: number;
+  terminalResetObservedAt: number | null;
+  outputAfterResetObservedAt: number | null;
+  singleScreenRefreshAt: number | null;
+  ptyResizePending: boolean;
+  ptyResizePendingAt: number | null;
+  ptyResizeCompletedAt: number | null;
+  ptyResizeCompletedResult: "sent" | "skipped" | "failed" | null;
+  outputObserved: boolean;
+  restoreCount: number;
+  releaseTimer: number | null;
 };
 
 export type TerminalCursorTextSnapshotOptions = {
@@ -101,17 +162,54 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
   let removeTermFocusListener: (() => void) | null = null;
   let removeTermBlurListener: (() => void) | null = null;
   let removeScrollListener: (() => void) | null = null;
+  let removeViewportScrollDebugListener: (() => void) | null = null;
   // 防重与抑制：用于避免 Ctrl+V 同时触发 keydown + paste 导致的重复粘贴
   let lastManualPasteAt = 0; // 上次手动触发粘贴时间戳（ms）
   let suppressNativePasteUntil = 0; // 在该时间点之前忽略原生 paste 事件（ms）
   let lastAuxMouseDownAt = 0; // 最近一次检测到鼠标侧键按下（ms）
   let lastCtrlKeydownAt = 0; // 最近一次 Ctrl 键按下（ms）
+  let lastViewportScrollLogAt = 0;
+  let lastViewportScrollTop: number | null = null;
+  let lastViewportUserScrollLogAt = 0;
+  let lastBufferScrollLogAt = 0;
+  let lastBufferViewportY: number | null = null;
+  let lastViewportBottomSnapshot: TerminalScrollSnapshot | null = null;
+  let lastViewportBottomDom: TerminalDomScrollState | null = null;
+  let lastViewportBottomObservedAt = 0;
   // 低版本 Windows（ConPTY < 21376）降级重排开关与状态
   let legacyWinNeedsReflowHack = false;
   let legacyWinBuild = 0;
   let legacyLastCols = 0;
   let appearance: TerminalAppearance = normalizeTerminalAppearance(options?.appearance);
   let lastScrollSnapshot: TerminalScrollSnapshot | null = null;
+  const VIEWPORT_SCROLL_INTENT_WINDOW_MS = 700;
+  const VIEWPORT_RECONCILE_FRAMES = 4;
+  const VIEWPORT_ROW_TOLERANCE = 1;
+  const VIEWPORT_BOTTOM_STRICT_TOLERANCE = 0;
+  const VIEWPORT_ANCHOR_RESTORE_FRAMES = 12;
+  const VIEWPORT_ANCHOR_TTL_MS = 1800;
+  const VIEWPORT_RESIZE_ANCHOR_IDLE_MS = 360;
+  const VIEWPORT_RESIZE_FOLLOW_BOTTOM_MIN_HOLD_MS = 900;
+  const VIEWPORT_RESIZE_ANCHOR_TTL_MS = 5200;
+  const VIEWPORT_RESIZE_RESET_SETTLE_MS = VIEWPORT_RESIZE_ANCHOR_IDLE_MS;
+  const VIEWPORT_RESIZE_RESET_SYNC_SETTLE_MS = 32;
+  const VIEWPORT_RESIZE_RESET_REFRESH_INTERVAL_MS = 120;
+  const VIEWPORT_RESIZE_SKIPPED_COMPLETE_PAINT_SETTLE_MS = 180;
+  const VIEWPORT_RESIZE_PENDING_RESET_MAX_DEFER_MS = 240;
+  const VIEWPORT_RESIZE_BOTTOM_INTENT_GRACE_MS = 1600;
+  const VIEWPORT_RESIZE_LAYOUT_CLAMP_TOLERANCE_ROWS = 2;
+  const VIEWPORT_DOM_BOTTOM_TOLERANCE_PX = 2;
+  let userViewportScrollUntil = 0;
+  let viewportReconcileRaf: number | null = null;
+  let viewportReconcilePendingFrames = 0;
+  let programmaticViewportScrollAllowance = 0;
+  let programmaticViewportScrollAllowanceUntil = 0;
+  let viewportReadAnchor: ViewportReadAnchor | null = null;
+  let viewportResizeTransaction: ViewportResizeTransaction | null = null;
+  let viewportResizeTransactionSeq = 0;
+  let deferredResizeStartedAt: number | null = null;
+  let deferredResizeNotifyRaf: number | null = null;
+  const deferredResizeListeners = new Set<() => void>();
 
   // 输出写入合并：避免在高频输出/多终端并发时把大量小片段直接灌入 xterm，导致写入队列膨胀与 UI 假死。
   const TERM_WRITE_MAX_PENDING_CHARS = 300_000;
@@ -120,6 +218,104 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
   let pendingWriteChars = 0;
   let pendingWriteDroppedChars = 0;
   let pendingWriteScheduled: number | null = null;
+  let pendingWriteFlushSeq = 0;
+  let pendingWriteDoneSeq = 0;
+  let termWriteInFlight = 0;
+  let lastTermWriteDoneAt = 0;
+
+  /**
+   * 格式化当前 xterm 写入队列状态，用于排查 resize 与输出分帧是否交错。
+   */
+  function formatPendingWriteState(): string {
+    const writeDoneAgo = lastTermWriteDoneAt > 0 ? Math.round(nowMs() - lastTermWriteDoneAt) : "n/a";
+    return `writePending=${Math.max(0, Math.round(pendingWriteChars))} writeChunks=${pendingWriteChunks.length} writeScheduled=${pendingWriteScheduled !== null ? "1" : "0"} writeInFlight=${termWriteInFlight} writeFlushSeq=${pendingWriteFlushSeq} writeDoneSeq=${pendingWriteDoneSeq} writeDoneAgo=${writeDoneAgo}`;
+  }
+
+  /**
+   * 格式化 resize 重绘事务状态，用于串联 resize、PTY 输出与释放时机。
+   * @param tx resize 重绘事务
+   */
+  function formatViewportResizeTransaction(tx: ViewportResizeTransaction | null | undefined): string {
+    if (!tx) return `tx=n/a ${formatPendingWriteState()}`;
+    const now = nowMs();
+    const resetAgo = tx.terminalResetObservedAt === null ? "n/a" : Math.round(now - tx.terminalResetObservedAt);
+    const resetOutAgo = tx.outputAfterResetObservedAt === null ? "n/a" : Math.round(now - tx.outputAfterResetObservedAt);
+    const ptyPendingAgo = tx.ptyResizePendingAt === null ? "n/a" : Math.round(now - tx.ptyResizePendingAt);
+    const ptyDoneAgo = tx.ptyResizeCompletedAt === null ? "n/a" : Math.round(now - tx.ptyResizeCompletedAt);
+    return `tx=${tx.id} mode=${tx.mode} age=${Math.round(now - tx.startedAt)} idle=${Math.round(now - tx.lastActivityAt)} resetAgo=${resetAgo} resetOutAgo=${resetOutAgo} ptyPending=${tx.ptyResizePending ? "1" : "0"} ptyPendingAgo=${ptyPendingAgo} ptyDoneAgo=${ptyDoneAgo} ptyResult=${tx.ptyResizeCompletedResult ?? "n/a"} out=${tx.outputObserved ? "1" : "0"} restores=${tx.restoreCount} obsBase=${Math.round(tx.observedBaseY)} obsIdle=${Math.round(now - tx.observedBaseYChangedAt)} ${formatPendingWriteState()}`;
+  }
+
+  /**
+   * 读取 xterm active buffer 的诊断字段。
+   */
+  function readBufferDebugState(): TerminalBufferDebugState | null {
+    if (!term) return null;
+    try {
+      const buf: any = (term as any)?.buffer?.active;
+      if (!buf) return null;
+      return {
+        type: String(buf.type || ""),
+        length: Number(buf.length || 0),
+        cursorY: Number(buf.cursorY || 0),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * 判断 CSI 参数列表是否包含指定数字参数。
+   * @param params CSI 参数文本
+   * @param target 目标数字参数
+   */
+  function csiParamsContain(params: string, target: number): boolean {
+    const normalized = String(params || "").replace(/[?<=>]/g, "");
+    return normalized.split(/[;:]/).some((part) => Number(part || 0) === target);
+  }
+
+  /**
+   * 概括终端输出中的关键控制序列，不记录原始内容，避免日志泄露命令输出。
+   * @param payload 即将写入 xterm 的 PTY 输出
+   */
+  function summarizeTerminalControlSequences(payload: string): string {
+    const text = String(payload || "");
+    let clearScrollback = 0;
+    let clearScreen = 0;
+    let cursorHome = 0;
+    let altEnter = 0;
+    let altExit = 0;
+    let fullReset = 0;
+    text.replace(/(?:\x1b\[|\u009b)([0-?]*)([ -/]*)([@-~])/g, (_match, params: string, _intermediate: string, final: string) => {
+      if (final === "J") {
+        if (csiParamsContain(params, 3)) clearScrollback += 1;
+        if (csiParamsContain(params, 2)) clearScreen += 1;
+      } else if (final === "H" || final === "f") {
+        cursorHome += 1;
+      } else if (final === "h" && /\?104[79]/.test(params)) {
+        altEnter += 1;
+      } else if (final === "l" && /\?104[79]/.test(params)) {
+        altExit += 1;
+      }
+      return "";
+    });
+    fullReset = (text.match(/\x1bc/g) || []).length;
+    return `len=${text.length} clearScrollback=${clearScrollback} clearScreen=${clearScreen} cursorHome=${cursorHome} altEnter=${altEnter} altExit=${altExit} fullReset=${fullReset}`;
+  }
+
+  /**
+   * 判断输出是否包含会语义性清空历史缓冲区的控制序列。
+   * @param payload 即将写入 xterm 的 PTY 输出
+   */
+  function hasTerminalHistoryResetSequence(payload: string): boolean {
+    const text = String(payload || "");
+    if (text.includes("\x1bc")) return true;
+    let found = false;
+    text.replace(/(?:\x1b\[|\u009b)([0-?]*)([ -/]*)([@-~])/g, (_match, params: string, _intermediate: string, final: string) => {
+      if (final === "J" && csiParamsContain(params, 3)) found = true;
+      return "";
+    });
+    return found;
+  }
 
   /**
    * 中文说明：将待写入数据分帧写入 xterm，避免一次性写入过大导致长帧/白屏。
@@ -128,6 +324,10 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
     pendingWriteScheduled = null;
     if (!term) return;
     if (pendingWriteChars <= 0 || pendingWriteChunks.length === 0) return;
+    const pendingBeforeFlush = pendingWriteChars;
+    const chunksBeforeFlush = pendingWriteChunks.length;
+    touchViewportResizeTransaction("write.before", true);
+    captureViewportReadAnchor("write.before");
     const limit = TERM_WRITE_MAX_CHARS_PER_FLUSH;
     let remaining = limit;
     const out: string[] = [];
@@ -152,7 +352,40 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
     if (dropped > 0) {
       try { dlog(`[adapter] write.drop chars=${dropped}`); } catch {}
     }
-    try { term.write(out.join("")); } catch {}
+    let payload = out.join("");
+    const tx = viewportResizeTransaction;
+    const controlSummary = summarizeTerminalControlSequences(payload);
+    const flushSeq = ++pendingWriteFlushSeq;
+    if (tx) {
+      logScrollDiagnostic(`write.flush.start seq=${flushSeq} payload=${payload.length} pendingBefore=${pendingBeforeFlush} chunksBefore=${chunksBeforeFlush} remaining=${pendingWriteChars} ${formatViewportResizeTransaction(tx)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+    }
+    const hasHistoryReset = tx ? hasTerminalHistoryResetSequence(payload) : false;
+    if (tx && hasHistoryReset) {
+      tx.terminalResetObservedAt = nowMs();
+      tx.outputAfterResetObservedAt = null;
+    } else if (tx && tx.terminalResetObservedAt !== null) {
+      tx.outputAfterResetObservedAt = nowMs();
+    }
+    if (tx && /clearScrollback=[1-9]|clearScreen=[1-9]|cursorHome=[1-9]|altEnter=[1-9]|altExit=[1-9]|fullReset=[1-9]/.test(controlSummary)) {
+      logScrollDiagnostic(`write.control source=resize-transaction seq=${flushSeq} ${controlSummary} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+    }
+    try {
+      termWriteInFlight += 1;
+      term.write(payload, () => {
+        termWriteInFlight = Math.max(0, termWriteInFlight - 1);
+        pendingWriteDoneSeq += 1;
+        lastTermWriteDoneAt = nowMs();
+        if (tx) {
+          logScrollDiagnostic(`write.done seq=${flushSeq} doneSeq=${pendingWriteDoneSeq} txCurrent=${viewportResizeTransaction === tx ? "1" : "0"} ${formatViewportResizeTransaction(tx)} current=${formatViewportResizeTransaction(viewportResizeTransaction)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+        }
+        try { scheduleViewportReconcile("write.done"); } catch {}
+        if (deferredResizeStartedAt !== null) scheduleDeferredResizeReady("write.done");
+      });
+    } catch {
+      termWriteInFlight = Math.max(0, termWriteInFlight - 1);
+      try { term.write(payload); } catch {}
+    }
+    scheduleViewportReconcile("write.after");
     // 若仍有残留，继续分帧
     if (pendingWriteChars > 0 && pendingWriteChunks.length > 0) {
       try { pendingWriteScheduled = window.requestAnimationFrame(flushPendingWrites); } catch {}
@@ -167,8 +400,14 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
     if (!term) return;
     const s = String(data || "");
     if (!s) return;
+    const tx = viewportResizeTransaction;
+    touchViewportResizeTransaction("write.enqueue", true);
+    captureViewportReadAnchor("write.enqueue");
     pendingWriteChunks.push(s);
     pendingWriteChars += s.length;
+    if (tx) {
+      logScrollDiagnostic(`write.enqueue len=${s.length} ${formatViewportResizeTransaction(tx)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+    }
     // 过载保护：仅保留尾部，避免内存无限增长
     if (pendingWriteChars > TERM_WRITE_MAX_PENDING_CHARS) {
       let overflow = pendingWriteChars - TERM_WRITE_MAX_PENDING_CHARS;
@@ -208,6 +447,1359 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
     } catch {
       return null;
     }
+  };
+
+  /**
+   * 中文说明：写入终端滚动诊断日志；默认关闭，仅在终端前端调试开关开启时进入 perf.log。
+   */
+  const logScrollDiagnostic = (message: string): void => {
+    if (!dbgEnabled()) return;
+    try {
+      void (window as any).host?.utils?.perfLogCritical?.(`[terminal.scroll-debug adapter] ${message}`);
+    } catch {}
+  };
+
+  /**
+   * 中文说明：读取 xterm DOM viewport 的滚动度量。
+   */
+  const readDomScrollState = (): TerminalDomScrollState | null => {
+    if (!container) return null;
+    try {
+      const viewport = container.querySelector(".xterm-viewport") as HTMLDivElement | null;
+      if (!viewport) return null;
+      const scrollTop = Number(viewport.scrollTop || 0);
+      const scrollHeight = Number(viewport.scrollHeight || 0);
+      const clientHeight = Number(viewport.clientHeight || 0);
+      return {
+        scrollTop,
+        scrollHeight,
+        clientHeight,
+        maxScrollTop: Math.max(0, scrollHeight - clientHeight),
+      };
+    } catch {
+      return null;
+    }
+  };
+
+  /**
+   * 中文说明：把 buffer 滚动快照压缩成单行日志字段。
+   */
+  const formatScrollSnapshot = (snapshot: TerminalScrollSnapshot | null | undefined): string => {
+    if (!snapshot) return "buf=n/a";
+    const debug = readBufferDebugState();
+    const suffix = debug ? ` type=${debug.type || "n/a"} len=${Math.round(debug.length)} cy=${Math.round(debug.cursorY)}` : "";
+    return `buf=${Math.round(snapshot.viewportY)}/${Math.round(snapshot.baseY)} bottom=${snapshot.isAtBottom ? "1" : "0"}${suffix}`;
+  };
+
+  /**
+   * 把阅读锚点压缩成单行日志字段。
+   * @param anchor 阅读锚点
+   */
+  function formatViewportReadAnchor(anchor: ViewportReadAnchor | null | undefined): string {
+    if (!anchor) return "anchor=n/a";
+    return `anchor=${Math.round(anchor.viewportY)}/${Math.round(anchor.baseY)} size=${anchor.cols}x${anchor.rows} dist=${Math.round(anchor.distanceFromBottom)} ratio=${anchor.ratio.toFixed(3)} bottom=${anchor.isAtBottom ? "1" : "0"} src=${anchor.source}`;
+  }
+
+  /**
+   * 用当前稳定滚动快照创建阅读锚点。
+   * @param snapshot 当前 xterm buffer 滚动快照
+   * @param source 捕获来源
+   */
+  function createViewportReadAnchor(
+    snapshot: TerminalScrollSnapshot,
+    source: string,
+    grid?: { cols: number; rows: number },
+  ): ViewportReadAnchor {
+    return {
+      viewportY: snapshot.viewportY,
+      baseY: snapshot.baseY,
+      cols: grid?.cols ?? term?.cols ?? 0,
+      rows: grid?.rows ?? term?.rows ?? 0,
+      distanceFromBottom: Math.max(0, snapshot.baseY - snapshot.viewportY),
+      ratio: snapshot.baseY > 0 ? Math.max(0, Math.min(1, snapshot.viewportY / snapshot.baseY)) : 0,
+      isAtBottom: snapshot.isAtBottom,
+      createdAt: nowMs(),
+      source,
+    };
+  }
+
+  /**
+   * 创建并登记 resize 重绘事务。
+   * @param anchor resize 前捕获的阅读锚点
+   */
+  function startViewportResizeTransaction(anchor: ViewportReadAnchor): ViewportResizeTransaction {
+    const createdAt = nowMs();
+    viewportReadAnchor = anchor;
+    viewportResizeTransaction = {
+      id: ++viewportResizeTransactionSeq,
+      mode: anchor.isAtBottom ? "follow-bottom" : "read-anchor",
+      anchor,
+      startedAt: createdAt,
+      lastActivityAt: createdAt,
+      observedBaseY: anchor.baseY,
+      observedBaseYChangedAt: createdAt,
+      terminalResetObservedAt: null,
+      outputAfterResetObservedAt: null,
+      singleScreenRefreshAt: null,
+      ptyResizePending: false,
+      ptyResizePendingAt: null,
+      ptyResizeCompletedAt: null,
+      ptyResizeCompletedResult: null,
+      outputObserved: false,
+      restoreCount: 0,
+      releaseTimer: null,
+    };
+    return viewportResizeTransaction;
+  }
+
+  /**
+   * 判断滚动快照是否已经严格处于 xterm 底部。
+   * @param snapshot 当前 xterm buffer 滚动快照
+   */
+  function isViewportAtStrictBottom(snapshot: TerminalScrollSnapshot | null | undefined): boolean {
+    if (!snapshot) return false;
+    if (snapshot.baseY <= 0) return false;
+    return Math.max(0, snapshot.baseY - snapshot.viewportY) <= VIEWPORT_BOTTOM_STRICT_TOLERANCE;
+  }
+
+  /**
+   * 判断 DOM viewport 滚动条是否已经位于底部。
+   * @param dom 当前 DOM 滚动度量
+   */
+  function isDomViewportAtBottom(dom: TerminalDomScrollState | null | undefined): boolean {
+    if (!dom) return false;
+    return Math.max(0, dom.maxScrollTop - dom.scrollTop) <= VIEWPORT_DOM_BOTTOM_TOLERANCE_PX;
+  }
+
+  /**
+   * 记录最近一次可信的底部状态，用于窗口 resize 时抵抗浏览器 viewport clamp 的短暂污染。
+   * @param snapshot 当前 xterm buffer 快照
+   * @param dom 当前 DOM viewport 滚动度量
+   */
+  function rememberViewportBottomEvidence(
+    snapshot: TerminalScrollSnapshot | null | undefined,
+    dom?: TerminalDomScrollState | null,
+  ): void {
+    if (!snapshot || snapshot.baseY <= 0 || !snapshot.isAtBottom) return;
+    if (nowMs() <= userViewportScrollUntil) return;
+    if (dom && !isDomViewportAtBottom(dom)) return;
+    lastViewportBottomSnapshot = {
+      viewportY: snapshot.baseY,
+      baseY: snapshot.baseY,
+      isAtBottom: true,
+    };
+    lastViewportBottomDom = dom
+      ? {
+        scrollTop: dom.scrollTop,
+        scrollHeight: dom.scrollHeight,
+        clientHeight: dom.clientHeight,
+        maxScrollTop: dom.maxScrollTop,
+      }
+      : null;
+    lastViewportBottomObservedAt = nowMs();
+  }
+
+  /**
+   * 判断当前非底部状态是否只是窗口高度变化后浏览器对 scrollTop 的 clamp。
+   * @param snapshot 当前 xterm buffer 快照
+   * @param dom 当前 DOM viewport 滚动度量
+   */
+  function isRecentViewportBottomClamp(
+    snapshot: TerminalScrollSnapshot | null | undefined,
+    dom: TerminalDomScrollState | null | undefined,
+  ): boolean {
+    if (!snapshot || snapshot.baseY <= 0 || !dom || !lastViewportBottomSnapshot) return false;
+    if (!isDomViewportAtBottom(dom)) return false;
+    if (nowMs() - lastViewportBottomObservedAt > VIEWPORT_RESIZE_BOTTOM_INTENT_GRACE_MS) return false;
+    if (nowMs() <= userViewportScrollUntil) return false;
+
+    const distanceFromBottom = Math.max(0, snapshot.baseY - snapshot.viewportY);
+    const lineHeight = readTerminalLineHeightPx();
+    const previousClientHeight = Math.max(0, Number(lastViewportBottomDom?.clientHeight || 0));
+    const heightDelta = previousClientHeight > 0
+      ? Math.max(0, dom.clientHeight - previousClientHeight)
+      : 0;
+    const expectedClampRows = lineHeight > 0
+      ? Math.ceil(heightDelta / lineHeight) + VIEWPORT_RESIZE_LAYOUT_CLAMP_TOLERANCE_ROWS
+      : VIEWPORT_RESIZE_LAYOUT_CLAMP_TOLERANCE_ROWS;
+    const baseDelta = Math.abs(snapshot.baseY - lastViewportBottomSnapshot.baseY);
+    return baseDelta <= VIEWPORT_ROW_TOLERANCE
+      && distanceFromBottom > VIEWPORT_BOTTOM_STRICT_TOLERANCE
+      && distanceFromBottom <= Math.max(VIEWPORT_RESIZE_LAYOUT_CLAMP_TOLERANCE_ROWS, expectedClampRows);
+  }
+
+  /**
+   * 为窗口/布局 resize 解析底部跟随锚点。仅在严格底部或最近底部被 layout clamp 污染时返回。
+   * @param snapshot 当前 xterm buffer 快照
+   * @param dom 当前 DOM viewport 滚动度量
+   */
+  function resolveLayoutResizeBottomAnchorSnapshot(
+    snapshot: TerminalScrollSnapshot | null | undefined,
+    dom: TerminalDomScrollState | null | undefined,
+  ): { snapshot: TerminalScrollSnapshot; reason: string } | null {
+    if (snapshot && snapshot.baseY > 0 && snapshot.isAtBottom) {
+      return {
+        snapshot: {
+          viewportY: snapshot.baseY,
+          baseY: snapshot.baseY,
+          isAtBottom: true,
+        },
+        reason: "strict-bottom",
+      };
+    }
+    if (isRecentViewportBottomClamp(snapshot, dom)) {
+      const baseY = Math.max(0, snapshot?.baseY ?? lastViewportBottomSnapshot?.baseY ?? 0);
+      return {
+        snapshot: {
+          viewportY: baseY,
+          baseY,
+          isAtBottom: true,
+        },
+        reason: "layout-clamp",
+      };
+    }
+    return null;
+  }
+
+  /**
+   * 中文说明：把 DOM 滚动度量压缩成单行日志字段。
+   */
+  const formatDomScrollState = (state: TerminalDomScrollState | null | undefined): string => {
+    if (!state) return "dom=n/a";
+    return `domTop=${Math.round(state.scrollTop)} domMax=${Math.round(state.maxScrollTop)} domClient=${Math.round(state.clientHeight)} domHeight=${Math.round(state.scrollHeight)}`;
+  };
+
+  /**
+   * 判断当前是否应接受 DOM scroll 事件回写 xterm buffer 视口。
+   */
+  function canAcceptViewportDomScroll(): boolean {
+    if (nowMs() <= userViewportScrollUntil) return true;
+    if (programmaticViewportScrollAllowance > 0 && nowMs() <= programmaticViewportScrollAllowanceUntil) {
+      programmaticViewportScrollAllowance -= 1;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * 标记一次由用户输入触发的 viewport 滚动窗口。
+   * @param source 触发来源
+   */
+  function markViewportUserScroll(source: string): void {
+    const now = nowMs();
+    userViewportScrollUntil = now + VIEWPORT_SCROLL_INTENT_WINDOW_MS;
+    viewportReadAnchor = null;
+    lastViewportBottomSnapshot = null;
+    lastViewportBottomDom = null;
+    lastViewportBottomObservedAt = 0;
+    if (viewportResizeTransaction) releaseViewportResizeTransaction(`user.${source}`);
+    if (now - lastViewportUserScrollLogAt > 300) {
+      lastViewportUserScrollLogAt = now;
+      logScrollDiagnostic(`viewport.user-scroll source=${source} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+    }
+  }
+
+  /**
+   * 给下一次程序写入 scrollTop 预留通过窗口，避免被非用户 scroll 拦截器吞掉。
+   * @param count 允许通过的 scroll 事件数量
+   */
+  function allowProgrammaticViewportScroll(count = 1): void {
+    programmaticViewportScrollAllowance = Math.max(programmaticViewportScrollAllowance, count);
+    programmaticViewportScrollAllowanceUntil = nowMs() + 250;
+  }
+
+  /**
+   * 生成 resize 重绘事务的 idle 释放来源，避免连续等待时不断叠加 idle 前缀。
+   * @param source 当前触发来源
+   */
+  function toViewportResizeIdleSource(source: string): string {
+    return source.startsWith("idle.") ? source : `idle.${source}`;
+  }
+
+  /**
+   * 安排下一次 resize 重绘事务释放检查。
+   * @param source 触发来源
+   * @param resetExisting 是否重置已经存在的释放计时器
+   */
+  function scheduleViewportResizeReleaseCheck(source: string, resetExisting: boolean): void {
+    const tx = viewportResizeTransaction;
+    if (!tx) return;
+    if (tx.releaseTimer !== null) {
+      if (!resetExisting) return;
+      try { window.clearTimeout(tx.releaseTimer); } catch {}
+      tx.releaseTimer = null;
+    }
+    try {
+      let timer: number | null = null;
+      timer = window.setTimeout(() => {
+        if (viewportResizeTransaction === tx && tx.releaseTimer === timer) {
+          tx.releaseTimer = null;
+        }
+        try { releaseViewportResizeTransaction(toViewportResizeIdleSource(source)); } catch {}
+      }, VIEWPORT_RESIZE_ANCHOR_IDLE_MS);
+      tx.releaseTimer = timer;
+    } catch {}
+  }
+
+  /**
+   * 继续等待 resize 重绘事务恢复，但不刷新真实活动时间。
+   * @param source 等待来源
+   */
+  function waitViewportResizeTransaction(source: string): void {
+    scheduleViewportResizeReleaseCheck(source, false);
+  }
+
+  /**
+   * 标记 resize 重绘事务发生了新活动，并延后释放窗口。
+   * @param source 活动来源
+   * @param outputObserved 是否观察到 PTY 输出
+   */
+  function touchViewportResizeTransaction(source: string, outputObserved = false): void {
+    const tx = viewportResizeTransaction;
+    if (!tx) return;
+    const now = nowMs();
+    tx.lastActivityAt = now;
+    tx.outputObserved = tx.outputObserved || outputObserved;
+    scheduleViewportResizeReleaseCheck(source, true);
+  }
+
+  /**
+   * 记录 resize 重绘事务中观察到的 buffer 高度变化。
+   * @param snapshot 当前 xterm buffer 滚动快照
+   */
+  function observeViewportResizeBaseY(snapshot: TerminalScrollSnapshot | null | undefined): void {
+    const tx = viewportResizeTransaction;
+    if (!tx || !snapshot) return;
+    const baseY = Math.max(0, Number(snapshot.baseY || 0));
+    if (Math.abs(baseY - tx.observedBaseY) <= VIEWPORT_ROW_TOLERANCE) return;
+    tx.observedBaseY = baseY;
+    tx.observedBaseYChangedAt = nowMs();
+  }
+
+  /**
+   * 判断 resize 重绘事务是否已经进入安静窗口。
+   * @param tx resize 重绘事务
+   */
+  function isViewportResizeTransactionIdle(tx: ViewportResizeTransaction): boolean {
+    if (tx.ptyResizePending) return false;
+    return nowMs() - tx.lastActivityAt >= VIEWPORT_RESIZE_ANCHOR_IDLE_MS;
+  }
+
+  /**
+   * 判断过期的 resize 重绘事务是否允许作为兜底释放。
+   * @param tx resize 重绘事务
+   */
+  function canExpireViewportResizeTransaction(tx: ViewportResizeTransaction): boolean {
+    if (nowMs() - tx.startedAt <= VIEWPORT_RESIZE_ANCHOR_TTL_MS) return false;
+    if (tx.ptyResizePending) {
+      const pendingAt = tx.ptyResizePendingAt ?? tx.startedAt;
+      return nowMs() - pendingAt > VIEWPORT_RESIZE_ANCHOR_TTL_MS;
+    }
+    return isViewportResizeTransactionIdle(tx);
+  }
+
+  /**
+   * 判断清历史后的 xterm buffer 是否已经收敛为当前视口内的单屏内容。
+   * @param snapshot 当前 xterm buffer 滚动快照
+   */
+  function isResetSingleScreenSnapshot(
+    snapshot: TerminalScrollSnapshot | null | undefined,
+  ): boolean {
+    if (!snapshot) return false;
+    if (snapshot.baseY > 0) return false;
+    if (snapshot.viewportY > VIEWPORT_ROW_TOLERANCE) return false;
+    const debug = readBufferDebugState();
+    const rows = Math.max(0, Number(term?.rows || 0));
+    if (!debug || rows <= 0) return false;
+    return debug.length <= rows + VIEWPORT_ROW_TOLERANCE;
+  }
+
+  /**
+   * 判断 follow-bottom 事务是否仍处在清历史后的空 buffer 窗口。
+   * @param tx resize 重绘事务
+   * @param snapshot 当前 xterm buffer 滚动快照
+   */
+  function isFollowBottomResetStillEmpty(
+    tx: ViewportResizeTransaction,
+    snapshot: TerminalScrollSnapshot | null | undefined,
+  ): boolean {
+    return tx.mode === "follow-bottom"
+      && tx.anchor.isAtBottom
+      && isResetSingleScreenSnapshot(snapshot);
+  }
+
+  /**
+   * 判断 follow-bottom 单屏 reset 是否已有可信稳定窗口。
+   * @param tx resize 重绘事务
+   */
+  function hasFollowBottomResetSingleScreenQuietWindow(tx: ViewportResizeTransaction): boolean {
+    if (isViewportResizeTransactionIdle(tx)) return true;
+    if (tx.ptyResizePending) return false;
+    if (tx.ptyResizeCompletedResult !== "skipped") return false;
+    if (tx.ptyResizeCompletedAt === null) return false;
+    if (tx.ptyResizeCompletedAt < tx.lastActivityAt - 1) return false;
+    return nowMs() - tx.ptyResizeCompletedAt >= VIEWPORT_RESIZE_SKIPPED_COMPLETE_PAINT_SETTLE_MS;
+  }
+
+  /**
+   * 判断 follow-bottom 模式下清历史后的单屏重绘是否已经稳定。
+   * @param tx resize 重绘事务
+   * @param snapshot 当前 xterm buffer 滚动快照
+   */
+  function isFollowBottomResetEmptyScreenSettled(
+    tx: ViewportResizeTransaction,
+    snapshot: TerminalScrollSnapshot | null | undefined,
+  ): boolean {
+    if (!isFollowBottomResetStillEmpty(tx, snapshot)) return false;
+    if (tx.terminalResetObservedAt === null) return false;
+    if (tx.outputAfterResetObservedAt === null) return false;
+    if (!hasFollowBottomResetSingleScreenQuietWindow(tx)) return false;
+    if (hasPendingTerminalWriteWork()) return false;
+    if (nowMs() - tx.outputAfterResetObservedAt < VIEWPORT_RESIZE_RESET_SETTLE_MS) return false;
+    return true;
+  }
+
+  /**
+   * 判断 reset 后单屏内容是否已经可先同步 viewport；该判断只用于刷新显示，不释放事务。
+   * @param tx resize 重绘事务
+   * @param snapshot 当前 xterm buffer 滚动快照
+   */
+  function canSyncFollowBottomResetSingleScreen(
+    tx: ViewportResizeTransaction,
+    snapshot: TerminalScrollSnapshot | null | undefined,
+  ): boolean {
+    if (!isFollowBottomResetStillEmpty(tx, snapshot)) return false;
+    if (tx.terminalResetObservedAt === null) return false;
+    if (tx.outputAfterResetObservedAt === null) return false;
+    if (hasPendingTerminalWriteWork()) return false;
+    return nowMs() - tx.outputAfterResetObservedAt >= VIEWPORT_RESIZE_RESET_SYNC_SETTLE_MS;
+  }
+
+  /**
+   * 判断 resize 期间的清历史输出是否已经稳定落地。
+   * @param tx resize 重绘事务
+   * @param snapshot 当前 xterm buffer 滚动快照
+   */
+  function isViewportResizeTerminalResetSettled(
+    tx: ViewportResizeTransaction,
+    snapshot: TerminalScrollSnapshot | null | undefined,
+  ): boolean {
+    if (tx.terminalResetObservedAt === null) return false;
+    if (!snapshot) return false;
+    const singleScreenSettled = isFollowBottomResetEmptyScreenSettled(tx, snapshot);
+    if (!isViewportResizeTransactionIdle(tx) && !singleScreenSettled) return false;
+    if (nowMs() - tx.terminalResetObservedAt < VIEWPORT_RESIZE_RESET_SETTLE_MS) return false;
+    if (isFollowBottomResetStillEmpty(tx, snapshot) && !singleScreenSettled) return false;
+    return true;
+  }
+
+  /**
+   * 判断 read-anchor 在清历史重绘后旧锚点是否已经被应用输出废弃。
+   * @param tx resize 重绘事务
+   * @param snapshot 当前 xterm buffer 滚动快照
+   */
+  function isReadAnchorResetAnchorInvalidated(
+    tx: ViewportResizeTransaction,
+    snapshot: TerminalScrollSnapshot | null | undefined,
+  ): boolean {
+    if (tx.mode !== "read-anchor" || tx.anchor.isAtBottom) return false;
+    if (tx.terminalResetObservedAt === null || tx.outputAfterResetObservedAt === null) return false;
+    if (!snapshot) return false;
+    if (!isViewportResizeTransactionIdle(tx)) return false;
+    if (hasPendingTerminalWriteWork()) return false;
+    const now = nowMs();
+    if (now - tx.terminalResetObservedAt < VIEWPORT_RESIZE_RESET_SETTLE_MS) return false;
+    if (now - tx.outputAfterResetObservedAt < VIEWPORT_RESIZE_RESET_SETTLE_MS) return false;
+
+    const baseY = Math.max(0, Math.round(snapshot.baseY || 0));
+    const anchorViewportY = Math.max(0, Math.round(tx.anchor.viewportY || 0));
+    return baseY < anchorViewportY - VIEWPORT_ROW_TOLERANCE;
+  }
+
+  /**
+   * 判断 resize 重绘事务是否已经可以安全释放。
+   */
+  function canReleaseViewportResizeTransaction(): boolean {
+    const tx = viewportResizeTransaction;
+    if (!tx) return false;
+    const txExpired = canExpireViewportResizeTransaction(tx);
+    if (tx.ptyResizePending && !txExpired) {
+      logScrollDiagnostic(`resize-anchor.release-check result=hold reason=pty-resize-pending ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+      return false;
+    }
+    if (tx.mode === "follow-bottom" && nowMs() - tx.startedAt < VIEWPORT_RESIZE_FOLLOW_BOTTOM_MIN_HOLD_MS) {
+      logScrollDiagnostic(`resize-anchor.release-check result=hold reason=follow-bottom-min-hold ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+      return false;
+    }
+    const snapshot = readScrollSnapshot();
+    observeViewportResizeBaseY(snapshot);
+    if (!snapshot) {
+      logScrollDiagnostic(`resize-anchor.release-check result=hold reason=missing-buffer ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+      return false;
+    }
+    if (!isViewportResizeTransactionIdle(tx) && !isFollowBottomResetEmptyScreenSettled(tx, snapshot)) return false;
+    if (isReadAnchorResetAnchorInvalidated(tx, snapshot)) {
+      logScrollDiagnostic(`resize-anchor.release-check result=release reason=terminal-reset-anchor-invalidated ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+      return true;
+    }
+    const anchorWaitReason = getViewportReadAnchorWaitReason(tx.anchor, snapshot);
+    if (anchorWaitReason) {
+      logScrollDiagnostic(`resize-anchor.release-check result=hold reason=${anchorWaitReason} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+      return false;
+    }
+    if (isViewportResizeTerminalResetSettled(tx, snapshot)) {
+      logScrollDiagnostic(`resize-anchor.release-check result=release reason=terminal-reset ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+      return true;
+    }
+    const rebuildReason = getViewportResizeRebuildReason(snapshot);
+    if (rebuildReason) {
+      logScrollDiagnostic(`resize-anchor.release-check result=hold reason=${rebuildReason} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+      return false;
+    }
+    const target = resolveViewportAnchorTarget(tx.anchor, snapshot);
+    const restored = tx.anchor.isAtBottom
+      ? isViewportAtStrictBottom(snapshot)
+      : Math.abs(snapshot.viewportY - target) <= VIEWPORT_ROW_TOLERANCE;
+    logScrollDiagnostic(`resize-anchor.release-check result=${restored ? "release" : "hold"} target=${target} strictBottom=${isViewportAtStrictBottom(snapshot) ? "1" : "0"} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+    return restored;
+  }
+
+  /**
+   * 判断当前 buffer 是否仍处于 resize 触发后的清屏/重建中间态。
+   * @param snapshot 当前 xterm buffer 滚动快照
+   */
+  function getViewportResizeRebuildReason(snapshot: TerminalScrollSnapshot | null | undefined): string | null {
+    const tx = viewportResizeTransaction;
+    if (!tx || tx.anchor.baseY <= 0) return null;
+    if (!snapshot) return "missing-buffer";
+    if (isViewportResizeTerminalResetSettled(tx, snapshot)) return null;
+    if (isFollowBottomResetEmptyScreenSettled(tx, snapshot)) return null;
+    if (snapshot.baseY <= 0) return "empty-buffer";
+    return null;
+  }
+
+  /**
+   * 判断是否仍有 PTY 输出正在分帧写入 xterm。
+   */
+  function hasPendingTerminalWriteWork(): boolean {
+    return pendingWriteChars > 0
+      || pendingWriteScheduled !== null
+      || termWriteInFlight > 0;
+  }
+
+  /**
+   * 判断当前写入队列中是否存在清屏/清历史重绘输出。
+   */
+  function hasPendingTerminalResetWriteWork(): boolean {
+    if (termWriteInFlight > 0 && viewportResizeTransaction && viewportResizeTransaction.terminalResetObservedAt !== null) return true;
+    return pendingWriteChunks.some((chunk) => hasTerminalHistoryResetSequence(chunk));
+  }
+
+  /**
+   * 读取 fit-addon 将要计算出的目标尺寸，但不改变 xterm 当前尺寸。
+   */
+  function proposeTerminalFitSize(): { cols: number; rows: number } | null {
+    try {
+      const proposed = (fitAddon as any)?.proposeDimensions?.();
+      const cols = Math.max(0, Math.floor(Number(proposed?.cols || 0)));
+      const rows = Math.max(0, Math.floor(Number(proposed?.rows || 0)));
+      if (!cols || !rows) return null;
+      return { cols, rows };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * 只测量当前宿主 DOM 对应的候选行列，不提交到 xterm。
+   */
+  function measureTerminalResize(): { cols: number; rows: number } {
+    if (!term || !fitAddon || !container) return { cols: 0, rows: 0 };
+    const proposed = proposeTerminalFitSize();
+    const size = proposed || { cols: term.cols, rows: term.rows };
+    try {
+      const rect = container.getBoundingClientRect();
+      const parentRect = container.parentElement?.getBoundingClientRect() || null;
+      const hostWidth = parentRect ? parentRect.width : rect.width;
+      const hostHeight = parentRect ? parentRect.height : rect.height;
+      logScrollDiagnostic(`adapter.resize.measure size=${size.cols}x${size.rows} host=${Math.round(hostWidth)}x${Math.round(hostHeight)} current=${term.cols}x${term.rows} ${formatPendingWriteState()} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+    } catch {}
+    return size;
+  }
+
+  /**
+   * 按已提交给 PTY 的行列更新本地 xterm，避免本地 fit 抢跑真实 resize。
+   * @param size 已提交或确认无需下发的 PTY 行列
+   * @param source 提交来源
+   */
+  function commitTerminalResize(
+    size: { cols: number; rows: number },
+    source: string,
+  ): { cols: number; rows: number } {
+    if (!term || !container) return { cols: 0, rows: 0 };
+    const cols = Math.max(2, Math.floor(Number(size?.cols || 0)));
+    const rows = Math.max(2, Math.floor(Number(size?.rows || 0)));
+    if (!cols || !rows) return { cols: term.cols, rows: term.rows };
+
+    const beforeSize = { cols: term.cols, rows: term.rows };
+    const beforeSnapshot = readScrollSnapshot();
+    const beforeDom = readDomScrollState();
+    const hadResizeTransaction = !!viewportResizeTransaction;
+    const changed = beforeSize.cols !== cols || beforeSize.rows !== rows;
+
+    if (changed && !viewportResizeTransaction && beforeSnapshot && beforeSnapshot.baseY > 0) {
+      const anchor = createViewportReadAnchor(beforeSnapshot, `resize.${source}`, beforeSize);
+      viewportResizeTransaction = startViewportResizeTransaction(anchor);
+      logScrollDiagnostic(`resize-anchor.capture source=${source} reason=size-commit ${formatViewportResizeTransaction(viewportResizeTransaction)} anchor=${formatViewportReadAnchor(anchor)} beforeSize=${beforeSize.cols}x${beforeSize.rows} afterSize=${cols}x${rows} ${formatScrollSnapshot(beforeSnapshot)} ${formatDomScrollState(beforeDom)}`);
+    }
+
+    try {
+      if ((container.style.height || "").trim() !== "100%") {
+        container.style.height = "100%";
+      }
+    } catch {}
+
+    try {
+      if (changed) term.resize(cols, rows);
+    } catch {}
+
+    if (changed) touchViewportResizeTransaction(source);
+    else waitViewportResizeTransaction(source);
+
+    try {
+      if (legacyWinNeedsReflowHack && term && changed) {
+        const need = legacyLastCols !== term.cols;
+        if (need) {
+          const targetCols = term.cols;
+          const prevMode = !!((term as any)?.options?.windowsMode);
+          logScrollDiagnostic(`legacy.reflow.try build=${legacyWinBuild} targetCols=${targetCols} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+          try {
+            (term as any).options = { windowsMode: false } as any;
+            try { (term as any).resize(Math.max(2, targetCols - 1), term.rows); } catch {}
+            try { (term as any).resize(targetCols, term.rows); } catch {}
+          } catch {} finally {
+            try { (term as any).options = { windowsMode: prevMode } as any; } catch {}
+          }
+          legacyLastCols = targetCols;
+        }
+      }
+    } catch {}
+
+    try { term.refresh(0, Math.max(0, term.rows - 1)); } catch {}
+    syncViewportHeight(source);
+    tryRestoreViewportReadAnchor(source);
+    scheduleViewportReconcile(source);
+    logScrollDiagnostic(`adapter.resize.commit source=${source} size=${term.cols}x${term.rows} same=${changed ? "0" : "1"} txBefore=${hadResizeTransaction ? "1" : "0"} txAfter=${viewportResizeTransaction ? "1" : "0"} ${formatViewportResizeTransaction(viewportResizeTransaction)} before=${formatScrollSnapshot(beforeSnapshot)} ${formatDomScrollState(beforeDom)} after=${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+    return { cols: term.cols, rows: term.rows };
+  }
+
+  /**
+   * 通知 Manager 重新执行 resize 测量；只在 reset 输出落地或达到最大等待窗口后触发。
+   */
+  function scheduleDeferredResizeReady(source: string): void {
+    if (deferredResizeNotifyRaf !== null) return;
+    const run = () => {
+      deferredResizeNotifyRaf = null;
+      if (deferredResizeStartedAt === null) return;
+      const age = nowMs() - deferredResizeStartedAt;
+      if (hasPendingTerminalWriteWork() && age < VIEWPORT_RESIZE_PENDING_RESET_MAX_DEFER_MS) {
+        try { deferredResizeNotifyRaf = window.requestAnimationFrame(run); } catch {}
+        return;
+      }
+      deferredResizeStartedAt = null;
+      logScrollDiagnostic(`adapter.resize.defer.ready source=${source} age=${Math.round(age)} ${formatPendingWriteState()} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+      for (const listener of Array.from(deferredResizeListeners)) {
+        try { listener(); } catch {}
+      }
+    };
+    try { deferredResizeNotifyRaf = window.requestAnimationFrame(run); } catch {}
+  }
+
+  /**
+   * 判断本次本地 xterm resize 是否应等待已排队的 reset 重绘先落地。
+   * @param beforeSize resize 前 xterm 尺寸
+   * @param proposed fit-addon 计算出的目标尺寸
+   */
+  function shouldDeferResizeForPendingResetOutput(
+    beforeSize: { cols: number; rows: number },
+    proposed: { cols: number; rows: number } | null,
+  ): boolean {
+    if (!proposed) return false;
+    if (beforeSize.cols === proposed.cols && beforeSize.rows === proposed.rows) return false;
+    if (!hasPendingTerminalResetWriteWork()) return false;
+    const startedAt = deferredResizeStartedAt ?? nowMs();
+    deferredResizeStartedAt = startedAt;
+    if (nowMs() - startedAt >= VIEWPORT_RESIZE_PENDING_RESET_MAX_DEFER_MS) {
+      deferredResizeStartedAt = null;
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * 判断非底部阅读锚点是否需要等待 buffer 重建后再恢复。
+   * @param anchor 阅读锚点
+   * @param snapshot 当前 xterm buffer 滚动快照
+   */
+  function getViewportReadAnchorWaitReason(
+    anchor: ViewportReadAnchor,
+    snapshot: TerminalScrollSnapshot | null | undefined,
+  ): string | null {
+    if (anchor.isAtBottom) return null;
+    if (!snapshot) return "missing-buffer";
+
+    const baseY = Math.max(0, Number(snapshot.baseY || 0));
+    const anchorViewportY = Math.max(0, Math.round(anchor.viewportY));
+    const anchorBaseY = Math.max(anchorViewportY, Math.round(anchor.baseY));
+    const currentCols = term?.cols || 0;
+    const sameCols = !anchor.cols || !currentCols || anchor.cols === currentCols;
+    if (!sameCols) return null;
+
+    if (baseY < anchorViewportY - VIEWPORT_ROW_TOLERANCE) return "anchor-beyond-buffer";
+    if (hasPendingTerminalWriteWork() && baseY < anchorBaseY - VIEWPORT_ROW_TOLERANCE) return "buffer-rebuilding";
+    return null;
+  }
+
+  /**
+   * 按当前 buffer 强制重绘可见终端行。
+   * @param source 触发来源
+   * @param clearRenderer 是否先清理 xterm 渲染层缓存
+   */
+  function refreshVisibleTerminalRows(source: string, clearRenderer = false): void {
+    if (!term) return;
+    try {
+      if (clearRenderer) {
+        const core: any = (term as any)?._core;
+        try { core?._renderService?.clear?.(); } catch {}
+        try { term.clearTextureAtlas?.(); } catch {}
+      }
+      try { term.refresh(0, Math.max(0, term.rows - 1)); } catch {}
+      if (clearRenderer) {
+        logScrollDiagnostic(`viewport.render-refresh source=${source} clear=1 ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+      }
+    } catch {}
+  }
+
+  /**
+   * 在 follow-bottom 语义已经成立时，只把 DOM 滚动条投影同步到 maxScrollTop。
+   * @param source 触发来源
+   */
+  function syncFollowBottomDomScrollbar(source: string): void {
+    if (!term || !container) return;
+    const snapshot = readScrollSnapshot();
+    if (!isViewportAtStrictBottom(snapshot)) return;
+    try {
+      const viewport = container.querySelector(".xterm-viewport") as HTMLDivElement | null;
+      if (!viewport) return;
+      const maxScrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+      if (Math.abs((viewport.scrollTop || 0) - maxScrollTop) <= VIEWPORT_DOM_BOTTOM_TOLERANCE_PX) return;
+      const beforeDom = readDomScrollState();
+      allowProgrammaticViewportScroll(1);
+      viewport.scrollTop = maxScrollTop;
+      logScrollDiagnostic(`scrollbar.bottom-sync source=${source} target=${Math.round(maxScrollTop)} ${formatScrollSnapshot(snapshot)} before=${formatDomScrollState(beforeDom)} after=${formatDomScrollState(readDomScrollState())}`);
+    } catch {}
+  }
+
+  /**
+   * 在释放 resize 事务前强制刷新可见视口，修正 xterm 渲染层与 buffer/DOM 状态偶发脱节。
+   * @param anchor 当前 resize 事务锚点
+   * @param source 触发来源
+   */
+  function forceRevealViewportAnchor(anchor: ViewportReadAnchor, source: string): void {
+    if (!term) return;
+    try {
+      allowProgrammaticViewportScroll(2);
+      if (anchor.isAtBottom) term.scrollToBottom();
+      else term.scrollToLine(resolveViewportAnchorTarget(anchor, readScrollSnapshot() || {
+        viewportY: anchor.viewportY,
+        baseY: anchor.baseY,
+        isAtBottom: anchor.isAtBottom,
+      }));
+      try { syncViewportHeight(`force-reveal.${source}`); } catch {}
+      if (anchor.isAtBottom) syncFollowBottomDomScrollbar(`force-reveal.${source}`);
+      refreshVisibleTerminalRows(`force-reveal.${source}`);
+      logScrollDiagnostic(`viewport.force-reveal source=${source} anchor=${formatViewportReadAnchor(anchor)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+    } catch {}
+  }
+
+  /**
+   * 在后续渲染帧再次刷新 reset 单屏内容，覆盖 rows 回落和浏览器 scrollTop clamp 的异步边界。
+   * @param source 触发来源
+   */
+  function scheduleFollowBottomResetSingleScreenRefresh(source: string): void {
+    const currentTerm = term;
+    if (!currentTerm) return;
+    let frame = 0;
+    const run = () => {
+      if (!term || term !== currentTerm) return;
+      frame += 1;
+      try {
+        syncViewportHeight(`terminal-reset-single-screen.${source}.raf${frame}`);
+        refreshVisibleTerminalRows(`terminal-reset-single-screen.${source}.raf${frame}`, true);
+        logScrollDiagnostic(`viewport.refresh-single-screen.raf frame=${frame} source=${source} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+      } catch {}
+      if (frame < 2) {
+        try { window.requestAnimationFrame(run); } catch {}
+      }
+    };
+    try { window.requestAnimationFrame(run); } catch {}
+  }
+
+  /**
+   * 刷新 reset 后的单屏 follow-bottom 视图，不主动滚动到底部。
+   * @param source 触发来源
+   */
+  function refreshFollowBottomResetSingleScreen(source: string): void {
+    if (!term) return;
+    try {
+      syncViewportHeight(`terminal-reset-single-screen.${source}`);
+      refreshVisibleTerminalRows(`terminal-reset-single-screen.${source}`, true);
+      scheduleFollowBottomResetSingleScreenRefresh(source);
+      logScrollDiagnostic(`viewport.refresh-single-screen source=${source} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+    } catch {}
+  }
+
+  /**
+   * 在事务仍等待真实 resize settle 时刷新 reset 单屏画面，但不主动滚动也不结束事务。
+   * @param tx resize 重绘事务
+   * @param source 触发来源
+   */
+  function refreshFollowBottomResetSingleScreenDuringTransaction(tx: ViewportResizeTransaction, source: string): void {
+    if (!term) return;
+    const now = nowMs();
+    if (tx.singleScreenRefreshAt !== null && now - tx.singleScreenRefreshAt < VIEWPORT_RESIZE_RESET_REFRESH_INTERVAL_MS) return;
+    tx.singleScreenRefreshAt = now;
+    try {
+      refreshVisibleTerminalRows(`terminal-reset-single-screen.tx.${source}`, true);
+      logScrollDiagnostic(`viewport.refresh-single-screen.pending source=${source} ${formatViewportResizeTransaction(tx)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+    } catch {}
+  }
+
+  /**
+   * 在宿主布局 resize 刚开始时提前保存底部跟随事务，避免后续 DOM 高度变化把底部污染成 read-anchor。
+   * @param source 触发来源
+   */
+  function notifyViewportLayoutResizeStart(source: string): void {
+    if (!term) return;
+    if (nowMs() <= userViewportScrollUntil) return;
+    const snapshot = readScrollSnapshot();
+    const dom = readDomScrollState();
+    rememberViewportBottomEvidence(snapshot, dom);
+
+    const existing = viewportResizeTransaction;
+    if (existing) {
+      waitViewportResizeTransaction(`layout-resize.${source}`);
+      logScrollDiagnostic(`resize-anchor.keep source=layout-resize.${source} reason=existing ${formatViewportResizeTransaction(existing)} anchor=${formatViewportReadAnchor(existing.anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(dom)}`);
+      return;
+    }
+
+    const resolved = resolveLayoutResizeBottomAnchorSnapshot(snapshot, dom);
+    if (!resolved) {
+      logScrollDiagnostic(`resize-anchor.layout-skip source=${source} reason=no-bottom-intent ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(dom)}`);
+      return;
+    }
+
+    const anchor = createViewportReadAnchor(resolved.snapshot, `layout-resize.${source}`, {
+      cols: term.cols,
+      rows: term.rows,
+    });
+    anchor.viewportY = anchor.baseY;
+    anchor.distanceFromBottom = 0;
+    anchor.ratio = 1;
+    anchor.isAtBottom = true;
+    const tx = startViewportResizeTransaction(anchor);
+    scheduleViewportReconcile(`layout-resize.${source}`);
+    scheduleViewportResizeReleaseCheck(`layout-resize.${source}`, true);
+    logScrollDiagnostic(`resize-anchor.capture source=layout-resize.${source} reason=${resolved.reason} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(dom)}`);
+  }
+
+  /**
+   * 标记真实 PTY resize 已进入 Manager 的延迟下发窗口。
+   * @param size Manager 计划下发到 PTY 的目标行列
+   * @param source 触发来源
+   */
+  function notifyViewportPtyResizePending(size: { cols: number; rows: number }, source: string): void {
+    const snapshot = readScrollSnapshot();
+    let tx = viewportResizeTransaction;
+    if (!tx && snapshot && snapshot.baseY > 0) {
+      const anchor = createViewportReadAnchor(snapshot, `pty-resize.${source}`, {
+        cols: term?.cols || size.cols || 0,
+        rows: term?.rows || size.rows || 0,
+      });
+      tx = startViewportResizeTransaction(anchor);
+      logScrollDiagnostic(`resize-anchor.capture source=pty-resize.pending reason=manager-pending ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(anchor)} targetSize=${size.cols}x${size.rows} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+    }
+    if (!tx) return;
+    const now = nowMs();
+    if (!tx.ptyResizePending) tx.ptyResizePendingAt = now;
+    tx.ptyResizePending = true;
+    tx.ptyResizeCompletedAt = null;
+    tx.ptyResizeCompletedResult = null;
+    tx.lastActivityAt = now;
+    scheduleViewportResizeReleaseCheck(`pty-resize.pending.${source}`, true);
+    logScrollDiagnostic(`resize-anchor.pty-pending source=${source} targetSize=${size.cols}x${size.rows} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+  }
+
+  /**
+   * 标记 Manager 的真实 PTY resize 排队窗口已经结束。
+   * @param size Manager 最终处理的目标行列
+   * @param source 触发来源
+   * @param result 下发结果
+   */
+  function notifyViewportPtyResizeComplete(
+    size: { cols: number; rows: number },
+    source: string,
+    result: "sent" | "skipped" | "failed",
+  ): void {
+    const tx = viewportResizeTransaction;
+    if (!tx) return;
+    const now = nowMs();
+    tx.ptyResizePending = false;
+    tx.ptyResizeCompletedAt = now;
+    tx.ptyResizeCompletedResult = result;
+    tx.lastActivityAt = now;
+    scheduleViewportResizeReleaseCheck(`pty-resize.${result}.${source}`, true);
+    scheduleViewportReconcile(`pty-resize.${result}.${source}`);
+    logScrollDiagnostic(`resize-anchor.pty-complete source=${source} result=${result} targetSize=${size.cols}x${size.rows} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+  }
+
+  /**
+   * 读取当前真实滚动快照。
+   *
+   * resize 事务只保存恢复意图，不能向外暴露旧锚点快照，否则标签恢复/滚动条同步会把旧 buffer 状态写回 DOM。
+   */
+  function readStableScrollSnapshot(): TerminalScrollSnapshot | null {
+    const snapshot = readScrollSnapshot();
+    rememberViewportBottomEvidence(snapshot, readDomScrollState());
+    return snapshot;
+  }
+
+  /**
+   * 结束 resize 重绘事务。
+   * @param source 释放来源
+   */
+  function releaseViewportResizeTransaction(source: string): void {
+    const tx = viewportResizeTransaction;
+    if (!tx) return;
+    const forceRelease = source === "dispose" || source.startsWith("user.");
+    const snapshot = readScrollSnapshot();
+    const rebuildReason = getViewportResizeRebuildReason(snapshot);
+    const txExpired = canExpireViewportResizeTransaction(tx);
+    const anchorWaitReason = getViewportReadAnchorWaitReason(tx.anchor, snapshot);
+    const readAnchorResetInvalidated = isReadAnchorResetAnchorInvalidated(tx, snapshot);
+    const terminalResetSettled = isViewportResizeTerminalResetSettled(tx, snapshot);
+    const followBottomMinHold = tx.mode === "follow-bottom" && nowMs() - tx.startedAt < VIEWPORT_RESIZE_FOLLOW_BOTTOM_MIN_HOLD_MS;
+    if (!forceRelease && followBottomMinHold) {
+      logScrollDiagnostic(`resize-anchor.keep source=${source} reason=follow-bottom-min-hold ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+      scheduleViewportReconcile(source);
+      waitViewportResizeTransaction(source);
+      return;
+    }
+    if (!forceRelease && tx.ptyResizePending && !txExpired) {
+      logScrollDiagnostic(`resize-anchor.keep source=${source} reason=pty-resize-pending ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+      scheduleViewportReconcile(source);
+      waitViewportResizeTransaction(source);
+      return;
+    } else if (!forceRelease && tx.ptyResizePending && txExpired) {
+      logScrollDiagnostic(`resize-anchor.expire source=${source} reason=pty-resize-pending ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+    }
+    if (!forceRelease && rebuildReason && !txExpired) {
+      logScrollDiagnostic(`resize-anchor.keep source=${source} reason=${rebuildReason} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+      scheduleViewportReconcile(source);
+      waitViewportResizeTransaction(source);
+      return;
+    } else if (!forceRelease && rebuildReason && txExpired) {
+      logScrollDiagnostic(`resize-anchor.expire source=${source} reason=${rebuildReason} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+    }
+    if (!forceRelease && anchorWaitReason && !readAnchorResetInvalidated && !txExpired) {
+      logScrollDiagnostic(`resize-anchor.keep source=${source} reason=${anchorWaitReason} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+      scheduleViewportReconcile(source);
+      waitViewportResizeTransaction(source);
+      return;
+    } else if (!forceRelease && anchorWaitReason && !readAnchorResetInvalidated && txExpired) {
+      logScrollDiagnostic(`resize-anchor.expire source=${source} reason=${anchorWaitReason} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+      if (!tx.anchor.isAtBottom) {
+        if (tx.releaseTimer !== null) {
+          try { window.clearTimeout(tx.releaseTimer); } catch {}
+        }
+        viewportResizeTransaction = null;
+        if (viewportReadAnchor === tx.anchor) viewportReadAnchor = null;
+        try { syncViewportHeight(`expired.${source}`); } catch {}
+        logScrollDiagnostic(`resize-anchor.release-expired-unavailable source=${source} reason=${anchorWaitReason} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+        return;
+      }
+    }
+    if (source.startsWith("idle.") && !txExpired && !canReleaseViewportResizeTransaction()) {
+      logScrollDiagnostic(`resize-anchor.keep source=${source} reason=not-restored ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+      scheduleViewportReconcile(source);
+      waitViewportResizeTransaction(source);
+      return;
+    }
+    if (tx.releaseTimer !== null) {
+      try { window.clearTimeout(tx.releaseTimer); } catch {}
+    }
+    if (terminalResetSettled && tx.mode === "follow-bottom") {
+      if (isFollowBottomResetEmptyScreenSettled(tx, snapshot)) {
+        refreshFollowBottomResetSingleScreen(source);
+        logScrollDiagnostic(`resize-anchor.release-terminal-reset-bottom-single-screen source=${source} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+      } else {
+        forceRevealViewportAnchor(tx.anchor, `terminal-reset.${source}`);
+        logScrollDiagnostic(`resize-anchor.release-terminal-reset-bottom source=${source} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+      }
+    } else if (readAnchorResetInvalidated) {
+      try { syncViewportHeight(`terminal-reset-invalidated.${source}`); } catch {}
+      logScrollDiagnostic(`resize-anchor.release-terminal-reset-invalidated source=${source} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+    } else if (terminalResetSettled) {
+      try { syncViewportHeight(`terminal-reset.${source}`); } catch {}
+      logScrollDiagnostic(`resize-anchor.release-terminal-reset source=${source} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+    } else if (tx.mode === "follow-bottom") {
+      forceRevealViewportAnchor(tx.anchor, source);
+    } else {
+      try { syncViewportHeight(`release.${source}`); } catch {}
+      const afterSyncSnapshot = readScrollSnapshot();
+      const afterSyncDom = readDomScrollState();
+      const target = afterSyncSnapshot ? resolveViewportAnchorTarget(tx.anchor, afterSyncSnapshot) : tx.anchor.viewportY;
+      const drifted = !afterSyncSnapshot
+        || Math.abs(afterSyncSnapshot.viewportY - target) > VIEWPORT_ROW_TOLERANCE
+        || hasViewportMismatch(afterSyncSnapshot, afterSyncDom);
+      if (drifted && !forceRelease) {
+        logScrollDiagnostic(`resize-anchor.release-read-anchor.post-sync-drift source=${source} target=${target} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(afterSyncSnapshot)} ${formatDomScrollState(afterSyncDom)}`);
+        scheduleViewportReconcile(source);
+        waitViewportResizeTransaction(source);
+        return;
+      }
+      logScrollDiagnostic(`resize-anchor.release-read-anchor source=${source} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+    }
+    viewportResizeTransaction = null;
+    if (viewportReadAnchor === tx.anchor) viewportReadAnchor = null;
+    logScrollDiagnostic(`resize-anchor.release source=${source} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(tx.anchor)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+  }
+
+  /**
+   * 依据当前 buffer 视口捕获阅读锚点，用于输出重绘或窗口尺寸变化后恢复用户正在看的位置。
+   * @param source 捕获来源
+   */
+  function captureViewportReadAnchor(source: string): ViewportReadAnchor | null {
+    const snapshot = readScrollSnapshot();
+    if (viewportResizeTransaction) {
+      waitViewportResizeTransaction(source);
+      logScrollDiagnostic(`resize-anchor.keep source=${source} reason=locked ${formatViewportResizeTransaction(viewportResizeTransaction)} existing=${formatViewportReadAnchor(viewportResizeTransaction.anchor)} current=${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+      return viewportResizeTransaction.anchor;
+    }
+    if (!snapshot || snapshot.baseY <= 0) return null;
+    if (
+      viewportReadAnchor
+      && !viewportReadAnchor.isAtBottom
+      && (
+        snapshot.viewportY < viewportReadAnchor.viewportY - VIEWPORT_ROW_TOLERANCE
+        || snapshot.baseY < viewportReadAnchor.baseY
+      )
+    ) {
+      logScrollDiagnostic(`anchor.keep source=${source} reason=buffer-shrunk existing=${formatViewportReadAnchor(viewportReadAnchor)} current=${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+      return viewportReadAnchor;
+    }
+    if (snapshot.isAtBottom) {
+      viewportReadAnchor = null;
+      return null;
+    }
+    const anchor = createViewportReadAnchor(snapshot, source);
+    viewportReadAnchor = anchor;
+    logScrollDiagnostic(`anchor.capture source=${source} anchor=${formatViewportReadAnchor(anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+    return anchor;
+  }
+
+  /**
+   * 根据当前 buffer 长度计算锚点应恢复到的 viewportY。
+   * @param anchor 阅读锚点
+   * @param snapshot 当前滚动快照
+   */
+  function resolveViewportAnchorTarget(
+    anchor: ViewportReadAnchor,
+    snapshot: TerminalScrollSnapshot,
+  ): number {
+    const baseY = Math.max(0, snapshot.baseY);
+    if (anchor.isAtBottom) return baseY;
+    const currentCols = term?.cols || 0;
+    if (!anchor.cols || !currentCols || anchor.cols === currentCols) {
+      return Math.max(0, Math.min(baseY, Math.round(anchor.viewportY)));
+    }
+    return Math.max(0, Math.min(baseY, Math.round(baseY * anchor.ratio)));
+  }
+
+  /**
+   * 尝试恢复阅读锚点，成功恢复或锚点过期时返回 true。
+   * @param source 触发来源
+   */
+  function tryRestoreViewportReadAnchor(source: string): boolean {
+    const anchor = viewportReadAnchor || viewportResizeTransaction?.anchor || null;
+    if (!anchor || !term) return false;
+    if (viewportResizeTransaction?.anchor === anchor && viewportReadAnchor !== anchor) viewportReadAnchor = anchor;
+    if (nowMs() <= userViewportScrollUntil) return false;
+    const tx = viewportResizeTransaction && viewportResizeTransaction.anchor === anchor ? viewportResizeTransaction : null;
+    const txExpired = !!tx && nowMs() - tx.startedAt > VIEWPORT_RESIZE_ANCHOR_TTL_MS;
+    const txCanExpire = !!tx && canExpireViewportResizeTransaction(tx);
+    const age = nowMs() - anchor.createdAt;
+    if (age > VIEWPORT_ANCHOR_TTL_MS) {
+      if (tx && !txExpired) {
+        waitViewportResizeTransaction(source);
+      } else if (!tx) {
+        logScrollDiagnostic(`anchor.drop source=${source} reason=expired age=${Math.round(age)} anchor=${formatViewportReadAnchor(anchor)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+        viewportReadAnchor = null;
+        return true;
+      }
+    }
+    const snapshot = readScrollSnapshot();
+    observeViewportResizeBaseY(snapshot);
+    if (!snapshot) {
+      if (txCanExpire) releaseViewportResizeTransaction(`expired.no-snapshot.${source}`);
+      else if (tx) waitViewportResizeTransaction(source);
+      return false;
+    }
+    if (!anchor.isAtBottom && !tx && snapshot.baseY >= anchor.baseY && Math.abs(snapshot.viewportY - anchor.viewportY) <= VIEWPORT_ROW_TOLERANCE) {
+      viewportReadAnchor = null;
+      return true;
+    }
+    const rebuildReason = tx ? getViewportResizeRebuildReason(snapshot) : null;
+    if (tx && rebuildReason) {
+      if (txCanExpire) {
+        logScrollDiagnostic(`resize-anchor.stalled source=${source} reason=${rebuildReason} action=expire ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+        releaseViewportResizeTransaction(`stalled-expired.${source}`);
+        return true;
+      }
+      waitViewportResizeTransaction(source);
+      logScrollDiagnostic(`resize-anchor.wait source=${source} reason=${rebuildReason} ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+      return false;
+    }
+    if (tx && isViewportResizeTerminalResetSettled(tx, snapshot)) {
+      releaseViewportResizeTransaction(`terminal-reset.${source}`);
+      return true;
+    }
+    const anchorWaitReason = getViewportReadAnchorWaitReason(anchor, snapshot);
+    if (anchorWaitReason) {
+      if (tx && txCanExpire) {
+        logScrollDiagnostic(`resize-anchor.stalled source=${source} reason=${anchorWaitReason} action=expire ${formatViewportResizeTransaction(tx)} anchor=${formatViewportReadAnchor(anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+        releaseViewportResizeTransaction(`stalled-expired.${source}`);
+        return true;
+      }
+      if (tx) waitViewportResizeTransaction(source);
+      scheduleViewportReconcile(source);
+      logScrollDiagnostic(`${tx ? "resize-anchor" : "anchor"}.wait source=${source} reason=${anchorWaitReason} ${tx ? formatViewportResizeTransaction(tx) : formatPendingWriteState()} anchor=${formatViewportReadAnchor(anchor)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+      return false;
+    }
+    const target = resolveViewportAnchorTarget(anchor, snapshot);
+    const restored = anchor.isAtBottom
+      ? isViewportAtStrictBottom(snapshot)
+      : Math.abs(snapshot.viewportY - target) <= VIEWPORT_ROW_TOLERANCE;
+    if (restored) {
+      if (anchor.isAtBottom) {
+        try { syncFollowBottomDomScrollbar(`anchor-settled.${source}`); } catch {}
+      }
+      logScrollDiagnostic(`${tx ? "resize-anchor" : "anchor"}.restore.skip source=${source} reason=settled target=${target} diff=${Math.round(Math.abs(snapshot.viewportY - target))} strictBottom=${isViewportAtStrictBottom(snapshot) ? "1" : "0"} ${tx ? formatViewportResizeTransaction(tx) : formatPendingWriteState()} anchor=${formatViewportReadAnchor(anchor)} current=${formatScrollSnapshot(snapshot)} ${formatDomScrollState(readDomScrollState())}`);
+      if (tx) {
+        if (txExpired && canReleaseViewportResizeTransaction()) releaseViewportResizeTransaction(`settled-expired.${source}`);
+        else waitViewportResizeTransaction(source);
+        return true;
+      }
+      viewportReadAnchor = null;
+      return true;
+    }
+    try {
+      allowProgrammaticViewportScroll(2);
+      if (anchor.isAtBottom) term.scrollToBottom();
+      else term.scrollToLine(target);
+      try { syncViewportHeight(`anchor.${source}`); } catch {}
+      if (anchor.isAtBottom) syncFollowBottomDomScrollbar(`anchor.${source}`);
+      const after = readScrollSnapshot();
+      logScrollDiagnostic(`${tx ? "resize-anchor" : "anchor"}.restore source=${source} target=${target} ${tx ? formatViewportResizeTransaction(tx) : formatPendingWriteState()} anchor=${formatViewportReadAnchor(anchor)} before=${formatScrollSnapshot(snapshot)} after=${formatScrollSnapshot(after)} ${formatDomScrollState(readDomScrollState())}`);
+      if (tx) {
+        tx.restoreCount += 1;
+        if (txExpired && canReleaseViewportResizeTransaction()) releaseViewportResizeTransaction(`restored-expired.${source}`);
+        else waitViewportResizeTransaction(source);
+      } else {
+        viewportReadAnchor = null;
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * 读取当前 xterm 渲染行高。
+   */
+  function readTerminalLineHeightPx(): number {
+    try {
+      const core: any = (term as any)?._core;
+      const dims = core?._renderService?.dimensions?.css?.cell || {};
+      const cellH = Number(dims?.height || 0);
+      if (cellH && isFinite(cellH)) return cellH;
+    } catch {}
+    const dom = readDomScrollState();
+    const snapshot = readScrollSnapshot();
+    if (dom && snapshot && snapshot.baseY > 0 && dom.maxScrollTop > 0) {
+      const guessed = dom.maxScrollTop / snapshot.baseY;
+      if (guessed && isFinite(guessed) && guessed > 0) return guessed;
+    }
+    return 0;
+  }
+
+  /**
+   * 判断 DOM 滚动条投影是否已经偏离 xterm buffer 视口。
+   * @param snapshot xterm buffer 滚动快照
+   * @param dom DOM viewport 滚动度量
+   */
+  function hasViewportMismatch(
+    snapshot: TerminalScrollSnapshot | null | undefined,
+    dom: TerminalDomScrollState | null | undefined,
+  ): boolean {
+    if (!snapshot || !dom) return false;
+    const lineHeight = readTerminalLineHeightPx();
+    if (!lineHeight || !isFinite(lineHeight) || lineHeight <= 0) return false;
+    const domViewportY = Math.round(dom.scrollTop / lineHeight);
+    return Math.abs(domViewportY - snapshot.viewportY) > VIEWPORT_ROW_TOLERANCE;
+  }
+
+  /**
+   * 把 DOM viewport 重新对齐到 xterm 当前 buffer 视口，避免浏览器 clamp 后反向污染 ydisp。
+   * @param source 触发来源
+   */
+  function scheduleViewportReconcile(source: string): void {
+    if (!term || !container) return;
+    viewportReconcilePendingFrames = Math.max(
+      viewportReconcilePendingFrames,
+      viewportReadAnchor ? VIEWPORT_ANCHOR_RESTORE_FRAMES : VIEWPORT_RECONCILE_FRAMES,
+    );
+    if (viewportReconcileRaf !== null) return;
+    /**
+     * 执行单帧 viewport 对齐。
+     */
+    const run = () => {
+      viewportReconcileRaf = null;
+      if (!term || !container || viewportReconcilePendingFrames <= 0) return;
+      if (nowMs() <= userViewportScrollUntil) {
+        if (!viewportReadAnchor) {
+          viewportReconcilePendingFrames = 0;
+          return;
+        }
+        try { viewportReconcileRaf = window.requestAnimationFrame(run); } catch { viewportReconcileRaf = null; }
+        return;
+      }
+      viewportReconcilePendingFrames -= 1;
+      const beforeSnapshot = readScrollSnapshot();
+      const beforeDom = readDomScrollState();
+      try { syncViewportHeight(`reconcile.${source}`); } catch {}
+      const hadAnchor = !!viewportReadAnchor;
+      tryRestoreViewportReadAnchor(source);
+      const afterSnapshot = readScrollSnapshot();
+      const afterDom = readDomScrollState();
+      if (!viewportReadAnchor && hasViewportMismatch(afterSnapshot, afterDom)) {
+        syncScrollbarToSnapshot(afterSnapshot, `reconcile.${source}`);
+      }
+      const finalSnapshot = readScrollSnapshot();
+      const finalDom = readDomScrollState();
+      if (hasViewportMismatch(finalSnapshot, finalDom) || hasDomScrollDelta(beforeDom, finalDom) || hadAnchor) {
+        logScrollDiagnostic(`viewport.reconcile source=${source} framesLeft=${viewportReconcilePendingFrames} anchorPending=${viewportReadAnchor ? "1" : "0"} before=${formatScrollSnapshot(beforeSnapshot)} ${formatDomScrollState(beforeDom)} after=${formatScrollSnapshot(finalSnapshot)} ${formatDomScrollState(finalDom)}`);
+      }
+      if (viewportReconcilePendingFrames > 0) {
+        try { viewportReconcileRaf = window.requestAnimationFrame(run); } catch { viewportReconcileRaf = null; }
+      }
+    };
+    try { viewportReconcileRaf = window.requestAnimationFrame(run); } catch { viewportReconcileRaf = null; }
+  }
+
+  /**
+   * 中文说明：判断两次 DOM 滚动度量是否存在值得记录的差异。
+   */
+  const hasDomScrollDelta = (
+    before: TerminalDomScrollState | null | undefined,
+    after: TerminalDomScrollState | null | undefined,
+  ): boolean => {
+    if (!before || !after) return !!before !== !!after;
+    return Math.abs(before.scrollTop - after.scrollTop) > 1
+      || Math.abs(before.scrollHeight - after.scrollHeight) > 1
+      || Math.abs(before.clientHeight - after.clientHeight) > 1
+      || Math.abs(before.maxScrollTop - after.maxScrollTop) > 1;
+  };
+
+  /**
+   * 中文说明：按事件源记录一次当前滚动状态。
+   */
+  const logCurrentScrollState = (source: string, extra = ""): void => {
+    const suffix = extra ? ` ${extra}` : "";
+    logScrollDiagnostic(`${source} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}${suffix}`);
+  };
+
+  /**
+   * 中文说明：安装 DOM viewport 滚动监听，捕获用户滚动、程序写 scrollTop 与浏览器锚点修正产生的实际结果。
+   */
+  const installViewportScrollDebugListener = (): void => {
+    try { removeViewportScrollDebugListener?.(); } catch {}
+    removeViewportScrollDebugListener = null;
+    if (!container) return;
+    try {
+      const viewport = container.querySelector(".xterm-viewport") as HTMLDivElement | null;
+      if (!viewport) return;
+      const host = container;
+      const onUserScrollIntent = () => {
+        try { markViewportUserScroll("viewport.input"); } catch {}
+        viewportReadAnchor = null;
+      };
+      const onWheelIntent = (event: WheelEvent) => {
+        try { markViewportUserScroll("wheel"); } catch {}
+        viewportReadAnchor = null;
+      };
+      const onViewportScroll = () => {
+        const state = readDomScrollState();
+        if (!state) return;
+        const now = nowMs();
+        const previousTop = lastViewportScrollTop;
+        const changed = previousTop === null || Math.abs(state.scrollTop - previousTop) > 1;
+        if (!changed && now - lastViewportScrollLogAt < 160) return;
+        lastViewportScrollLogAt = now;
+        lastViewportScrollTop = state.scrollTop;
+        const snapshot = readScrollSnapshot();
+        if (viewportResizeTransaction && hasViewportMismatch(snapshot, state)) {
+          logScrollDiagnostic(`dom.scroll.ignored prevTop=${previousTop === null ? "n/a" : Math.round(previousTop)} reason=resize-transaction ${formatViewportResizeTransaction(viewportResizeTransaction)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(state)}`);
+          return;
+        }
+        if (!canAcceptViewportDomScroll() && hasViewportMismatch(snapshot, state)) {
+          logScrollDiagnostic(`dom.scroll.ignored prevTop=${previousTop === null ? "n/a" : Math.round(previousTop)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(state)}`);
+          return;
+        }
+        logScrollDiagnostic(`dom.scroll prevTop=${previousTop === null ? "n/a" : Math.round(previousTop)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(state)}`);
+      };
+      try { host.addEventListener("wheel", onWheelIntent, { passive: true, capture: true }); } catch {}
+      viewport.addEventListener("wheel", onUserScrollIntent, { passive: true });
+      viewport.addEventListener("pointerdown", onUserScrollIntent, true);
+      viewport.addEventListener("touchstart", onUserScrollIntent, { passive: true });
+      viewport.addEventListener("scroll", onViewportScroll, { passive: true });
+      removeViewportScrollDebugListener = () => {
+        try { host.removeEventListener("wheel", onWheelIntent, true); } catch {}
+        try { viewport.removeEventListener("wheel", onUserScrollIntent); } catch {}
+        try { viewport.removeEventListener("pointerdown", onUserScrollIntent, true); } catch {}
+        try { viewport.removeEventListener("touchstart", onUserScrollIntent); } catch {}
+        try { viewport.removeEventListener("scroll", onViewportScroll); } catch {}
+      };
+      logCurrentScrollState("dom.scroll.listener-ready");
+    } catch {}
+  };
+
+  /**
+   * 中文说明：记录 xterm buffer 滚动事件，限频避免长输出时 perf.log 被刷爆。
+   */
+  const logBufferScrollEvent = (): void => {
+    const snapshot = readScrollSnapshot();
+    if (!snapshot) return;
+    const dom = readDomScrollState();
+    rememberViewportBottomEvidence(snapshot, dom);
+    const now = nowMs();
+    const previousY = lastBufferViewportY;
+    const changed = previousY === null || Math.abs(snapshot.viewportY - previousY) > 0.1;
+    if (!changed && now - lastBufferScrollLogAt < 250) return;
+    lastBufferScrollLogAt = now;
+    lastBufferViewportY = snapshot.viewportY;
+    logScrollDiagnostic(`buffer.scroll prevY=${previousY === null ? "n/a" : Math.round(previousY)} ${formatScrollSnapshot(snapshot)} ${formatDomScrollState(dom)}`);
+    scheduleViewportReconcile("buffer.scroll");
   };
 
   /**
@@ -318,9 +1910,18 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
    */
   const syncScrollbarToSnapshot = (snapshot?: TerminalScrollSnapshot | null, tag = "sync") => {
     if (!term || !container) return;
-    const current = readScrollSnapshot();
-    const effective = current || snapshot || lastScrollSnapshot;
+    if (viewportResizeTransaction) {
+      logScrollDiagnostic(`scrollbar.skip tag=${tag} reason=resize-transaction snapshot=${formatScrollSnapshot(snapshot ?? null)} current=${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
+      return;
+    }
+    const current = readStableScrollSnapshot();
+    if (!current || current.baseY <= 0) {
+      logScrollDiagnostic(`scrollbar.skip tag=${tag} reason=unstable-current snapshot=${formatScrollSnapshot(snapshot ?? null)} current=${formatScrollSnapshot(current)} last=${formatScrollSnapshot(lastScrollSnapshot)} ${formatDomScrollState(readDomScrollState())}`);
+      return;
+    }
+    const effective = current;
     if (!effective) return;
+    const beforeDom = readDomScrollState();
 
     // 先同步 scrollArea，确保 viewport.scrollHeight 可靠
     try { syncViewportHeight(`scrollbar.${tag}`); } catch {}
@@ -350,11 +1951,16 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
       const clamped = Math.max(0, Math.min(target, maxScrollTop));
       // 仅在差异明显时写入，避免频繁写 scrollTop 导致抖动
       if (Math.abs((viewport.scrollTop || 0) - clamped) > 1) {
+        logScrollDiagnostic(`scrollbar.write tag=${tag} target=${clamped} perLine=${perLinePx.toFixed(3)} effective=${formatScrollSnapshot(effective)} current=${formatScrollSnapshot(current)} before=${formatDomScrollState(beforeDom)}`);
+        allowProgrammaticViewportScroll();
         viewport.scrollTop = clamped;
+        logCurrentScrollState(`scrollbar.after-write tag=${tag}`);
+      } else if (tag.startsWith("restore")) {
+        logScrollDiagnostic(`scrollbar.keep tag=${tag} target=${clamped} effective=${formatScrollSnapshot(effective)} current=${formatScrollSnapshot(current)} before=${formatDomScrollState(beforeDom)} after=${formatDomScrollState(readDomScrollState())}`);
       }
     } catch {}
 
-    lastScrollSnapshot = readScrollSnapshot();
+    lastScrollSnapshot = readStableScrollSnapshot();
   };
 
   const applyAppearanceToTerminal = (next: TerminalAppearance) => {
@@ -403,11 +2009,32 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
   // 关键：标签页切换后强制同步滚动区域高度，避免滚轮无法滚至底部
   const syncViewportHeight = (tag: string) => {
     if (!term) return;
+    const beforeDom = readDomScrollState();
+    const beforeSnapshot = readScrollSnapshot();
+    const rebuildReason = getViewportResizeRebuildReason(beforeSnapshot);
+    const resizeTx = viewportResizeTransaction;
+    const allowResetSingleScreenSync = !!resizeTx
+      && rebuildReason === "empty-buffer"
+      && canSyncFollowBottomResetSingleScreen(resizeTx, beforeSnapshot);
+    if (rebuildReason && resizeTx && !allowResetSingleScreenSync) {
+      waitViewportResizeTransaction(tag);
+      logScrollDiagnostic(`viewport.sync.skip tag=${tag} reason=${rebuildReason} anchor=${formatViewportReadAnchor(resizeTx.anchor)} before=${formatScrollSnapshot(beforeSnapshot)} ${formatDomScrollState(beforeDom)} after=${formatDomScrollState(readDomScrollState())}`);
+      return;
+    }
     try {
       const core: any = (term as any)?._core;
       const viewport = core?.viewport;
       if (viewport && typeof viewport.syncScrollArea === "function") {
         viewport.syncScrollArea(true);
+        const afterDom = readDomScrollState();
+        const afterSnapshot = readScrollSnapshot();
+        rememberViewportBottomEvidence(afterSnapshot, afterDom);
+        if (hasDomScrollDelta(beforeDom, afterDom) || tag.startsWith("scrollbar") || tag === "fitAndPin") {
+          logScrollDiagnostic(`viewport.sync tag=${tag} before=${formatScrollSnapshot(beforeSnapshot)} ${formatDomScrollState(beforeDom)} after=${formatScrollSnapshot(afterSnapshot)} ${formatDomScrollState(afterDom)}`);
+        }
+        if (allowResetSingleScreenSync && resizeTx) {
+          refreshFollowBottomResetSingleScreenDuringTransaction(resizeTx, tag);
+        }
         if (dbgEnabled()) {
           try {
             (window as any).host?.utils?.perfLog?.(`[adapter] viewport.sync tag=${tag}`);
@@ -435,6 +2062,7 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
       dlog(
         `[adapter] fit.start hostWH=${Math.round(hostW0)}x${Math.round(hostH0)} before=${before.cols}x${before.rows}`
       );
+      logScrollDiagnostic(`fit.start host=${Math.round(hostW0)}x${Math.round(hostH0)} before=${before.cols}x${before.rows} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
 
       // 若宿主高度为 0 或被隐藏，则跳过本次 fit/pin，避免产生 11x6 等异常度量
       try {
@@ -452,6 +2080,7 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
           dlog(
             `[adapter] fit.skip hiddenOrZero hidden=${hidden} host=${Math.round(hostW0)}x${Math.round(hostH0)}`
           );
+          logScrollDiagnostic(`fit.skip hidden=${hidden ? "1" : "0"} host=${Math.round(hostW0)}x${Math.round(hostH0)} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
           if (forceRefresh) try { term.refresh(0, term.rows - 1); } catch {}
           return { cols: term.cols, rows: term.rows };
         }
@@ -467,6 +2096,7 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
       const cellW = Number(dims?.width || 0);
       if (!cellH || !isFinite(cellH)) {
         dlog(`[adapter] fit.noCellH rows=${term.rows} cols=${term.cols}`);
+        logScrollDiagnostic(`fit.noCellH size=${term.cols}x${term.rows} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
         if (forceRefresh) try { term.refresh(0, term.rows - 1); } catch {}
         return { cols: term.cols, rows: term.rows };
       }
@@ -475,6 +2105,7 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
         // 调试开关：禁用“整行钉死”，仅执行常规 fit
         fitAddon.fit();
         dlog(`[adapter] dims cell=${cellW.toFixed(2)}x${cellH.toFixed(2)} dpr=${(window.devicePixelRatio||1).toFixed(2)}`);
+        logScrollDiagnostic(`fit.pinDisabled cell=${cellW.toFixed(2)}x${cellH.toFixed(2)} after=${term.cols}x${term.rows} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
         if (forceRefresh) try { term.refresh(0, term.rows - 1); } catch {}
         dlog(`[adapter] fit.pinDisabled after=${term.cols}x${term.rows}`);
         return { cols: term.cols, rows: term.rows };
@@ -502,6 +2133,7 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
       dlog(
         `[adapter] fit.pinned cell=${cellW.toFixed(2)}x${cellH.toFixed(2)} host=${Math.round(hostWidth)}x${hostH} rows=${rows} pinnedPx=${pinnedPx} after=${term.cols}x${term.rows}`
       );
+      logScrollDiagnostic(`fit.pinned cell=${cellW.toFixed(2)}x${cellH.toFixed(2)} host=${Math.round(hostWidth)}x${hostH} rows=${rows} pinnedPx=${pinnedPx} after=${term.cols}x${term.rows} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
       // 低版本 Windows：尝试一次“临时关闭 windowsMode + 列宽轻抖动”的降级重排
       try {
         if (legacyWinNeedsReflowHack && term && term.cols) {
@@ -510,6 +2142,7 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
             const targetCols = term.cols;
             const prevMode = !!((term as any)?.options?.windowsMode);
             dlog(`[adapter] legacy.reflow try build=${legacyWinBuild} targetCols=${targetCols}`);
+            logScrollDiagnostic(`legacy.reflow.try build=${legacyWinBuild} targetCols=${targetCols} ${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
             try {
               (term as any).options = { windowsMode: false } as any;
               try { (term as any).resize(Math.max(2, targetCols - 1), term.rows); } catch {}
@@ -523,9 +2156,13 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
       } catch {}
       if (forceRefresh) try { term.refresh(0, term.rows - 1); } catch {}
       syncViewportHeight("fitAndPin");
+      tryRestoreViewportReadAnchor("fitAndPin");
+      scheduleViewportReconcile("fitAndPin");
       return { cols: term.cols, rows: term.rows };
     } catch {
       try { fitAddon!.fit(); } catch {}
+      tryRestoreViewportReadAnchor("fitAndPin.catch");
+      scheduleViewportReconcile("fitAndPin.catch");
       return { cols: term!.cols, rows: term!.rows };
     }
   };
@@ -605,7 +2242,8 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
       }
       try {
         const disp = term.onScroll(() => {
-          lastScrollSnapshot = readScrollSnapshot();
+          lastScrollSnapshot = readStableScrollSnapshot();
+          try { logBufferScrollEvent(); } catch {}
         });
         removeScrollListener = () => disp.dispose();
       } catch {
@@ -631,6 +2269,8 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
       container = el;
       term!.open(el);
       try { dlog(`[adapter] mount.open dpr=${window.devicePixelRatio || 1}`); } catch {}
+      try { installViewportScrollDebugListener(); } catch {}
+      try { logCurrentScrollState("mount.open", `dpr=${(window.devicePixelRatio || 1).toFixed(2)}`); } catch {}
       try {
         removeTermFocusListener?.();
       } catch {} finally { removeTermFocusListener = null; }
@@ -665,6 +2305,14 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
           return ((e.ctrlKey || e.metaKey) && !e.shiftKey && key === 'v');
         };
         /**
+         * 判断按键是否表达了用户查看历史输出的意图。
+         * @param e 键盘事件
+         */
+        const isHistoryScrollKey = (e: KeyboardEvent): boolean => {
+          const key = String(e.key || "").toLowerCase();
+          return key === "pageup" || key === "pagedown";
+        };
+        /**
          * 中文说明：解析终端滚动端点快捷键，仅响应 Ctrl + Home / Ctrl + End。
          */
         const getBoundaryScrollAction = (e: KeyboardEvent): "top" | "bottom" | null => {
@@ -696,6 +2344,8 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
           const action = getBoundaryScrollAction(e);
           if (!action || !canHandleBoundaryScrollAction(action)) return false;
           try {
+            markViewportUserScroll(`key.${action}`);
+            viewportReadAnchor = null;
             if (action === "top") term?.scrollToTop();
             else term?.scrollToBottom();
           } catch {}
@@ -877,6 +2527,7 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
         term!.attachCustomKeyEventHandler((e: KeyboardEvent) => {
           try {
             maybeMarkCtrlKeydown(e);
+            if (!getBoundaryScrollAction(e) && isHistoryScrollKey(e)) markViewportUserScroll("key.history");
             if (handleBoundaryScrollAction(e)) return false;
             if (isCopyCombo(e)) {
               const sel = getXtermSelection();
@@ -899,6 +2550,7 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
         const onKeydownCapture = (e: KeyboardEvent) => {
           try {
             maybeMarkCtrlKeydown(e);
+            if (!getBoundaryScrollAction(e) && isHistoryScrollKey(e)) markViewportUserScroll("key.history");
             if (handleBoundaryScrollAction(e)) {
               e.preventDefault();
               e.stopPropagation();
@@ -933,11 +2585,13 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
         const onDocKeydownCapture = (e: KeyboardEvent) => {
           try {
             maybeMarkCtrlKeydown(e);
-            if (!(getBoundaryScrollAction(e) || isCopyCombo(e) || isPasteCombo(e) || isStdPasteCombo(e))) return;
+            const boundaryAction = getBoundaryScrollAction(e);
+            if (!(boundaryAction || isHistoryScrollKey(e) || isCopyCombo(e) || isPasteCombo(e) || isStdPasteCombo(e))) return;
             const target = e.target as any as Node | null;
             const active = (document.activeElement as any) as Node | null;
             const within = !!container && (container.contains(target || (null as any)) || container.contains(active || (null as any)));
             if (!within) return;
+            if (!boundaryAction && isHistoryScrollKey(e)) markViewportUserScroll("key.history");
             if (handleBoundaryScrollAction(e)) {
               e.preventDefault();
               e.stopPropagation();
@@ -1159,24 +2813,74 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
       const d = term!.onData(cb);
       return () => d.dispose();
     },
+    measureResize: () => {
+      if (!term) ensure();
+      return measureTerminalResize();
+    },
+    resizeTo: (size: { cols: number; rows: number }, source = "resizeTo") => {
+      if (!term) ensure();
+      return commitTerminalResize(size, source);
+    },
+    hasPendingWriteWork: () => {
+      return hasPendingTerminalWriteWork();
+    },
     resize: () => {
       // 每次外部要求 resize 时，执行“fit+pin”并强制 refresh
       if (!term || !fitAddon || !container) return { cols: 0, rows: 0 };
+      const beforeSize = { cols: term.cols, rows: term.rows };
+      const beforeSnapshot = readScrollSnapshot();
+      const beforeDom = readDomScrollState();
+      const hadResizeTransaction = !!viewportResizeTransaction;
+      const proposedSize = proposeTerminalFitSize();
+      if (shouldDeferResizeForPendingResetOutput(beforeSize, proposedSize)) {
+        scheduleDeferredResizeReady("adapter.resize");
+        logScrollDiagnostic(`adapter.resize.defer reason=pending-reset-output target=${proposedSize ? `${proposedSize.cols}x${proposedSize.rows}` : "n/a"} current=${beforeSize.cols}x${beforeSize.rows} txBefore=${hadResizeTransaction ? "1" : "0"} ${formatViewportResizeTransaction(viewportResizeTransaction)} ${formatScrollSnapshot(beforeSnapshot)} ${formatDomScrollState(beforeDom)}`);
+        return beforeSize;
+      }
       const s = fitAndPin(true);
+      const changed = s.cols !== beforeSize.cols || s.rows !== beforeSize.rows;
+      if (changed) {
+        if (!viewportResizeTransaction && beforeSnapshot && beforeSnapshot.baseY > 0) {
+          const anchor = createViewportReadAnchor(beforeSnapshot, "resize.adapter.resize", beforeSize);
+          viewportResizeTransaction = startViewportResizeTransaction(anchor);
+          logScrollDiagnostic(`resize-anchor.capture source=adapter.resize reason=size-changed ${formatViewportResizeTransaction(viewportResizeTransaction)} anchor=${formatViewportReadAnchor(anchor)} beforeSize=${beforeSize.cols}x${beforeSize.rows} afterSize=${s.cols}x${s.rows} ${formatScrollSnapshot(beforeSnapshot)} ${formatDomScrollState(beforeDom)}`);
+        }
+        touchViewportResizeTransaction("adapter.resize");
+      } else {
+        waitViewportResizeTransaction("adapter.resize");
+      }
+      logScrollDiagnostic(`adapter.resize size=${s.cols}x${s.rows} same=${s.cols === beforeSize.cols && s.rows === beforeSize.rows ? "1" : "0"} txBefore=${hadResizeTransaction ? "1" : "0"} txAfter=${viewportResizeTransaction ? "1" : "0"} ${formatViewportResizeTransaction(viewportResizeTransaction)} before=${formatScrollSnapshot(beforeSnapshot)} ${formatDomScrollState(beforeDom)} after=${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
       dlog(`[adapter] resize -> ${s.cols}x${s.rows}`);
       return s;
     },
+    notifyPtyResizePending: (size: { cols: number; rows: number }, source: string) => {
+      notifyViewportPtyResizePending(size, source);
+    },
+    notifyPtyResizeComplete: (size: { cols: number; rows: number }, source: string, result: "sent" | "skipped" | "failed") => {
+      notifyViewportPtyResizeComplete(size, source, result);
+    },
+    notifyLayoutResizeStart: (source: string) => {
+      notifyViewportLayoutResizeStart(source);
+    },
+    onDeferredResizeReady: (cb: () => void) => {
+      deferredResizeListeners.add(cb);
+      return () => {
+        deferredResizeListeners.delete(cb);
+      };
+    },
     getScrollSnapshot: () => {
       if (!term) ensure();
-      const snapshot = readScrollSnapshot();
+      const snapshot = readStableScrollSnapshot();
       lastScrollSnapshot = snapshot;
       return snapshot;
     },
     restoreScrollSnapshot: (snapshot?: TerminalScrollSnapshot | null) => {
       if (!term) ensure();
+      viewportReadAnchor = null;
+      logScrollDiagnostic(`restore.request snapshot=${formatScrollSnapshot(snapshot ?? null)} current=${formatScrollSnapshot(readScrollSnapshot())} ${formatDomScrollState(readDomScrollState())}`);
       try { syncScrollbarToSnapshot(snapshot ?? null, "restore"); } catch {}
       // 二次对齐：用于处理标签刚切回时 DOM 尚未稳定的场景
-      try { requestAnimationFrame(() => { try { syncScrollbarToSnapshot(snapshot ?? null, "restore.raf"); } catch {} }); } catch {}
+      try { requestAnimationFrame(() => { try { syncScrollbarToSnapshot(snapshot ?? null, "restore.raf"); logCurrentScrollState("restore.raf.done"); } catch {} }); } catch {}
     },
     readCursorTextSnapshot: (options?: TerminalCursorTextSnapshotOptions) => {
       if (!term) ensure();
@@ -1202,16 +2906,34 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
       applyAppearanceToTerminal(next);
     },
     scrollToTop: () => {
-      try { term?.scrollToTop(); } catch {}
+      try {
+        viewportReadAnchor = null;
+        markViewportUserScroll("api.top");
+        term?.scrollToTop();
+      } catch {}
     },
     scrollToBottom: () => {
-      try { term?.scrollToBottom(); } catch {}
+      try {
+        viewportReadAnchor = null;
+        markViewportUserScroll("api.bottom");
+        term?.scrollToBottom();
+      } catch {}
     },
     dispose: () => {
       try { dlog('[adapter] dispose'); if (container) container.style.height = ""; } catch {}
       // 先取消 pending write，避免在 dispose 后的下一帧仍尝试写入（导致异常或泄漏）。
       try { if (pendingWriteScheduled !== null) cancelAnimationFrame(pendingWriteScheduled); } catch {}
+      try { if (viewportReconcileRaf !== null) cancelAnimationFrame(viewportReconcileRaf); } catch {}
+      try { if (deferredResizeNotifyRaf !== null) cancelAnimationFrame(deferredResizeNotifyRaf); } catch {}
       pendingWriteScheduled = null;
+      viewportReconcileRaf = null;
+      deferredResizeNotifyRaf = null;
+      deferredResizeStartedAt = null;
+      deferredResizeListeners.clear();
+      viewportReconcilePendingFrames = 0;
+      programmaticViewportScrollAllowance = 0;
+      try { releaseViewportResizeTransaction("dispose"); } catch {}
+      viewportReadAnchor = null;
       pendingWriteChunks = [];
       pendingWriteChars = 0;
       pendingWriteDroppedChars = 0;
@@ -1243,6 +2965,8 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
       removeTermBlurListener = null;
       try { removeScrollListener?.(); } catch {}
       removeScrollListener = null;
+      try { removeViewportScrollDebugListener?.(); } catch {}
+      removeViewportScrollDebugListener = null;
       // 释放终端与引用
       term?.dispose();
       term = null;
@@ -1251,6 +2975,10 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
       lastAuxMouseDownAt = 0;
       lastCtrlKeydownAt = 0;
       lastScrollSnapshot = null;
+      lastViewportScrollLogAt = 0;
+      lastViewportScrollTop = null;
+      lastBufferScrollLogAt = 0;
+      lastBufferViewportY = null;
     }
   };
 }

--- a/web/src/app/app-shared.tsx
+++ b/web/src/app/app-shared.tsx
@@ -1971,7 +1971,7 @@ function TerminalView({
   }, [mounted, triggerScrollChrome]);
   return (
     <div
-      className="relative h-full min-h-0 group/terminal"
+      className="relative h-full min-h-0 min-w-0 overflow-hidden group/terminal"
       onContextMenu={(event) => {
         if (onContextMenuDebug) {
           onContextMenuDebug(event);
@@ -1981,13 +1981,13 @@ function TerminalView({
       {/* 外层容器负责视觉（圆角/背景/阴影），并裁剪内部，保证四角对称 */}
       <div
         ref={chromeRef}
-        className="cf-terminal-chrome h-full min-h-[320px] w-full rounded-lg overflow-hidden border [background-clip:padding-box]"
+        className="cf-terminal-chrome h-full min-h-[320px] min-w-0 w-full rounded-lg overflow-hidden border [background-clip:padding-box]"
         style={frameStyle}
         onMouseEnter={() => triggerScrollChrome(1400)}
         onMouseLeave={deactivateScrollChrome}
       >
         {/* 纯净宿主：无 padding/滚动，避免 fit 计算偏差；xterm 内部自带滚动 */}
-        <div ref={hostRef} className="h-full w-full overflow-hidden" />
+        <div ref={hostRef} className="h-full min-w-0 w-full overflow-hidden" />
         {/* 初始占位：终端挂载后隐藏，避免与 xterm 重叠 */}
         <pre className={`whitespace-pre-wrap font-mono text-sm leading-6 p-3 opacity-70 ${mounted ? 'hidden' : ''}`} style={{ color: placeholderColor }}>
           {logs.length === 0 ? (

--- a/web/src/components/ui/path-chips-input.tsx
+++ b/web/src/components/ui/path-chips-input.tsx
@@ -68,6 +68,13 @@ export interface PathChipsInputProps extends Omit<React.InputHTMLAttributes<HTML
   onWarnOutsideProjectDropChange?: (enabled: boolean) => void | Promise<void>;
 }
 
+/**
+ * 中文说明：读取终端前端诊断日志开关，默认关闭。
+ */
+function isTerminalFrontendDebugEnabled(): boolean {
+  try { return !!(globalThis as any).__cf_term_debug__; } catch { return false; }
+}
+
 function uid(): string {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
@@ -505,6 +512,10 @@ export default function PathChipsInput({
     draft: String(draft || ""),
     chips: cloneChipsForHistory(chips),
   });
+  const layoutStateRef = useRef<PathChipsValueState>({
+    draft: String(draft || ""),
+    chips: cloneChipsForHistory(chips),
+  });
   const historyRef = useRef<{
     past: PathChipsHistorySnapshot[];
     current: PathChipsHistorySnapshot | null;
@@ -550,7 +561,61 @@ export default function PathChipsInput({
   );
 
   // 由于 Chips 改为常规布局，不再依赖动态 padding-top；仅保留 ref 以备后用。
+  const rootRef = useRef<HTMLDivElement | null>(null);
   const chipsRef = useRef<HTMLDivElement | null>(null);
+  const lastLayoutLogRef = useRef<{ chipsSignature: string; draftLen: number; width: number; height: number; chipsHeight: number; inputHeight: number } | null>(null);
+
+  /**
+   * 中文说明：写入输入区布局诊断日志，记录 chip 与草稿变化是否伴随容器尺寸变化。
+   */
+  const logLayoutDiagnostic = useCallback((source: string) => {
+    try {
+      if (!isTerminalFrontendDebugEnabled()) return;
+      const root = rootRef.current;
+      if (!root) return;
+      const chipsNode = chipsRef.current;
+      const inputNode = inputRef.current;
+      const rootRect = root.getBoundingClientRect();
+      const chipsRect = chipsNode?.getBoundingClientRect() || null;
+      const inputRect = inputNode?.getBoundingClientRect() || null;
+      const currentState = layoutStateRef.current;
+      const nextState = {
+        chipsSignature: buildChipsStateSignature(currentState.chips),
+        draftLen: String(currentState.draft || "").length,
+        width: Math.round(rootRect.width),
+        height: Math.round(rootRect.height),
+        chipsHeight: Math.round(chipsRect?.height || 0),
+        inputHeight: Math.round(inputRect?.height || 0),
+      };
+      const prev = lastLayoutLogRef.current;
+      const shouldLog = !prev
+        || prev.chipsSignature !== nextState.chipsSignature
+        || (prev.draftLen > 0 && nextState.draftLen === 0)
+        || Math.abs(prev.width - nextState.width) > 1
+        || Math.abs(prev.height - nextState.height) > 1
+        || Math.abs(prev.chipsHeight - nextState.chipsHeight) > 1
+        || Math.abs(prev.inputHeight - nextState.inputHeight) > 1;
+      if (!shouldLog && source !== "resize-observer") return;
+      lastLayoutLogRef.current = nextState;
+      void (window as any).host?.utils?.perfLogCritical?.(
+        `[terminal.scroll-debug chips] ${source} chips=${currentState.chips.length} draftLen=${nextState.draftLen} root=${nextState.width}x${nextState.height} chipsH=${nextState.chipsHeight} inputH=${nextState.inputHeight}`,
+      );
+    } catch {}
+  }, []);
+
+  useLayoutEffect(() => {
+    logLayoutDiagnostic("render");
+  }, [chips, draft, logLayoutDiagnostic]);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      logLayoutDiagnostic("resize-observer");
+    });
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, [logLayoutDiagnostic]);
 
   // 右键菜单（打开所在文件夹 / 复制路径）
   const [ctxMenu, setCtxMenu] = useState<{ show: boolean; x: number; y: number; chip?: PathChip | null }>({ show: false, x: 0, y: 0, chip: null });
@@ -694,6 +759,7 @@ export default function PathChipsInput({
       chips: cloneChipsForHistory(chips),
     };
     valueStateRef.current = nextState;
+    layoutStateRef.current = nextState;
 
     const hist = historyRef.current;
     const nextSignature = buildValueStateSignature(nextState);
@@ -949,8 +1015,9 @@ export default function PathChipsInput({
       });
       const nextChips = buildMergedChips(items);
       applyValueChange({ chips: nextChips });
+      logLayoutDiagnostic("drop.paths");
     } catch {}
-  }, [applyValueChange, buildMergedChips, projectPathStyle, readCurrentValueState, runEnv, t, winRoot]);
+  }, [applyValueChange, buildMergedChips, logLayoutDiagnostic, projectPathStyle, readCurrentValueState, runEnv, t, winRoot]);
 
   /**
    * 打开“目录外资源提醒”弹窗，并缓存待处理的拖拽数据。
@@ -1161,12 +1228,14 @@ export default function PathChipsInput({
       } as any;
     });
     const nextChips = buildMergedChips(items);
-    return applyValueChange({
+    const ok = applyValueChange({
       chips: nextChips,
       draft: "",
       selection: createCollapsedSelection(0),
     });
-  }, [applyValueChange, buildMergedChips, projectPathStyle, readCurrentValueState, runEnv, t, winRoot]);
+    if (ok) logLayoutDiagnostic("draft.commit");
+    return ok;
+  }, [applyValueChange, buildMergedChips, logLayoutDiagnostic, projectPathStyle, readCurrentValueState, runEnv, t, winRoot]);
 
   const onKeyDown = (e: React.KeyboardEvent<any>) => {
     try { externalOnKeyDown && externalOnKeyDown(e); } catch {}
@@ -1262,6 +1331,7 @@ export default function PathChipsInput({
         chips: nextChips,
         selection: captureSelectionSnapshot(inputRef.current, latest.draft),
       });
+      logLayoutDiagnostic("paste.images");
     } catch {}
   };
 
@@ -1304,6 +1374,7 @@ export default function PathChipsInput({
           draft: next,
           selection: createCollapsedSelection(nextCaret),
         });
+        logLayoutDiagnostic("pick.file");
         // 关闭面板
         dismissedAtIndexRef.current = atIndexRef.current;
         atIndexRef.current = null;
@@ -1344,6 +1415,7 @@ export default function PathChipsInput({
           draft: next,
           selection: createCollapsedSelection(nextCaret),
         });
+        logLayoutDiagnostic("pick.rule");
         dismissedAtIndexRef.current = atIndexRef.current;
         atIndexRef.current = null;
         setQ("");
@@ -1372,6 +1444,7 @@ export default function PathChipsInput({
   return (
     <>
       <div
+        ref={rootRef}
         className={containerClass}
         onClick={() => { try { inputRef.current?.focus(); } catch {} }}
 	        onDragOver={(e) => { try { e.preventDefault(); e.dataTransfer!.dropEffect = 'copy'; } catch {} }}
@@ -1520,6 +1593,7 @@ export default function PathChipsInput({
                       chips: next,
                       selection: captureSelectionSnapshot(inputRef.current, current.draft),
                     });
+                    logLayoutDiagnostic("chip.delete");
                   }}
                 >
                   <span className="text-xs">×</span>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -451,6 +451,11 @@ body {
   --cf-terminal-scrollbar-border: rgba(255, 255, 255, 0.4);
   --cf-terminal-scrollbar-glow: rgba(15, 23, 42, 0.28);
 }
+.cf-terminal-chrome > div,
+.cf-terminal-chrome .xterm {
+  min-width: 0;
+  max-width: 100%;
+}
 .cf-terminal-chrome .xterm-viewport {
   background-color: var(--cf-terminal-bg, transparent) !important;
   scrollbar-width: thin;

--- a/web/src/lib/TerminalManager.ts
+++ b/web/src/lib/TerminalManager.ts
@@ -82,6 +82,18 @@ const GEMINI_WINDOWS_EDITOR_STATUS_TIMEOUT_MS = 15000;
 const GEMINI_EXTERNAL_EDITOR_AUTO_PROBE_TIMEOUT_MS = 3000;
 const GEMINI_WSL_EDITOR_TRIGGER_CHAR_THRESHOLD = 12000;
 const GEMINI_WSL_EDITOR_TRIGGER_DISPATCH_THRESHOLD_MS = 2500;
+const TERMINAL_PTY_RESIZE_STABLE_DELAY_MS = 220;
+const TERMINAL_PTY_RESIZE_MIN_INTERVAL_MS = 320;
+const TERMINAL_PTY_RESIZE_MAX_DEFER_MS = 1200;
+const TERMINAL_RESIZE_DEBOUNCE_MS = 150;
+const TERMINAL_WINDOW_RESIZE_FAST_DEBOUNCE_MS = 220;
+const TERMINAL_WINDOW_RESIZE_STABLE_DEBOUNCE_MS = 1280;
+const TERMINAL_WINDOW_RESIZE_STABLE_QUIET_MS = 1600;
+const TERMINAL_WINDOW_RESIZE_STABLE_RETRY_MS = 180;
+const TERMINAL_WINDOW_RESIZE_STABLE_SAMPLE_COUNT = 2;
+const TERMINAL_WINDOW_RESIZE_SESSION_IDLE_MS = 1800;
+const TERMINAL_WINDOW_RESIZE_SESSION_MAX_MS = 9000;
+const TERMINAL_HOST_LAYOUT_ANCESTOR_LIMIT = 12;
 
 /**
  * 渲染进程侧的 PTY 接口抽象，便于将 TerminalManager 从具体的 window.host.pty 解耦以实现复用。
@@ -100,6 +112,37 @@ export interface HostPtyAPI {
   onExit?: (handler: (payload: { id: string; exitCode?: number }) => void) => (() => void);
 }
 
+type ResizePtyPauseState = {
+  ptyId: string;
+  source: string;
+  since: number;
+  resumeRaf?: number;
+};
+
+type TerminalHostRectSnapshot = {
+  width: number;
+  height: number;
+  parentWidth: number;
+  parentHeight: number;
+};
+
+type WindowResizeDirection = "expand" | "shrink" | "mixed" | "unknown";
+
+type WindowResizeSessionState = {
+  startedAt: number;
+  lastActivityAt: number;
+  source: string;
+  lastRect?: TerminalHostRectSnapshot;
+  rectChangeCount: number;
+  direction: WindowResizeDirection;
+};
+
+type WindowResizeStableSample = {
+  size?: { cols: number; rows: number };
+  rect?: TerminalHostRectSnapshot;
+  count: number;
+};
+
 /**
  * TerminalManager 负责：
  * - 为每个 tab 创建并持有一个持久化的 DOM container（避免因 React 卸载而销毁 xterm 实例）
@@ -112,6 +155,30 @@ export default class TerminalManager {
   // 调试辅助：统一配置
   private dbgEnabled(): boolean { try { return !!(globalThis as any).__cf_term_debug__; } catch { return false; } }
   private dlog(msg: string): void { if (this.dbgEnabled()) { try { (window as any).host?.utils?.perfLog?.(`[tm] ${msg}`); } catch {} } }
+  /**
+   * 中文说明：写入终端滚动链路诊断日志；默认关闭，仅在终端前端调试开关开启时进入 perf.log。
+   */
+  private logScrollDiagnostic(message: string): void {
+    if (!this.dbgEnabled()) return;
+    try { void (window as any).host?.utils?.perfLogCritical?.(`[terminal.scroll-debug tm] ${message}`); } catch {}
+  }
+
+  /**
+   * 中文说明：格式化当前 tab 的宿主尺寸，辅助判断输入区高度变化是否触发终端 resize。
+   */
+  private formatHostRect(tabId: string): string {
+    try {
+      const host = this.hostElByTab[tabId];
+      if (!host) return "host=n/a";
+      const r = host.getBoundingClientRect();
+      const pr = host.parentElement ? host.parentElement.getBoundingClientRect() : null;
+      const style = window.getComputedStyle(host);
+      const hidden = style.display === "none" || style.visibility === "hidden";
+      return `host=${Math.round(r.width)}x${Math.round(r.height)} parent=${pr ? `${Math.round(pr.width)}x${Math.round(pr.height)}` : "n/a"} hidden=${hidden ? "1" : "0"}`;
+    } catch {
+      return "host=error";
+    }
+  }
   private sendTraceSeq = 0;
   private adapters: Record<string, TerminalAdapterAPI | null> = {};
   private containers: Record<string, HTMLDivElement | null> = {};
@@ -124,13 +191,487 @@ export default class TerminalManager {
   private lastSentSizeByTab: Record<string, { cols: number; rows: number } | undefined> = {};
   private pendingTimerByTab: Record<string, number | undefined> = {};
   private pendingSizeByTab: Record<string, { cols: number; rows: number } | undefined> = {};
+  private pendingPtyResizeTimerByTab: Record<string, number | undefined> = {};
+  private pendingPtyResizeSinceByTab: Record<string, number | undefined> = {};
+  private resizePtyPauseByTab: Record<string, ResizePtyPauseState | undefined> = {};
+  private lastPtyResizeAtByTab: Record<string, number | undefined> = {};
+  private windowResizeSessionByTab: Record<string, WindowResizeSessionState | undefined> = {};
+  private lastHostRectByTab: Record<string, TerminalHostRectSnapshot | undefined> = {};
   private isAnimatingByTab: Record<string, boolean> = {};
+  private resizeScheduleSeqByTab: Record<string, number | undefined> = {};
+  private resizeFlushSeqByTab: Record<string, number | undefined> = {};
+  private resizePtySeqByTab: Record<string, number | undefined> = {};
+  private adapterResizeReadyUnsubByTab: Record<string, (() => void) | null> = {};
   private hostElByTab: Record<string, HTMLElement | null> = {};
   private backlogHydratedPtyByTab: Record<string, string | undefined> = {};
+  private windowResizeStableSampleByTab: Record<string, WindowResizeStableSample | undefined> = {};
   private getPtyId: (tabId: string) => string | undefined;
   private hostPty: HostPtyAPI;
   private appearance: TerminalAppearance = normalizeTerminalAppearance();
   private lastFocusedTabId: string | null = null;
+
+  /**
+   * 生成 tab 内递增的 resize 调度序号。
+   */
+  private nextResizeScheduleSeq(tabId: string): number {
+    const next = (this.resizeScheduleSeqByTab[tabId] || 0) + 1;
+    this.resizeScheduleSeqByTab[tabId] = next;
+    return next;
+  }
+
+  /**
+   * 生成 tab 内递增的 resize flush 序号。
+   */
+  private nextResizeFlushSeq(tabId: string): number {
+    const next = (this.resizeFlushSeqByTab[tabId] || 0) + 1;
+    this.resizeFlushSeqByTab[tabId] = next;
+    return next;
+  }
+
+  /**
+   * 生成 tab 内递增的 PTY resize 序号。
+   */
+  private nextResizePtySeq(tabId: string): number {
+    const next = (this.resizePtySeqByTab[tabId] || 0) + 1;
+    this.resizePtySeqByTab[tabId] = next;
+    return next;
+  }
+
+  /**
+   * 获取当前高精度时间戳，用于 resize 防抖与日志。
+   */
+  private nowMs(): number {
+    return typeof performance !== "undefined" ? performance.now() : Date.now();
+  }
+
+  /**
+   * 格式化 resize 调度状态，用于串联 debounce、flush 与 PTY resize。
+   */
+  private formatResizeDebugState(tabId: string): string {
+    const last = this.lastSentSizeByTab[tabId];
+    const pending = this.pendingSizeByTab[tabId];
+    const pause = this.resizePtyPauseByTab[tabId];
+    const now = this.nowMs();
+    const lastPtyAt = this.lastPtyResizeAtByTab[tabId];
+    const windowSession = this.windowResizeSessionByTab[tabId];
+    const pendingPtySince = this.pendingPtyResizeSinceByTab[tabId];
+    const lastPtyAgo = typeof lastPtyAt === "number" ? Math.round(now - lastPtyAt) : "n/a";
+    const windowResizeAgo = windowSession ? Math.round(now - windowSession.lastActivityAt) : "n/a";
+    const windowSessionFor = windowSession ? Math.round(now - windowSession.startedAt) : "n/a";
+    const windowRectChanges = windowSession ? windowSession.rectChangeCount : "n/a";
+    const windowDirection = windowSession ? windowSession.direction : "n/a";
+    const pendingPtyFor = typeof pendingPtySince === "number" ? Math.round(now - pendingPtySince) : "n/a";
+    const pauseFor = pause ? Math.round(now - pause.since) : "n/a";
+    return `schedSeq=${this.resizeScheduleSeqByTab[tabId] || 0} flushSeq=${this.resizeFlushSeqByTab[tabId] || 0} ptySeq=${this.resizePtySeqByTab[tabId] || 0} pendingTimer=${typeof this.pendingTimerByTab[tabId] === "number" ? "1" : "0"} ptyDefer=${typeof this.pendingPtyResizeTimerByTab[tabId] === "number" ? "1" : "0"} ptyPaused=${pause ? "1" : "0"} ptyPausedFor=${pauseFor} lastSent=${last ? `${last.cols}x${last.rows}` : "n/a"} pending=${pending ? `${pending.cols}x${pending.rows}` : "n/a"} anim=${this.isAnimatingByTab[tabId] ? "1" : "0"} lastPtyAgo=${lastPtyAgo} winResizeAgo=${windowResizeAgo} winSessionFor=${windowSessionFor} winRectChanges=${windowRectChanges} winDir=${windowDirection} ptyDeferFor=${pendingPtyFor}`;
+  }
+
+  /**
+   * 判断两个终端尺寸是否完全一致。
+   * @param a 第一个尺寸
+   * @param b 第二个尺寸
+   */
+  private isSameTerminalSize(
+    a: { cols: number; rows: number } | undefined,
+    b: { cols: number; rows: number } | undefined,
+  ): boolean {
+    return !!a && !!b && a.cols === b.cols && a.rows === b.rows;
+  }
+
+  /**
+   * 读取宿主元素和父容器的当前布局尺寸，用于判断窗口 resize 会话是否仍在变化。
+   * @param tabId tab 标识
+   */
+  private readHostRectSnapshot(tabId: string): TerminalHostRectSnapshot | undefined {
+    try {
+      const host = this.hostElByTab[tabId];
+      if (!host) return undefined;
+      const r = host.getBoundingClientRect();
+      const pr = host.parentElement ? host.parentElement.getBoundingClientRect() : null;
+      return {
+        width: Math.round(r.width),
+        height: Math.round(r.height),
+        parentWidth: pr ? Math.round(pr.width) : -1,
+        parentHeight: pr ? Math.round(pr.height) : -1,
+      };
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * 判断两个宿主布局快照是否相同。
+   * @param a 第一个宿主布局快照
+   * @param b 第二个宿主布局快照
+   */
+  private isSameHostRectSnapshot(
+    a: TerminalHostRectSnapshot | undefined,
+    b: TerminalHostRectSnapshot | undefined,
+  ): boolean {
+    return !!a
+      && !!b
+      && a.width === b.width
+      && a.height === b.height
+      && a.parentWidth === b.parentWidth
+      && a.parentHeight === b.parentHeight;
+  }
+
+  /**
+   * 根据前后宿主尺寸判断窗口 resize 的主方向。
+   * @param previous 前一个宿主布局快照
+   * @param next 下一个宿主布局快照
+   */
+  private resolveWindowResizeDirection(
+    previous: TerminalHostRectSnapshot | undefined,
+    next: TerminalHostRectSnapshot | undefined,
+  ): WindowResizeDirection {
+    if (!previous || !next) return "unknown";
+    const widthDelta = next.width - previous.width;
+    const heightDelta = next.height - previous.height;
+    const meaningfulWidth = Math.abs(widthDelta) > 2;
+    const meaningfulHeight = Math.abs(heightDelta) > 2;
+    if (!meaningfulWidth && !meaningfulHeight) return "unknown";
+    if (widthDelta >= 0 && heightDelta >= 0 && (meaningfulWidth || meaningfulHeight)) return "expand";
+    if (widthDelta <= 0 && heightDelta <= 0 && (meaningfulWidth || meaningfulHeight)) return "shrink";
+    return "mixed";
+  }
+
+  /**
+   * 合并窗口 resize 方向，保留多段过程中出现的混合变化信号。
+   * @param previous 既有方向
+   * @param next 本次方向
+   */
+  private mergeWindowResizeDirection(
+    previous: WindowResizeDirection | undefined,
+    next: WindowResizeDirection,
+  ): WindowResizeDirection {
+    if (!previous || previous === "unknown") return next;
+    if (next === "unknown" || next === previous) return previous;
+    return "mixed";
+  }
+
+  /**
+   * 通知 Adapter 宿主布局 resize 已开始，用于提前保存底部跟随锚点。
+   * @param tabId tab 标识
+   * @param source 触发来源
+   */
+  private notifyAdapterLayoutResizeStart(tabId: string, source: string): void {
+    try {
+      this.adapters[tabId]?.notifyLayoutResizeStart?.(source);
+    } catch {}
+  }
+
+  /**
+   * 记录窗口 resize 会话活动，用于把 maximize/restore 及其后续 RO 布局反馈合并到最终尺寸。
+   * @param tabId tab 标识
+   * @param source 触发来源
+   */
+  private markWindowResizeActivity(tabId: string, source: string): void {
+    const now = this.nowMs();
+    const existing = this.getActiveWindowResizeSession(tabId);
+    const nextRect = this.readHostRectSnapshot(tabId);
+    const previousRect = existing?.lastRect ?? this.lastHostRectByTab[tabId];
+    if (source !== "window" && existing && this.isSameHostRectSnapshot(existing.lastRect, nextRect)) {
+      if (nextRect) this.lastHostRectByTab[tabId] = nextRect;
+      this.notifyAdapterLayoutResizeStart(tabId, source);
+      return;
+    }
+    const rectChanged = !this.isSameHostRectSnapshot(previousRect, nextRect);
+    const direction = this.mergeWindowResizeDirection(
+      existing?.direction,
+      this.resolveWindowResizeDirection(previousRect, nextRect),
+    );
+    if (rectChanged) {
+      delete this.windowResizeStableSampleByTab[tabId];
+    }
+    this.windowResizeSessionByTab[tabId] = {
+      startedAt: existing?.startedAt ?? now,
+      lastActivityAt: now,
+      source,
+      lastRect: nextRect ?? existing?.lastRect,
+      rectChangeCount: (existing?.rectChangeCount ?? 0) + (rectChanged ? 1 : 0),
+      direction,
+    };
+    if (nextRect) this.lastHostRectByTab[tabId] = nextRect;
+    this.notifyAdapterLayoutResizeStart(tabId, source);
+    this.logScrollDiagnostic(`window.resize tab=${tabId} source=${source} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+  }
+
+  /**
+   * 获取仍有效的窗口 resize 会话；超出空闲或最大持有时间后自动过期。
+   * @param tabId tab 标识
+   */
+  private getActiveWindowResizeSession(tabId: string): WindowResizeSessionState | undefined {
+    const session = this.windowResizeSessionByTab[tabId];
+    if (!session) return undefined;
+    const now = this.nowMs();
+    const sessionAge = now - session.startedAt;
+    const idleAge = now - session.lastActivityAt;
+    if (
+      sessionAge > TERMINAL_WINDOW_RESIZE_SESSION_MAX_MS
+      || idleAge > TERMINAL_WINDOW_RESIZE_SESSION_IDLE_MS
+    ) {
+      delete this.windowResizeSessionByTab[tabId];
+      delete this.windowResizeStableSampleByTab[tabId];
+      return undefined;
+    }
+    return session;
+  }
+
+  /**
+   * 判断当前是否仍处在窗口 resize 会话内。
+   * @param tabId tab 标识
+   */
+  private isWindowResizeSessionActive(tabId: string): boolean {
+    return !!this.getActiveWindowResizeSession(tabId);
+  }
+
+  /**
+   * 判断窗口 resize 会话是否需要等待稳定样本，避免 restore/shrink 中间尺寸逐段下发。
+   * @param session 窗口 resize 会话
+   */
+  private shouldWaitForWindowResizeStability(session: WindowResizeSessionState): boolean {
+    return session.direction !== "expand" || session.rectChangeCount > 1;
+  }
+
+  /**
+   * 获取本轮 resize 测量防抖延迟；窗口 maximize/restore 会话内使用更长窗口合并中间尺寸。
+   * @param tabId tab 标识
+   */
+  private getResizeDebounceDelay(tabId: string): number {
+    const session = this.getActiveWindowResizeSession(tabId);
+    if (!session) return TERMINAL_RESIZE_DEBOUNCE_MS;
+    const shouldWaitForStableRect = this.shouldWaitForWindowResizeStability(session);
+    return shouldWaitForStableRect
+      ? TERMINAL_WINDOW_RESIZE_STABLE_DEBOUNCE_MS
+      : TERMINAL_WINDOW_RESIZE_FAST_DEBOUNCE_MS;
+  }
+
+  /**
+   * 判断窗口 resize 会话中的 immediate 请求是否应保留既有防抖等待。
+   * @param tabId tab 标识
+   */
+  private shouldKeepPendingDebounceForWindowResizeImmediate(tabId: string): boolean {
+    if (typeof this.pendingTimerByTab[tabId] !== "number") return false;
+    const session = this.getActiveWindowResizeSession(tabId);
+    if (!session) return false;
+    return this.shouldWaitForWindowResizeStability(session);
+  }
+
+  /**
+   * 记录一次窗口 resize 稳定采样，返回连续一致次数。
+   * @param tabId tab 标识
+   * @param size 当前候选终端行列
+   * @param rect 当前宿主布局快照
+   */
+  private updateWindowResizeStableSample(
+    tabId: string,
+    size: { cols: number; rows: number } | undefined,
+    rect: TerminalHostRectSnapshot | undefined,
+  ): number {
+    const previous = this.windowResizeStableSampleByTab[tabId];
+    const same = this.isSameTerminalSize(previous?.size, size)
+      && this.isSameHostRectSnapshot(previous?.rect, rect);
+    const next: WindowResizeStableSample = {
+      size,
+      rect,
+      count: same ? (previous?.count || 0) + 1 : 1,
+    };
+    this.windowResizeStableSampleByTab[tabId] = next;
+    return next.count;
+  }
+
+  /**
+   * 在窗口 resize timer 触发时确认是否可以提交 PTY resize。
+   * @param tabId tab 标识
+   * @param adapter 终端适配器
+   * @param scheduleSeq 关联调度序号
+   */
+  private canFlushWindowResizeNow(
+    tabId: string,
+    adapter: TerminalAdapterAPI,
+    scheduleSeq: number,
+  ): { ok: boolean; reason: string; retryDelay: number } {
+    const session = this.getActiveWindowResizeSession(tabId);
+    if (!session || !this.shouldWaitForWindowResizeStability(session)) {
+      return { ok: true, reason: "not-window-stable-session", retryDelay: 0 };
+    }
+
+    const now = this.nowMs();
+    const rect = this.readHostRectSnapshot(tabId);
+    if (!rect) {
+      return { ok: true, reason: "no-host-rect", retryDelay: 0 };
+    }
+    const rectChanged = !this.isSameHostRectSnapshot(session.lastRect, rect);
+    if (rectChanged) {
+      const direction = this.mergeWindowResizeDirection(
+        session.direction,
+        this.resolveWindowResizeDirection(session.lastRect, rect),
+      );
+      this.windowResizeSessionByTab[tabId] = {
+        ...session,
+        lastActivityAt: now,
+        lastRect: rect ?? session.lastRect,
+        rectChangeCount: session.rectChangeCount + 1,
+        direction,
+      };
+      if (rect) this.lastHostRectByTab[tabId] = rect;
+      delete this.windowResizeStableSampleByTab[tabId];
+      return { ok: false, reason: "rect-changed", retryDelay: TERMINAL_WINDOW_RESIZE_STABLE_RETRY_MS };
+    }
+
+    const measured = this.measureAdapterResize(tabId, adapter, `stable-check#${scheduleSeq}`);
+    if (measured && measured.cols && measured.rows) {
+      this.pendingSizeByTab[tabId] = measured;
+    }
+    const pendingSize = this.pendingSizeByTab[tabId];
+    const sampleCount = this.updateWindowResizeStableSample(tabId, pendingSize, rect);
+    const sessionAge = Math.max(0, now - session.startedAt);
+    if (sessionAge >= TERMINAL_WINDOW_RESIZE_SESSION_MAX_MS) {
+      return { ok: true, reason: "session-max", retryDelay: 0 };
+    }
+
+    const idleAge = Math.max(0, now - session.lastActivityAt);
+    if (idleAge < TERMINAL_WINDOW_RESIZE_STABLE_QUIET_MS) {
+      const remaining = TERMINAL_WINDOW_RESIZE_STABLE_QUIET_MS - idleAge;
+      return {
+        ok: false,
+        reason: `quiet-${Math.round(idleAge)}`,
+        retryDelay: Math.max(TERMINAL_WINDOW_RESIZE_STABLE_RETRY_MS, Math.min(remaining, TERMINAL_WINDOW_RESIZE_STABLE_DEBOUNCE_MS)),
+      };
+    }
+
+    if (sampleCount < TERMINAL_WINDOW_RESIZE_STABLE_SAMPLE_COUNT) {
+      return { ok: false, reason: `sample-${sampleCount}`, retryDelay: TERMINAL_WINDOW_RESIZE_STABLE_RETRY_MS };
+    }
+
+    if (this.adapterHasPendingWriteWork(tabId)) {
+      return { ok: false, reason: "write-pending", retryDelay: Math.min(48, TERMINAL_WINDOW_RESIZE_STABLE_RETRY_MS) };
+    }
+
+    if (typeof this.pendingPtyResizeTimerByTab[tabId] === "number") {
+      return { ok: false, reason: "pty-defer-pending", retryDelay: Math.min(48, TERMINAL_WINDOW_RESIZE_STABLE_RETRY_MS) };
+    }
+
+    return { ok: true, reason: `stable-${sampleCount}`, retryDelay: 0 };
+  }
+
+  /**
+   * 设置 resize 防抖 timer；触发时先走窗口稳定门槛，未稳定则重排检查。
+   * @param tabId tab 标识
+   * @param scheduleSeq 关联调度序号
+   * @param delay 延迟毫秒
+   * @param reason 设置原因
+   */
+  private setResizeDebounceTimer(tabId: string, scheduleSeq: number, delay: number, reason: string): void {
+    const timerId = window.setTimeout(() => {
+      if (
+        typeof this.pendingTimerByTab[tabId] === "number"
+        && this.pendingTimerByTab[tabId] !== timerId
+      ) {
+        return;
+      }
+      this.pendingTimerByTab[tabId] = undefined;
+      this.logScrollDiagnostic(`schedule.timer.fire tab=${tabId} seq=${scheduleSeq} reason=${reason} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+      const adapter = this.adapters[tabId];
+      if (!adapter) return;
+      const stable = this.canFlushWindowResizeNow(tabId, adapter, scheduleSeq);
+      if (!stable.ok) {
+        this.logScrollDiagnostic(`schedule.stable.defer tab=${tabId} seq=${scheduleSeq} reason=${stable.reason} retry=${Math.round(stable.retryDelay)} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+        this.setResizeDebounceTimer(tabId, scheduleSeq, stable.retryDelay, `stable.${stable.reason}`);
+        return;
+      }
+      this.logScrollDiagnostic(`schedule.stable.ok tab=${tabId} seq=${scheduleSeq} reason=${stable.reason} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+      this.flushResizeIfNeeded(tabId, true);
+    }, delay);
+    this.pendingTimerByTab[tabId] = timerId;
+    this.logScrollDiagnostic(`schedule.timer.set tab=${tabId} seq=${scheduleSeq} delay=${Math.round(delay)} reason=${reason} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+  }
+
+  /**
+   * 归一化终端宿主链路的横向约束，避免 xterm 内容最小宽度反向挤压父级布局。
+   * @param hostEl 当前可见终端宿主元素
+   */
+  private normalizeTerminalHostLayout(hostEl: HTMLElement): void {
+    try {
+      const targets: HTMLElement[] = [];
+      let current: HTMLElement | null = hostEl;
+      while (current && targets.length < TERMINAL_HOST_LAYOUT_ANCESTOR_LIMIT) {
+        targets.push(current);
+        current = current.parentElement;
+      }
+      for (const el of targets) {
+        try {
+          el.style.minWidth = "0";
+          el.style.maxWidth = "100%";
+          el.style.boxSizing = "border-box";
+        } catch {}
+      }
+    } catch {}
+  }
+
+  /**
+   * 只测量 Adapter 当前候选行列，不提交本地 xterm resize。
+   * @param tabId tab 标识
+   * @param adapter 终端适配器
+   * @param source 测量来源
+   */
+  private measureAdapterResize(
+    tabId: string,
+    adapter: TerminalAdapterAPI,
+    source: string,
+  ): { cols: number; rows: number } | undefined {
+    try {
+      const measured = typeof adapter.measureResize === "function"
+        ? adapter.measureResize()
+        : adapter.resize();
+      if (measured && measured.cols && measured.rows) {
+        this.logScrollDiagnostic(`adapter.measure tab=${tabId} source=${source} size=${measured.cols}x${measured.rows} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+      }
+      return measured;
+    } catch {
+      this.logScrollDiagnostic(`adapter.measure.error tab=${tabId} source=${source} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+      return undefined;
+    }
+  }
+
+  /**
+   * 在 PTY resize 已发送或确认无需发送后，按同一行列提交本地 xterm resize。
+   * @param tabId tab 标识
+   * @param size 已提交给 PTY 的行列
+   * @param source 提交来源
+   * @param flushSeq 关联的 flush 序号
+   */
+  private commitAdapterResize(
+    tabId: string,
+    size: { cols: number; rows: number },
+    source: string,
+    flushSeq: number,
+  ): { cols: number; rows: number } | undefined {
+    const adapter = this.adapters[tabId];
+    if (!adapter) return undefined;
+    try {
+      const committed = typeof adapter.resizeTo === "function"
+        ? adapter.resizeTo(size, `pty.${source}#${flushSeq}`)
+        : adapter.resize();
+      this.logScrollDiagnostic(`adapter.commit tab=${tabId} seq=${flushSeq} source=${source} target=${size.cols}x${size.rows} actual=${committed?.cols || 0}x${committed?.rows || 0} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+      return committed;
+    } catch {
+      this.logScrollDiagnostic(`adapter.commit.error tab=${tabId} seq=${flushSeq} source=${source} target=${size.cols}x${size.rows} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+      return undefined;
+    }
+  }
+
+  /**
+   * 判断 Adapter 是否仍有旧 PTY 输出尚未写入本地 xterm。
+   * @param tabId tab 标识
+   */
+  private adapterHasPendingWriteWork(tabId: string): boolean {
+    try {
+      return !!this.adapters[tabId]?.hasPendingWriteWork?.();
+    } catch {
+      return false;
+    }
+  }
 
   /**
    * 中文说明：保存指定 tab 的滚动快照。
@@ -144,6 +685,7 @@ export default class TerminalManager {
       if (snapshot) {
         this.scrollSnapshotByTab[tabId] = snapshot;
         this.dlog(`scroll.save tab=${tabId} source=${source} y=${snapshot.viewportY}/${snapshot.baseY} bottom=${snapshot.isAtBottom ? '1' : '0'}`);
+        this.logScrollDiagnostic(`scroll.save tab=${tabId} source=${source} y=${Math.round(snapshot.viewportY)}/${Math.round(snapshot.baseY)} bottom=${snapshot.isAtBottom ? "1" : "0"} ${this.formatHostRect(tabId)}`);
       }
     } catch {}
   }
@@ -158,14 +700,15 @@ export default class TerminalManager {
     try {
       adapter.restoreScrollSnapshot?.(snapshot);
       this.dlog(`scroll.restore tab=${tabId} source=${source} has=${snapshot ? '1' : '0'}`);
+      this.logScrollDiagnostic(`scroll.restore tab=${tabId} source=${source} has=${snapshot ? "1" : "0"} y=${snapshot ? `${Math.round(snapshot.viewportY)}/${Math.round(snapshot.baseY)}` : "n/a"} ${this.formatHostRect(tabId)}`);
     } catch {}
   }
 
   /**
-   * 中文说明：判断当前发送是否需要输出强制诊断日志。
-   * 说明：仅对已知有“长文本发送时序问题”的 Provider 开启，避免 perf.log 噪音过大。
+   * 中文说明：判断当前发送是否需要生成诊断 traceId；实际写入还受终端前端调试开关控制。
+   * 说明：仅对已知有“长文本发送时序问题”的 Provider 开启，避免无关路径产生额外状态。
    * @param providerId providerId
-   * @returns 是否输出强制诊断日志
+   * @returns 是否生成发送诊断 traceId
    */
   private shouldTraceSendDiagnostics(providerId?: string | null): boolean {
     const normalized = String(providerId || "").trim().toLowerCase();
@@ -184,13 +727,13 @@ export default class TerminalManager {
   }
 
   /**
-   * 中文说明：写入单次发送的强制诊断日志。
-   * 说明：走 `perfLogCritical`，默认会写入 `perf.log`，无需依赖普通终端调试开关。
+   * 中文说明：写入单次发送诊断日志；默认关闭，仅在终端前端调试开关开启时进入 perf.log。
    * @param traceId 单次发送 traceId
    * @param message 诊断消息
    */
   private logSendDiagnostic(traceId: string | null | undefined, message: string): void {
     if (!traceId) return;
+    if (!this.dbgEnabled()) return;
     try { (window as any).host?.utils?.perfLogCritical?.(`[tm.send ${traceId}] ${message}`); } catch {}
   }
 
@@ -1388,24 +1931,296 @@ export default class TerminalManager {
     const t = this.pendingTimerByTab[tabId];
     if (typeof t === 'number') {
       try { clearTimeout(t); } catch {}
+      this.logScrollDiagnostic(`schedule.timer.clear tab=${tabId} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
     }
     this.pendingTimerByTab[tabId] = undefined;
   }
 
   /**
-   * 立即尝试下发尺寸（若可下发）。
-   * 与 ConPTY 做最小握手：暂停数据 -> 前端 fit -> 发送 resize -> 下一帧恢复。
+   * 清理某 tab 延迟下发 PTY resize 的定时器。
+   * @param tabId tab 标识
+   * @param source 清理来源
+   */
+  private clearPendingPtyResizeTimer(tabId: string, source: string): void {
+    const timer = this.pendingPtyResizeTimerByTab[tabId];
+    if (typeof timer === "number") {
+      try { clearTimeout(timer); } catch {}
+      this.logScrollDiagnostic(`flush.resize-pty.defer.clear tab=${tabId} source=${source} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+    }
+    this.pendingPtyResizeTimerByTab[tabId] = undefined;
+  }
+
+  /**
+   * 在真实 PTY resize 待稳定期间暂停 PTY 数据流，避免输出按旧尺寸生成后写入已 resize 的 xterm。
+   * @param tabId tab 标识
+   * @param ptyId PTY 标识
+   * @param source 触发来源
+   * @param flushSeq 关联的 flush 序号
+   */
+  private pausePtyForResizeSettle(tabId: string, ptyId: string, source: string, flushSeq: number): void {
+    const existing = this.resizePtyPauseByTab[tabId];
+    if (existing?.ptyId === ptyId) {
+      if (typeof existing.resumeRaf === "number") {
+        try { cancelAnimationFrame(existing.resumeRaf); } catch {}
+        existing.resumeRaf = undefined;
+      }
+      this.logScrollDiagnostic(`flush.pause.keep tab=${tabId} seq=${flushSeq} source=${source} reason=resize-settle pty=${ptyId} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+      return;
+    }
+    if (existing) {
+      this.resumePtyForResizeSettle(tabId, existing.ptyId, source, flushSeq, "pty-changed", true);
+    }
+    this.resizePtyPauseByTab[tabId] = {
+      ptyId,
+      source,
+      since: this.nowMs(),
+    };
+    try { this.hostPty.pause?.(ptyId); } catch {}
+    this.dlog(`pause pty=${ptyId} tab=${tabId} reason=resize-settle`);
+    this.logScrollDiagnostic(`flush.pause tab=${tabId} seq=${flushSeq} source=${source} reason=resize-settle pty=${ptyId} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+  }
+
+  /**
+   * 释放 resize 稳定窗口持有的 PTY 暂停；默认延后一帧恢复，让 xterm resize/refresh 先落到浏览器渲染队列。
+   * @param tabId tab 标识
+   * @param ptyId PTY 标识
+   * @param source 触发来源
+   * @param flushSeq 关联的 flush 序号
+   * @param reason 恢复原因
+   * @param immediate 是否立即恢复
+   */
+  private resumePtyForResizeSettle(
+    tabId: string,
+    ptyId: string,
+    source: string,
+    flushSeq: number,
+    reason: string,
+    immediate = false,
+  ): void {
+    const paused = this.resizePtyPauseByTab[tabId];
+    if (!paused || paused.ptyId !== ptyId) return;
+    if (typeof paused.resumeRaf === "number") {
+      try { cancelAnimationFrame(paused.resumeRaf); } catch {}
+      paused.resumeRaf = undefined;
+    }
+    const resume = () => {
+      if (this.resizePtyPauseByTab[tabId] !== paused) return;
+      const heldMs = Math.round(this.nowMs() - paused.since);
+      delete this.resizePtyPauseByTab[tabId];
+      try { this.hostPty.resume?.(ptyId); } catch {}
+      this.dlog(`resume pty=${ptyId} tab=${tabId} reason=${reason}`);
+      this.logScrollDiagnostic(`flush.resume tab=${tabId} seq=${flushSeq} source=${source} reason=${reason} held=${heldMs} pty=${ptyId} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+    };
+    if (immediate) {
+      resume();
+      return;
+    }
+    try {
+      paused.resumeRaf = requestAnimationFrame(resume);
+    } catch {
+      resume();
+    }
+  }
+
+  /**
+   * 通知适配器真实 PTY resize 已进入待下发窗口。
+   * @param tabId tab 标识
+   * @param size 目标行列
+   * @param source 触发来源
+   * @param flushSeq 关联的 flush 序号
+   */
+  private notifyAdapterPtyResizePending(
+    tabId: string,
+    size: { cols: number; rows: number },
+    source: string,
+    flushSeq: number,
+  ): void {
+    try {
+      this.adapters[tabId]?.notifyPtyResizePending?.(size, `${source}#${flushSeq}`);
+    } catch {}
+  }
+
+  /**
+   * 通知适配器真实 PTY resize 待下发窗口已经结束。
+   * @param tabId tab 标识
+   * @param size 目标行列
+   * @param source 触发来源
+   * @param flushSeq 关联的 flush 序号
+   * @param result 下发结果
+   */
+  private notifyAdapterPtyResizeComplete(
+    tabId: string,
+    size: { cols: number; rows: number },
+    source: string,
+    flushSeq: number,
+    result: "sent" | "skipped" | "failed",
+  ): void {
+    try {
+      this.adapters[tabId]?.notifyPtyResizeComplete?.(size, `${source}#${flushSeq}`, result);
+    } catch {}
+  }
+
+  /**
+   * 立即向 PTY 下发稳定后的终端尺寸，并在下发窗口内短暂停止数据流。
+   * @param tabId tab 标识
+   * @param ptyId PTY 标识
+   * @param size 目标行列
+   * @param source 下发来源
+   * @param flushSeq 关联的 flush 序号
+   */
+  private sendPtyResizeNow(
+    tabId: string,
+    ptyId: string,
+    size: { cols: number; rows: number },
+    source: string,
+    flushSeq: number,
+  ): void {
+    let resizeSent = false;
+    this.pausePtyForResizeSettle(tabId, ptyId, source, flushSeq);
+
+    try {
+      const ptySeq = this.nextResizePtySeq(tabId);
+      this.hostPty.resize(ptyId, size.cols, size.rows);
+      resizeSent = true;
+      this.dlog(`resize->pty tab=${tabId} ${size.cols}x${size.rows}`);
+      this.lastSentSizeByTab[tabId] = size;
+      this.lastPtyResizeAtByTab[tabId] = this.nowMs();
+      this.logScrollDiagnostic(`flush.resize-pty tab=${tabId} seq=${flushSeq} source=${source} ptySeq=${ptySeq} size=${size.cols}x${size.rows} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+      this.commitAdapterResize(tabId, size, source, flushSeq);
+    } catch {
+      // 即便失败也尝试恢复数据流。
+    } finally {
+      this.notifyAdapterPtyResizeComplete(tabId, size, source, flushSeq, resizeSent ? "sent" : "failed");
+      this.resumePtyForResizeSettle(tabId, ptyId, source, flushSeq, resizeSent ? "resize-sent" : "resize-failed");
+    }
+  }
+
+  /**
+   * 请求向 PTY 下发 resize；快速布局抖动期间只保留最终稳定尺寸。
+   * @param tabId tab 标识
+   * @param size 候选行列
+   * @param source 请求来源
+   * @param flushSeq 关联的 flush 序号
+   * @param force 是否按最终同步规则判定
+   */
+  private requestPtyResize(
+    tabId: string,
+    size: { cols: number; rows: number },
+    source: string,
+    flushSeq: number,
+    force: boolean,
+  ): void {
+    const ptyId = this.getPtyId(tabId);
+    if (!ptyId) return;
+    const previousPendingSize = this.pendingSizeByTab[tabId];
+    const hasActivePtyDefer = typeof this.pendingPtyResizeTimerByTab[tabId] === "number";
+    const sameActivePendingSize = hasActivePtyDefer && this.isSameTerminalSize(previousPendingSize, size);
+    this.pendingSizeByTab[tabId] = size;
+
+    if (!this.shouldSendResize(tabId, size, force)) {
+      this.clearPendingPtyResizeTimer(tabId, `${source}.same-size`);
+      delete this.pendingPtyResizeSinceByTab[tabId];
+      this.commitAdapterResize(tabId, size, source, flushSeq);
+      this.notifyAdapterPtyResizeComplete(tabId, size, source, flushSeq, "skipped");
+      this.resumePtyForResizeSettle(tabId, ptyId, source, flushSeq, "resize-skipped");
+      this.logScrollDiagnostic(`flush.resize-pty.defer.skip tab=${tabId} seq=${flushSeq} source=${source} force=${force ? "1" : "0"} reason=same-size size=${size.cols}x${size.rows} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+      return;
+    }
+
+    if (sameActivePendingSize) {
+      this.logScrollDiagnostic(`flush.resize-pty.defer.keep tab=${tabId} seq=${flushSeq} source=${source} force=${force ? "1" : "0"} reason=same-pending size=${size.cols}x${size.rows} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+      return;
+    }
+
+    this.notifyAdapterPtyResizePending(tabId, size, source, flushSeq);
+    this.pausePtyForResizeSettle(tabId, ptyId, source, flushSeq);
+
+    if (!this.lastSentSizeByTab[tabId]) {
+      this.clearPendingPtyResizeTimer(tabId, `${source}.initial`);
+      delete this.pendingPtyResizeSinceByTab[tabId];
+      this.sendPtyResizeNow(tabId, ptyId, size, source, flushSeq);
+      return;
+    }
+
+    const now = this.nowMs();
+    if (typeof this.pendingPtyResizeSinceByTab[tabId] !== "number") {
+      this.pendingPtyResizeSinceByTab[tabId] = now;
+    }
+    const pendingSince = this.pendingPtyResizeSinceByTab[tabId] || now;
+    const deferFor = Math.max(0, now - pendingSince);
+    const lastPtyAt = this.lastPtyResizeAtByTab[tabId];
+    const lastPtyAgo = typeof lastPtyAt === "number" ? Math.max(0, now - lastPtyAt) : TERMINAL_PTY_RESIZE_MIN_INTERVAL_MS;
+    const stableDelay = Math.max(
+      TERMINAL_PTY_RESIZE_STABLE_DELAY_MS,
+      TERMINAL_PTY_RESIZE_MIN_INTERVAL_MS - lastPtyAgo,
+      0,
+    );
+    const remainingMaxDelay = Math.max(0, TERMINAL_PTY_RESIZE_MAX_DEFER_MS - deferFor);
+    const delay = Math.min(stableDelay, remainingMaxDelay);
+
+    this.clearPendingPtyResizeTimer(tabId, `${source}.reschedule`);
+    this.logScrollDiagnostic(`flush.resize-pty.defer tab=${tabId} seq=${flushSeq} source=${source} force=${force ? "1" : "0"} delay=${Math.round(delay)} size=${size.cols}x${size.rows} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+    const fireDeferredResize = () => {
+      this.pendingPtyResizeTimerByTab[tabId] = undefined;
+      const adapter = this.adapters[tabId];
+      if (adapter) {
+        const measuredNow = this.measureAdapterResize(tabId, adapter, `defer.fire.${source}`);
+        if (measuredNow && measuredNow.cols && measuredNow.rows) {
+          this.pendingSizeByTab[tabId] = measuredNow;
+        }
+      }
+      const finalSize = this.pendingSizeByTab[tabId];
+      const currentPtyId = this.getPtyId(tabId);
+      if (!finalSize || !currentPtyId) {
+        delete this.pendingPtyResizeSinceByTab[tabId];
+        this.notifyAdapterPtyResizeComplete(tabId, finalSize || size, source, flushSeq, "skipped");
+        this.resumePtyForResizeSettle(tabId, ptyId, source, flushSeq, "resize-missing-final");
+        return;
+      }
+      const pendingSinceNow = this.pendingPtyResizeSinceByTab[tabId] || this.nowMs();
+      const deferForNow = Math.max(0, this.nowMs() - pendingSinceNow);
+      if (this.adapterHasPendingWriteWork(tabId) && deferForNow < TERMINAL_PTY_RESIZE_MAX_DEFER_MS) {
+        const waitDelay = Math.max(16, Math.min(48, TERMINAL_PTY_RESIZE_MAX_DEFER_MS - deferForNow));
+        this.logScrollDiagnostic(`flush.resize-pty.defer.wait-writes tab=${tabId} seq=${flushSeq} source=${source} delay=${Math.round(waitDelay)} size=${finalSize.cols}x${finalSize.rows} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+        this.pendingPtyResizeTimerByTab[tabId] = window.setTimeout(fireDeferredResize, waitDelay);
+        return;
+      }
+      this.logScrollDiagnostic(`flush.resize-pty.defer.fire tab=${tabId} seq=${flushSeq} source=${source} size=${finalSize.cols}x${finalSize.rows} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+      if (this.isHostInactive(tabId)) {
+        delete this.pendingPtyResizeSinceByTab[tabId];
+        this.notifyAdapterPtyResizeComplete(tabId, finalSize, source, flushSeq, "skipped");
+        this.resumePtyForResizeSettle(tabId, currentPtyId, source, flushSeq, "resize-host-inactive");
+        this.logScrollDiagnostic(`flush.resize-pty.defer.skip tab=${tabId} seq=${flushSeq} source=${source} reason=host-inactive size=${finalSize.cols}x${finalSize.rows} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+        return;
+      }
+      if (!this.shouldSendResize(tabId, finalSize, force)) {
+        delete this.pendingPtyResizeSinceByTab[tabId];
+        this.commitAdapterResize(tabId, finalSize, source, flushSeq);
+        this.notifyAdapterPtyResizeComplete(tabId, finalSize, source, flushSeq, "skipped");
+        this.resumePtyForResizeSettle(tabId, currentPtyId, source, flushSeq, "resize-same-size-final");
+        this.logScrollDiagnostic(`flush.resize-pty.defer.skip tab=${tabId} seq=${flushSeq} source=${source} force=${force ? "1" : "0"} reason=same-size-final size=${finalSize.cols}x${finalSize.rows} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+        return;
+      }
+      delete this.pendingPtyResizeSinceByTab[tabId];
+      this.sendPtyResizeNow(tabId, currentPtyId, finalSize, `deferred.${source}`, flushSeq);
+    };
+    this.pendingPtyResizeTimerByTab[tabId] = window.setTimeout(fireDeferredResize, delay);
+  }
+
+  /**
+   * 测量终端尺寸，并把真实 PTY resize 合并到稳定窗口后下发。
+   * @param tabId tab 标识
+   * @param force 是否由强制同步触发
    */
   private flushResizeIfNeeded(tabId: string, force = false): void {
     const adapter = this.adapters[tabId];
     if (!adapter) return;
     const ptyId = this.getPtyId(tabId);
     if (!ptyId) return;
+    const flushSeq = this.nextResizeFlushSeq(tabId);
+    this.logScrollDiagnostic(`flush.start tab=${tabId} seq=${flushSeq} force=${force ? "1" : "0"} pty=${ptyId} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
 
-    // 1) 暂停数据，避免旧尺寸数据在重排期间灌入 UI
-    try { this.hostPty.pause?.(ptyId); this.dlog(`pause pty=${ptyId} tab=${tabId}`); } catch {}
-
-    // 2) 记录宿主与父容器尺寸，并在 0/隐藏 时直接恢复退出（避免 11x6 抖动）
+    // 记录宿主与父容器尺寸，并在 0/隐藏 时直接退出，避免 11x6 抖动。
     try {
       const host = this.hostElByTab[tabId];
       if (host) {
@@ -1416,56 +2231,47 @@ export default class TerminalManager {
         const hidden = style.display === 'none' || style.visibility === 'hidden';
         if (hidden || r.height <= 1 || r.width <= 1) {
           this.dlog(`flush.skip tab=${tabId} hidden=${hidden} rect=${Math.round(r.width)}x${Math.round(r.height)}`);
-          try { this.hostPty.resume?.(ptyId); } catch {}
+          this.logScrollDiagnostic(`flush.skip tab=${tabId} seq=${flushSeq} reason=hidden-or-zero ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
           return;
         }
       }
     } catch {}
-    // 2b) 前端先精确 fit（内部可能 pin 整数行），拿到当前网格
+    // 先只测量候选行列，不提交本地 xterm resize；本地提交必须等 PTY resize 同步完成。
     let measured: { cols: number; rows: number } | undefined;
-    try {
-      measured = adapter.resize();
-    } catch {
-      // 防御：度量异常时确保恢复数据流，避免 PTY 长时间处于暂停状态
-      try { this.hostPty.resume?.(ptyId); } catch {}
+    measured = this.measureAdapterResize(tabId, adapter, `flush#${flushSeq}`);
+    if (!measured) {
+      this.logScrollDiagnostic(`flush.skip tab=${tabId} seq=${flushSeq} reason=measure-error ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
       return;
     }
     this.dlog(`measure tab=${tabId} size=${measured?.cols || 0}x${measured?.rows || 0} force=${force}`);
-    if (!measured || !measured.cols || !measured.rows) { try { this.hostPty.resume?.(ptyId); } catch {} return; }
-    // 记录最新一次测量，供后续判重
-    this.pendingSizeByTab[tabId] = measured;
-
-    // 若处于不可下发阶段，则不调用 PTY，等待后续 flush 时机
-    if (this.isHostInactive(tabId)) { this.dlog(`hostInactive tab=${tabId}`); try { this.hostPty.resume?.(ptyId); } catch {}; return; }
-
-    if (!this.shouldSendResize(tabId, measured, force)) { this.dlog(`skipResize tab=${tabId}`); try { this.hostPty.resume?.(ptyId); } catch {}; return; }
-    try {
-      this.hostPty.resize(ptyId, measured.cols, measured.rows);
-      this.dlog(`resize->pty tab=${tabId} ${measured.cols}x${measured.rows}`);
-      this.lastSentSizeByTab[tabId] = measured;
-    } catch {
-      // 即便失败也尝试恢复
-    } finally {
-      // 4) 让布局/ConPTY 重绘落地后再恢复
-      try {
-        requestAnimationFrame(() => { try { this.hostPty.resume?.(ptyId); this.dlog(`resume pty=${ptyId}`); } catch {} });
-      } catch { try { this.hostPty.resume?.(ptyId); this.dlog(`resume pty=${ptyId}`); } catch {} }
-
-      // 5) 尾帧校验：下一帧再次测量，如行列仍有差异，再下发一次 resize，确保最终一致
-      try {
-        requestAnimationFrame(() => {
-          try {
-            const again = adapter.resize();
-            this.dlog(`tail-measure tab=${tabId} size=${again?.cols || 0}x${again?.rows || 0}`);
-            if (again && again.cols && again.rows && this.shouldSendResize(tabId, again, true)) {
-              this.hostPty.resize(ptyId, again.cols, again.rows);
-              this.dlog(`tail-resize->pty tab=${tabId} ${again.cols}x${again.rows}`);
-              this.lastSentSizeByTab[tabId] = again;
-            }
-          } catch {}
-        });
-      } catch {}
+    this.logScrollDiagnostic(`flush.measure tab=${tabId} seq=${flushSeq} size=${measured?.cols || 0}x${measured?.rows || 0} force=${force ? "1" : "0"} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+    if (!measured || !measured.cols || !measured.rows) {
+      this.logScrollDiagnostic(`flush.skip tab=${tabId} seq=${flushSeq} reason=invalid-measure ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+      return;
     }
+
+    // 若处于不可下发阶段，则不调用 PTY，等待后续 flush 时机。
+    if (this.isHostInactive(tabId)) {
+      this.dlog(`hostInactive tab=${tabId}`);
+      this.logScrollDiagnostic(`flush.skip tab=${tabId} seq=${flushSeq} reason=host-inactive ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+      return;
+    }
+
+    this.requestPtyResize(tabId, measured, force ? "flush.force" : "flush", flushSeq, force);
+
+    // 尾帧校验只更新候选最终尺寸，不在同一帧直接反向下发 PTY resize。
+    try {
+      requestAnimationFrame(() => {
+        try {
+          const again = this.measureAdapterResize(tabId, adapter, `tail-measure#${flushSeq}`);
+          this.dlog(`tail-measure tab=${tabId} size=${again?.cols || 0}x${again?.rows || 0}`);
+          this.logScrollDiagnostic(`flush.tail-measure tab=${tabId} seq=${flushSeq} size=${again?.cols || 0}x${again?.rows || 0} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+          if (again && again.cols && again.rows) {
+            this.requestPtyResize(tabId, again, "tail-measure", flushSeq, true);
+          }
+        } catch {}
+      });
+    } catch {}
   }
 
   private blurTab(tabId: string, reason: string): void {
@@ -1496,11 +2302,15 @@ export default class TerminalManager {
    * 调度一次 resize 同步：
    * - immediate=true: 立刻尝试 flush。
    * - immediate=false: 150ms 防抖后 flush。
-   * 始终会优先更新前端画布（adapter.resize）。
+   * 这里只测量候选尺寸；本地 xterm resize 由 PTY resize 提交点统一触发。
    */
   private scheduleResizeSync(tabId: string, immediate: boolean): void {
     const adapter = this.adapters[tabId];
     if (!adapter) return;
+    const keepPendingWindowDebounce = immediate && this.shouldKeepPendingDebounceForWindowResizeImmediate(tabId);
+    const effectiveImmediate = immediate && !keepPendingWindowDebounce;
+    const scheduleSeq = this.nextResizeScheduleSeq(tabId);
+    this.logScrollDiagnostic(`schedule.start tab=${tabId} seq=${scheduleSeq} mode=${effectiveImmediate ? "immediate" : "debounce"} requested=${immediate ? "immediate" : "debounce"} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
     // 先判断宿主是否可测量；若为 0 或隐藏，则跳过本轮（避免 11x6 抖动）
     try {
       const host = this.hostElByTab[tabId];
@@ -1510,27 +2320,33 @@ export default class TerminalManager {
         const hidden = style.display === 'none' || style.visibility === 'hidden';
         if (hidden || rect.height <= 1 || rect.width <= 1) {
           this.dlog(`schedule.skip tab=${tabId} hidden=${hidden} rect=${Math.round(rect.width)}x${Math.round(rect.height)}`);
+          this.logScrollDiagnostic(`schedule.skip tab=${tabId} seq=${scheduleSeq} reason=hidden-or-zero ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
           return;
         }
       }
     } catch {}
-    // 可测量时，更新画布并记录测量
-    try {
-      const s = adapter.resize();
-      if (s && s.cols && s.rows) { this.pendingSizeByTab[tabId] = s; this.dlog(`schedule(${immediate ? 'immediate' : 'debounce'}) tab=${tabId} measure=${s.cols}x${s.rows}`); }
-    } catch {}
+    const s = this.measureAdapterResize(tabId, adapter, `schedule#${scheduleSeq}`);
+    if (s && s.cols && s.rows) {
+      this.pendingSizeByTab[tabId] = s;
+      this.dlog(`schedule(${effectiveImmediate ? 'immediate' : 'debounce'}) tab=${tabId} measure=${s.cols}x${s.rows}`);
+      this.logScrollDiagnostic(`schedule.measure tab=${tabId} seq=${scheduleSeq} mode=${effectiveImmediate ? "immediate" : "debounce"} requested=${immediate ? "immediate" : "debounce"} size=${s.cols}x${s.rows} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+    }
 
-    if (immediate) {
+    if (effectiveImmediate) {
       this.clearPendingTimer(tabId);
+      this.logScrollDiagnostic(`schedule.flush-now tab=${tabId} seq=${scheduleSeq} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
       this.flushResizeIfNeeded(tabId, true);
       return;
     }
 
+    if (keepPendingWindowDebounce) {
+      this.logScrollDiagnostic(`schedule.immediate-defer.keep tab=${tabId} seq=${scheduleSeq} reason=window-resize-pending ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+      return;
+    }
+
     this.clearPendingTimer(tabId);
-    this.pendingTimerByTab[tabId] = window.setTimeout(() => {
-      // 尾触发一次“精确同步”，避免最终只有 1 列/1 行差异时前后端网格不一致
-      this.flushResizeIfNeeded(tabId, true);
-    }, 150);
+    const delay = this.getResizeDebounceDelay(tabId);
+    this.setResizeDebounceTimer(tabId, scheduleSeq, delay, "schedule");
   }
 
   /**
@@ -1539,8 +2355,15 @@ export default class TerminalManager {
   private installHostEventHandlers(tabId: string, hostEl: HTMLElement): () => void {
     const onUp = () => { try { this.scheduleResizeSync(tabId, true); } catch {} };
     const onVisibility = () => { if (!document.hidden) { try { this.scheduleResizeSync(tabId, true); } catch {} } };
-    const onAnimStart = () => { this.isAnimatingByTab[tabId] = true; };
-    const onAnimEnd = () => { this.isAnimatingByTab[tabId] = false; try { this.scheduleResizeSync(tabId, true); } catch {} };
+    const onAnimStart = (event: Event) => {
+      if (event.target !== hostEl) return;
+      this.isAnimatingByTab[tabId] = true;
+    };
+    const onAnimEnd = (event: Event) => {
+      if (event.target !== hostEl) return;
+      this.isAnimatingByTab[tabId] = false;
+      try { this.scheduleResizeSync(tabId, true); } catch {}
+    };
 
     window.addEventListener('mouseup', onUp);
     window.addEventListener('pointerup', onUp);
@@ -1576,7 +2399,10 @@ export default class TerminalManager {
       container = document.createElement('div');
       container.style.height = '100%';
       container.style.width = '100%';
+      container.style.minWidth = '0';
+      container.style.maxWidth = '100%';
       container.style.boxSizing = 'border-box';
+      container.style.contain = 'inline-size';
       // 终端宿主不应产生滚动条，否则会干扰 xterm 内部滚动度量
       container.style.overflow = 'hidden';
       this.containers[tabId] = container;
@@ -1586,6 +2412,12 @@ export default class TerminalManager {
       if (!adapter) {
         adapter = createTerminalAdapter({ appearance: this.appearance });
         this.adapters[tabId] = adapter;
+      }
+      if (!this.adapterResizeReadyUnsubByTab[tabId]) {
+        this.adapterResizeReadyUnsubByTab[tabId] = adapter.onDeferredResizeReady?.(() => {
+          this.logScrollDiagnostic(`adapter.resize.defer.ready tab=${tabId} ${this.formatResizeDebugState(tabId)} ${this.formatHostRect(tabId)}`);
+          try { this.scheduleResizeSync(tabId, true); } catch {}
+        }) ?? null;
       }
       try { adapter.setAppearance(this.appearance); } catch {}
       try { adapter.mount(container); } catch (err) { console.warn('adapter.mount failed', err); }
@@ -1597,6 +2429,7 @@ export default class TerminalManager {
 
     if (!this.windowResizeCleanupByTab[tabId]) {
       const onResize = () => {
+        try { this.markWindowResizeActivity(tabId, "window"); } catch {}
         try { this.scheduleResizeSync(tabId, false); } catch {}
       };
       window.addEventListener('resize', onResize);
@@ -1903,6 +2736,7 @@ export default class TerminalManager {
    */
   onTabActivated(tabId: string): void {
     this.dlog(`tabActivated tab=${tabId}`);
+    this.logScrollDiagnostic(`tab.activate tab=${tabId} ${this.formatHostRect(tabId)}`);
     if (this.lastFocusedTabId && this.lastFocusedTabId !== tabId) {
       this.blurTab(this.lastFocusedTabId, "switch");
     }
@@ -1935,6 +2769,7 @@ export default class TerminalManager {
   onTabDeactivated(tabId: string | null | undefined): void {
     if (!tabId) return;
     this.dlog(`tabDeactivated tab=${tabId}`);
+    this.logScrollDiagnostic(`tab.deactivate tab=${tabId} ${this.formatHostRect(tabId)}`);
     if (this.lastFocusedTabId === tabId) {
       this.lastFocusedTabId = null;
     }
@@ -1948,6 +2783,7 @@ export default class TerminalManager {
    */
   attachToHost(tabId: string, hostEl: HTMLElement): void {
     this.dlog(`attachToHost tab=${tabId}`);
+    this.logScrollDiagnostic(`attach.start tab=${tabId} ${this.formatHostRect(tabId)}`);
     // 关键修复：重复挂载时需先清理旧的宿主事件，避免全局监听器累积导致内存泄漏。
     const existingCleanup = this.resizeUnsubByTab[tabId];
     if (typeof existingCleanup === 'function') {
@@ -1965,6 +2801,10 @@ export default class TerminalManager {
     } catch (err) { console.warn('attachToHost failed', err); }
     // 记录 hostEl，安装事件以感知动画/可见性变化
     this.hostElByTab[tabId] = hostEl;
+    this.normalizeTerminalHostLayout(hostEl);
+    this.lastHostRectByTab[tabId] = this.readHostRectSnapshot(tabId);
+    delete this.windowResizeStableSampleByTab[tabId];
+    this.logScrollDiagnostic(`attach.host-set tab=${tabId} ${this.formatHostRect(tabId)}`);
     const removeHostHandlers = this.installHostEventHandlers(tabId, hostEl);
 
     // 触发一次同步（立即 flush）
@@ -1990,6 +2830,10 @@ export default class TerminalManager {
             const r = host.getBoundingClientRect();
             const pr = host.parentElement ? host.parentElement.getBoundingClientRect() : null;
             this.dlog(`ro.cb tab=${tabId} host=${Math.round(r.width)}x${Math.round(r.height)} parent=${pr ? `${Math.round(pr.width)}x${Math.round(pr.height)}` : 'n/a'}`);
+            this.logScrollDiagnostic(`ro.cb tab=${tabId} host=${Math.round(r.width)}x${Math.round(r.height)} parent=${pr ? `${Math.round(pr.width)}x${Math.round(pr.height)}` : 'n/a'} ${this.formatHostRect(tabId)}`);
+            if (this.isWindowResizeSessionActive(tabId)) {
+              this.markWindowResizeActivity(tabId, "ro");
+            }
           }
         } catch {}
         try {
@@ -2008,8 +2852,10 @@ export default class TerminalManager {
         try { removeHostHandlers(); } catch {}
         this.hostResizeObserverByTab[tabId] = null;
       };
+      this.logScrollDiagnostic(`attach.ro-ready tab=${tabId} ${this.formatHostRect(tabId)}`);
     } catch (err) {
       // If ResizeObserver is not available or errors, fall back to window resize (already registered)
+      this.logScrollDiagnostic(`attach.ro-fallback tab=${tabId} err=${String((err as Error)?.message || err)} ${this.formatHostRect(tabId)}`);
     }
   }
 
@@ -2027,9 +2873,25 @@ export default class TerminalManager {
     delete this.windowResizeCleanupByTab[tabId];
     // 清理定时器与状态
     try { this.clearPendingTimer(tabId); } catch {}
+    try { this.clearPendingPtyResizeTimer(tabId, "dispose"); } catch {}
+    const paused = this.resizePtyPauseByTab[tabId];
+    if (paused) {
+      try { this.resumePtyForResizeSettle(tabId, paused.ptyId, "dispose", this.resizeFlushSeqByTab[tabId] || 0, "dispose", true); } catch {}
+    }
     delete this.pendingSizeByTab[tabId];
+    delete this.pendingPtyResizeSinceByTab[tabId];
+    delete this.resizePtyPauseByTab[tabId];
+    delete this.lastPtyResizeAtByTab[tabId];
+    delete this.windowResizeSessionByTab[tabId];
     delete this.lastSentSizeByTab[tabId];
+    delete this.lastHostRectByTab[tabId];
     delete this.isAnimatingByTab[tabId];
+    delete this.resizeScheduleSeqByTab[tabId];
+    delete this.resizeFlushSeqByTab[tabId];
+    delete this.resizePtySeqByTab[tabId];
+    delete this.windowResizeStableSampleByTab[tabId];
+    try { this.adapterResizeReadyUnsubByTab[tabId]?.(); } catch {}
+    delete this.adapterResizeReadyUnsubByTab[tabId];
     delete this.hostElByTab[tabId];
     try { this.unsubByTab[tabId]?.(); } catch {}
     delete this.unsubByTab[tabId];


### PR DESCRIPTION
- 将终端 resize 拆分为候选测量与 PTY 同步提交，避免 xterm 行列抢跑后端输出
- 在窗口 resize、输入区高度变化和清屏重绘期间维护底部跟随与阅读锚点
- 为终端滚动和 resize 链路增加默认关闭的前端诊断日志
- 收紧 Git 过滤分页与更新配置测试，避免 Windows 并发 IO 下误报超时