### PR TITLE
feat(history): 支持引用历史会话文件到输入区

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Combobox } from "@/components/ui/combobox";
-import PathChipsInput, { type PathChip } from "@/components/ui/path-chips-input";
+import PathChipsInput, { buildPathChipFromPath, mergePathChips, type PathChip } from "@/components/ui/path-chips-input";
 import InteractiveImagePreview from "@/components/ui/interactive-image-preview";
 import { retainPreviewUrl, releasePreviewUrl } from "@/lib/previewUrlRegistry";
 import { retainPastedImage, releasePastedImage, requestTrashWinPath } from "@/lib/imageResourceRegistry";
@@ -30,6 +30,7 @@ import {
   CheckCircle2,
   MoreVertical,
   FileClock,
+  FileText,
   ChevronDown,
   ChevronUp,
   ChevronRight,
@@ -88,6 +89,7 @@ import { VirtualizedList, type VirtualizedListHandle } from "@/features/history/
 import { buildHistoryUserInputMessageKeys } from "@/features/history/user-input-anchors";
 import { applyHistoryFindHighlights, clearHistoryFindHighlights, setActiveHistoryFindMatch } from "@/features/history/find/history-find";
 import { toWSLForInsert } from "@/lib/wsl";
+import { probeWinPathKind, type WinPathProbeResult } from "@/lib/dragDrop";
 import { extractGeminiProjectHashFromPath, deriveGeminiProjectHashCandidatesFromPath } from "@/lib/gemini-hash";
 import { buildGeminiImageAttachmentToken, isGeminiImageChip } from "@/lib/gemini-attachments";
 import {
@@ -6442,6 +6444,53 @@ export default function CodexFlowManagerUI() {
     return parts.join("\n");
   }
 
+  /**
+   * 将历史会话文件作为输入附件追加到当前普通终端标签页，等价于把该文件拖入输入框。
+   */
+  const referenceHistorySessionInActiveInput = useCallback(async (session?: HistorySession | null): Promise<boolean> => {
+    const filePath = String(session?.filePath || "").trim();
+    if (!filePath) return false;
+    const targetTab = (activeTab && activeTab.kind !== "git")
+      ? activeTab
+      : (tabsForProject.find((tab) => tab.kind !== "git") || null);
+    if (!targetTab) {
+      setNoticeDialog({
+        open: true,
+        title: String(t("history:referenceInSession")),
+        message: String(t("history:referenceNoActiveInput")),
+      });
+      return false;
+    }
+
+    let probe: WinPathProbeResult | null = null;
+    try {
+      probe = await probeWinPathKind(filePath);
+    } catch {}
+    const execEnv = getTabExecEnv(targetTab.id, targetTab.providerId);
+    const chip = buildPathChipFromPath({
+      rawPath: filePath,
+      probe,
+      runEnv: execEnv.terminal as any,
+      winRoot: selectedProject?.winPath,
+      projectPathStyle,
+      fileNameFallback: session?.title || session?.id || "",
+    });
+    if (!chip) return false;
+
+    setChipsByTab((prev) => ({
+      ...prev,
+      [targetTab.id]: mergePathChips(prev[targetTab.id] || [], [chip]),
+    }));
+    try { setCenterMode("console"); } catch {}
+    setActiveTab(targetTab.id, { projectId: selectedProjectId, focusMode: "immediate", allowDuringRename: true, delay: 0 });
+    try {
+      requestAnimationFrame(() => {
+        try { scheduleFocusForTab(targetTab.id, { immediate: true, allowDuringRename: true }); } catch {}
+      });
+    } catch {}
+    return true;
+  }, [activeTab, getTabExecEnv, projectPathStyle, scheduleFocusForTab, selectedProject?.winPath, selectedProjectId, setActiveTab, tabsForProject, t]);
+
   const requestInputFullscreenOpen = useCallback((tabId: string) => {
     if (!tabId) return;
     const isClosing = !!inputFullscreenClosingTabs[tabId];
@@ -11199,6 +11248,19 @@ export default function CodexFlowManagerUI() {
 	                >
 	                  <ExternalLink className="h-4 w-4 text-[var(--cf-text-muted)]" /> {t('history:continueExternalWith', { env: resolveResumeShellLabel(historyCtxMenu.item?.filePath, historyCtxMenu.item) })}
 	                </button>
+                <button
+                  className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[var(--cf-text-primary)] rounded-apple-sm hover:bg-[var(--cf-surface-hover)] transition-all duration-apple-fast"
+                  onClick={async () => {
+                    try {
+                      await referenceHistorySessionInActiveInput(historyCtxMenu.item);
+                    } catch (err) {
+                      console.warn("reference history session failed", err);
+                    }
+                    setHistoryCtxMenu((m) => ({ ...m, show: false }));
+                  }}
+                >
+                  <FileText className="h-4 w-4 text-[var(--cf-text-muted)]" /> {t("history:referenceInSession")}
+                </button>
 	              </>
 	            ) : null}
                 <button

--- a/web/src/components/ui/path-chips-input.test.tsx
+++ b/web/src/components/ui/path-chips-input.test.tsx
@@ -3,7 +3,7 @@
 import React, { act, useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createRoot, type Root } from "react-dom/client";
-import PathChipsInput, { type PathChip } from "./path-chips-input";
+import PathChipsInput, { buildPathChipFromPath, mergePathChips, type PathChip } from "./path-chips-input";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -262,6 +262,41 @@ async function dispatchContextMenu(target: HTMLElement): Promise<{ allowed: bool
   });
   return { allowed, defaultPrevented: event.defaultPrevented };
 }
+
+describe("PathChipsInput 路径 Chip 构造", () => {
+  it("可将历史会话文件路径构造成目标终端可发送的文件 Chip", () => {
+    const chip = buildPathChipFromPath({
+      rawPath: "C:\\Example\\History\\session.jsonl",
+      probe: { kind: "file", exists: true, isDirectory: false, isFile: true },
+      runEnv: "pwsh",
+      winRoot: "C:\\Example\\Repo",
+      projectPathStyle: "relative",
+      fileNameFallback: "fallback",
+    });
+
+    expect(chip).not.toBeNull();
+    expect(chip?.chipKind).toBe("file");
+    expect((chip as any)?.isDir).toBe(false);
+    expect(chip?.fileName).toBe("session.jsonl");
+    expect(chip?.winPath).toBe("C:\\Example\\History\\session.jsonl");
+    expect(chip?.wslPath).toBe("/mnt/c/Example/History/session.jsonl");
+  });
+
+  it("合并路径 Chip 时应按稳定路径键去重", () => {
+    const first = buildPathChipFromPath({
+      rawPath: "C:\\Example\\History\\session.jsonl",
+      runEnv: "pwsh",
+    });
+    const duplicated = first ? { ...first, id: "duplicated-id" } : null;
+
+    expect(first).not.toBeNull();
+    expect(duplicated).not.toBeNull();
+    const merged = mergePathChips([first as PathChip], [duplicated as PathChip]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].id).toBe(first?.id);
+  });
+});
 
 describe("PathChipsInput（复制名称按钮）", () => {
   let cleanup: (() => void) | null = null;

--- a/web/src/components/ui/path-chips-input.tsx
+++ b/web/src/components/ui/path-chips-input.tsx
@@ -68,6 +68,15 @@ export interface PathChipsInputProps extends Omit<React.InputHTMLAttributes<HTML
   onWarnOutsideProjectDropChange?: (enabled: boolean) => void | Promise<void>;
 }
 
+export type BuildPathChipFromPathOptions = {
+  rawPath: string;
+  probe?: WinPathProbeResult | null;
+  runEnv?: PathChipsInputProps["runEnv"];
+  winRoot?: string;
+  projectPathStyle?: "absolute" | "relative";
+  fileNameFallback?: string;
+};
+
 /**
  * 中文说明：读取终端前端诊断日志开关，默认关闭。
  */
@@ -209,7 +218,7 @@ function buildChipPaths(args: {
 /**
  * 中文说明：按路径候选推断 Chip 类型，统一保证图片文件在 Gemini 场景下能走图片附件语义。
  */
-function resolvePathChipKind(args: { fileName?: string; isImage?: boolean; chipKind?: PathChip["chipKind"] }): PathChip["chipKind"] {
+export function resolvePathChipKind(args: { fileName?: string; isImage?: boolean; chipKind?: PathChip["chipKind"] }): PathChip["chipKind"] {
   if (args.chipKind === "rule") return "rule";
   if (args.isImage) return "image";
   if (isImageFileName(args.fileName)) return "image";
@@ -290,7 +299,10 @@ function normalizeWslPathForDedupe(p: string): string {
   } catch { return String(p || ""); }
 }
 
-function buildChipDedupeKey(chip: Partial<PathChip>): string {
+/**
+ * 生成用于 PathChip 去重的稳定键，优先使用 Windows 路径，其次使用 WSL 路径。
+ */
+export function buildPathChipDedupeKey(chip: Partial<PathChip>): string {
   try {
     const wp = String((chip as any)?.winPath || "").trim();
     const wsl = String((chip as any)?.wslPath || "").trim();
@@ -299,6 +311,61 @@ function buildChipDedupeKey(chip: Partial<PathChip>): string {
     const name = String((chip as any)?.fileName || "").trim();
     return name ? `name:${name}` : "";
   } catch { return ""; }
+}
+
+/**
+ * 将单个路径转换为输入框可展示/发送的 PathChip，供拖拽与外部菜单入口复用。
+ */
+export function buildPathChipFromPath(args: BuildPathChipFromPathOptions): PathChip | null {
+  const rawPath = String(args.rawPath || "").trim();
+  if (!rawPath) return null;
+  const paths = buildChipPaths({
+    rawPath,
+    runEnv: args.runEnv,
+    winRoot: args.winRoot,
+    projectPathStyle: args.projectPathStyle,
+  });
+  const probe = args.probe || null;
+  const isDir = probe?.kind === "directory";
+  const isImage = !isDir && isImageFileName(rawPath);
+  const labelBase = (paths.pathText === ".")
+    ? (rawPath.split(/[/\\]/).pop() || ".")
+    : ((paths.pathText || rawPath).split(/[/\\]/).pop() || "");
+  const fallbackName = String(args.fileNameFallback || "").trim();
+  return {
+    id: uid(),
+    blob: new Blob(),
+    previewUrl: "",
+    type: "text/path",
+    size: 0,
+    saved: true,
+    winPath: paths.winPath,
+    wslPath: paths.wslPath,
+    fileName: labelBase || fallbackName || "path",
+    fromPaste: false,
+    isDir,
+    chipKind: resolvePathChipKind({ fileName: labelBase || fallbackName, isImage }),
+  } as any;
+}
+
+/**
+ * 合并 Chip 列表并按路径稳定键去重，确保菜单引用与拖拽追加行为一致。
+ */
+export function mergePathChips(current: PathChip[], incoming: PathChip[]): PathChip[] {
+  const merged = [
+    ...(Array.isArray(current) ? current : []),
+    ...(Array.isArray(incoming) ? incoming.map((chip) => ({ ...(chip as any) })) : []),
+  ];
+  const seen = new Set<string>();
+  const unique: PathChip[] = [];
+  for (const chip of merged) {
+    const key = buildPathChipDedupeKey(chip) || buildChipStableKey(chip, String(unique.length));
+    const sig = `k:${key}`;
+    if (seen.has(sig)) continue;
+    seen.add(sig);
+    unique.push(chip);
+  }
+  return unique;
 }
 
 const MAX_INPUT_HISTORY_ENTRIES = 120;
@@ -683,18 +750,7 @@ export default function PathChipsInput({
    */
   const buildMergedChips = useCallback((items: SavedImage[]): PathChip[] => {
     const current = readCurrentValueState();
-    const merged = [...current.chips, ...items.map((it) => ({ ...it }))];
-    const seen = new Set<string>();
-    const unique: PathChip[] = [];
-    for (const chip of merged) {
-      const k = buildChipDedupeKey(chip);
-      const key = k || buildChipStableKey(chip, String(unique.length));
-      const sig = `k:${key}`;
-      if (seen.has(sig)) continue;
-      seen.add(sig);
-      unique.push(chip);
-    }
-    return unique;
+    return mergePathChips(current.chips, items as PathChip[]);
   }, [readCurrentValueState]);
 
   /**
@@ -938,7 +994,7 @@ export default function PathChipsInput({
       const current = readCurrentValueState();
       const existingKeys = new Set<string>();
       for (const chip of current.chips) {
-        const k = buildChipDedupeKey(chip);
+        const k = buildPathChipDedupeKey(chip);
         if (k) existingKeys.add(k);
       }
       const localKeys = new Set<string>();
@@ -956,7 +1012,7 @@ export default function PathChipsInput({
         const labelBase = (paths.pathText === ".")
           ? (String(wp).split(/[/\\]/).pop() || ".")
           : ((paths.pathText || wp).split(/[/\\]/).pop() || "");
-        const key = buildChipDedupeKey({
+        const key = buildPathChipDedupeKey({
           winPath: paths.winPath,
           wslPath: paths.wslPath,
           fileName: labelBase,

--- a/web/src/locales/en/history.json
+++ b/web/src/locales/en/history.json
@@ -18,6 +18,8 @@
   "noMatch": "No matching history",
   "copyImage": "Copy Image",
   "copyPath": "Copy Path",
+  "referenceInSession": "Reference in Session",
+  "referenceNoActiveInput": "No terminal input is available to receive this reference.",
   "linkMenuSetProjectIde": "Set IDE for This Project",
   "linkMenuUseVsCode": "Use VS Code",
   "linkMenuUseCursor": "Use Cursor",

--- a/web/src/locales/zh/history.json
+++ b/web/src/locales/zh/history.json
@@ -18,6 +18,8 @@
   "noMatch": "无匹配历史",
   "copyImage": "复制图片",
   "copyPath": "复制路径",
+  "referenceInSession": "在会话中引用",
+  "referenceNoActiveInput": "当前没有可接收引用的终端输入框",
   "linkMenuSetProjectIde": "设置当前项目 IDE",
   "linkMenuUseVsCode": "使用 VS Code",
   "linkMenuUseCursor": "使用 Cursor",


### PR DESCRIPTION
- 在历史列表右键菜单新增“在会话中引用”，将历史会话文件复用 PathChip 加入当前普通终端输入区。
- 抽取路径 Chip 构造与合并去重逻辑，确保菜单引用与拖拽路径追加保持一致。
- 使用应用内 Dialog 提示无可接收输入终端的场景，避免原生 alert。
- 补充中英文历史文案与 PathChip 构造/去重单测。

审查与验证:
- npm run i18n:check
- npm run build:web
- npm run test -- --run