### PR TITLE
fix(worktree): 修复基线分支失效时删除 worktree 失败

### DIFF
--- a/electron/git/worktreeOps.ts
+++ b/electron/git/worktreeOps.ts
@@ -234,6 +234,35 @@ async function hasDirtyWorktreeForRemoveAsync(args: {
 }
 
 /**
+ * 校验 Git 引用是否能解析到提交对象。
+ * - 用途：删除 worktree 前的合并检查只需要知道目标基线是否可验证；
+ * - 引用不存在时返回 valid=false，不把它当成阻塞删除流程的 fatal 错误。
+ */
+async function verifyGitCommitRefForRemoveAsync(args: {
+  repoDir: string;
+  ref: string;
+  gitPath?: string;
+  timeoutMs?: number;
+}): Promise<{ ok: true; valid: boolean } | { ok: false; error: string }> {
+  const repoDir = toFsPathAbs(args.repoDir);
+  const ref = String(args.ref || "").trim();
+  if (!repoDir || !ref) return { ok: false, error: "missing args" };
+
+  const verified = await execGitAsync({
+    gitPath: args.gitPath,
+    argv: ["-C", repoDir, "rev-parse", "-q", "--verify", `${ref}^{commit}`],
+    timeoutMs: Math.max(200, Math.min(30_000, Number(args.timeoutMs ?? 8000))),
+  });
+  if (verified.ok) return { ok: true, valid: true };
+  if (verified.exitCode === 1) return { ok: true, valid: false };
+
+  return {
+    ok: false,
+    error: String(verified.error || verified.stderr || verified.stdout || "git rev-parse failed").trim() || "git rev-parse failed",
+  };
+}
+
+/**
  * 检查指定路径是否仍登记在 `git worktree list` 中。
  * - 用途：兼容 `git worktree remove` 已完成解绑，但目录清理因“Directory not empty”失败的场景；
  * - 返回 `registered=false` 时，可继续执行分支删除与兜底目录清理，而不再把该错误视为整体失败。
@@ -1872,12 +1901,20 @@ export async function removeWorktreeAsync(req: RemoveWorktreeRequest): Promise<R
     const wtBranchForDelete = String(resolvedWtBranch || "").trim();
     const baseRef = String(baseRefForMergedCheck || "").trim() || "HEAD";
     if (req.deleteBranch && wtBranchForDelete) {
-      const merged = await execGitAsync({ gitPath, argv: ["-C", repoMainPath, "merge-base", "--is-ancestor", wtBranchForDelete, baseRef], timeoutMs: 10_000 });
-      // merge-base --is-ancestor：0=是祖先（已合并），1=否，其它=错误
-      if (merged.exitCode !== 0 && merged.exitCode !== 1) {
-        return { ok: false, removedWorktree: false, removedBranch: false, error: merged.error || merged.stderr.trim() || "git merge-base failed" };
+      const baseRefValid = await verifyGitCommitRefForRemoveAsync({ repoDir: repoMainPath, ref: baseRef, gitPath, timeoutMs: 8000 });
+      if (!baseRefValid.ok) {
+        return { ok: false, removedWorktree: false, removedBranch: false, error: baseRefValid.error };
       }
-      isMergedWithBaseRef = merged.exitCode === 0;
+      if (!baseRefValid.valid) {
+        isMergedWithBaseRef = false;
+      } else {
+        const merged = await execGitAsync({ gitPath, argv: ["-C", repoMainPath, "merge-base", "--is-ancestor", wtBranchForDelete, baseRef], timeoutMs: 10_000 });
+        // merge-base --is-ancestor：0=是祖先（已合并），1=否，其它=错误
+        if (merged.exitCode !== 0 && merged.exitCode !== 1) {
+          return { ok: false, removedWorktree: false, removedBranch: false, error: merged.error || merged.stderr.trim() || "git merge-base failed" };
+        }
+        isMergedWithBaseRef = merged.exitCode === 0;
+      }
     }
 
     let needsForceRemoveWorktree = false;

--- a/electron/git/worktreeRemove.test.ts
+++ b/electron/git/worktreeRemove.test.ts
@@ -20,6 +20,7 @@ vi.mock("./exec", async () => {
 
 import { execGitAsync, spawnGitAsync } from "./exec";
 import { removeWorktreeAsync } from "./worktreeOps";
+import { setWorktreeMeta } from "../stores/worktreeMetaStore";
 
 /**
  * 中文说明：在临时仓库中执行 git 命令，并对失败给出明确断言信息。
@@ -115,6 +116,54 @@ describe("removeWorktreeAsync（删除预检与兜底）", () => {
           worktreePath: fixture.wtDir,
           deleteBranch: true,
           forceRemoveWorktree: true,
+          forceDeleteBranch: true,
+        });
+
+        expect(removeRes.ok).toBe(true);
+        if (removeRes.ok) {
+          expect(removeRes.removedWorktree).toBe(true);
+          expect(removeRes.removedBranch).toBe(true);
+        }
+
+        const ref = await gitTry(fixture.repo, ["show-ref", "--verify", "refs/heads/wt"]);
+        expect(ref.ok).toBe(false);
+      } finally {
+        await cleanupFixtureAsync(fixture);
+      }
+    },
+    { timeout: 120_000 }
+  );
+
+  it(
+    "当记录的基线分支已失效时，应转为分支强制删除确认",
+    async () => {
+      const fixture = await createWorktreeFixtureAsync("codexflow-wt-remove-missing-base-");
+
+      try {
+        await fsp.writeFile(path.join(fixture.wtDir, "feature.txt"), "feature\n", "utf8");
+        await git(fixture.wtDir, ["add", "feature.txt"]);
+        await git(fixture.wtDir, ["commit", "-m", "wt: feature"]);
+        setWorktreeMeta(fixture.wtDir, {
+          repoMainPath: fixture.repo,
+          baseBranch: "missing-base",
+          wtBranch: "wt",
+          createdAt: Date.now(),
+        });
+
+        const previewRes = await removeWorktreeAsync({
+          worktreePath: fixture.wtDir,
+          deleteBranch: true,
+        });
+
+        expect(previewRes.ok).toBe(false);
+        expect(previewRes.removedWorktree).toBe(false);
+        expect(previewRes.removedBranch).toBe(false);
+        expect(previewRes.needsForceDeleteBranch).toBe(true);
+        expect(previewRes.error).toBeUndefined();
+
+        const removeRes = await removeWorktreeAsync({
+          worktreePath: fixture.wtDir,
+          deleteBranch: true,
           forceDeleteBranch: true,
         });
 


### PR DESCRIPTION
删除 worktree 并同步删除分支前，先校验元数据记录的基线引用是否仍能解析为提交对象。
当基线引用已不存在时，不再把 merge-base 的失败作为致命错误，而是按未合并分支处理，
返回强制删除确认，避免旧 worktree 元数据阻塞清理流程。

补充缺失基线分支的删除预检与强制删除回归测试。