### PR TITLE
fix(git): 修复 Fetch 对话框 Hook 顺序

### DIFF
--- a/web/src/features/git/fetch-dialog.test.tsx
+++ b/web/src/features/git/fetch-dialog.test.tsx
@@ -46,6 +46,43 @@ afterEach(() => {
 });
 
 describe("FetchDialog", () => {
+  it("从关闭态打开时应保持 Hook 调用顺序稳定", async () => {
+    const mounted = createMountedRoot();
+    const props = {
+      repositories: [{
+        repoRoot: "/repo/app",
+        label: "/repo/app",
+        defaultRemote: "origin",
+        remotes: [{ name: "origin" }],
+      }],
+      value: {
+        repoRoot: "/repo/app",
+        mode: "default-remote" as const,
+        remote: "origin",
+        refspec: "",
+        unshallow: false,
+        tagMode: "auto" as const,
+      },
+      submitting: false,
+      onClose: () => {},
+      onChange: () => {},
+      onSubmit: () => {},
+    };
+    try {
+      await act(async () => {
+        mounted.root.render(<FetchDialog open={false} {...props} />);
+      });
+      await act(async () => {
+        mounted.root.render(<FetchDialog open={true} {...props} />);
+      });
+
+      expect(document.body.textContent).toContain("获取远端变更");
+      expect(document.body.textContent).toContain("git fetch origin");
+    } finally {
+      mounted.unmount();
+    }
+  });
+
   it("应渲染多 root fetch 参数，并显示具体命令预览", async () => {
     const mounted = createMountedRoot();
     const onClose = vi.fn();

--- a/web/src/features/git/fetch-dialog.tsx
+++ b/web/src/features/git/fetch-dialog.tsx
@@ -100,11 +100,11 @@ export function FetchDialog(props: GitFetchDialogProps): JSX.Element | null {
     onChange,
     onSubmit,
   } = props;
-  if (!open) return null;
 
   const gt = React.useCallback((key: string, fallback: string, values?: Record<string, unknown>): string => {
     return resolveGitTextWith(t, key, fallback, values);
   }, [t]);
+  if (!open) return null;
 
   const selectedRepository = resolveSelectedRepository(repositories, value.repoRoot);
   const selectedRemote = String(value.remote || "").trim();


### PR DESCRIPTION
- 将 FetchDialog 的 i18n 回退回调 Hook 固定在 open 早返回之前，避免关闭态切到打开态时触发 React Hook 数量变化错误。
- 补充 Fetch 对话框关闭态打开的回归测试，确认 Git Fetch 命令预览可正常渲染。

审查与验证:
- npm run test
- npm run i18n:check