### PR TITLE
feat(settings): 增加 YOLO 权限模式启动引导

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -23,6 +23,7 @@ import { hasNonEmptyIOFromMessages } from "./agentSessions/shared/empty";
 import { historyItemBelongsToScope } from "./historyScope";
 import { perfLogger } from "./log";
 import settings, { ensureSettingsAutodetect, ensureFirstRunTerminalSelection, type ThemeSetting as SettingsThemeSetting, type AppSettings, type IdeOpenSettings } from "./settings";
+import { getOnboardingState, updateOnboardingState } from "./onboarding";
 import { normalizeTerminal, resolveWindowsShell, detectPwshExecutable } from "./shells";
 import { resolveActiveProviderId, resolveProviderRuntimeEnvFromSettings, resolveProviderStartupCmdFromSettings } from "./providers/runtime";
 import i18n from "./i18n";
@@ -6063,6 +6064,25 @@ ipcMain.handle('settings.get', async () => {
     cfg.experimental = { ...(cfg.experimental || {}), multiInstanceEnabled: !!flags.multiInstanceEnabled };
   } catch {}
   return cfg;
+});
+
+ipcMain.handle("onboarding.get", async () => {
+  try {
+    return { ok: true, state: getOnboardingState() };
+  } catch (e: any) {
+    return { ok: false, error: String(e) };
+  }
+});
+
+ipcMain.handle("onboarding.update", async (_e, partial: any) => {
+  try {
+    const next = updateOnboardingState({
+      yoloPromptHandled: partial?.yoloPromptHandled === true,
+    });
+    return { ok: true, state: next };
+  } catch (e: any) {
+    return { ok: false, error: String(e) };
+  }
 });
 
 ipcMain.handle('settings.update', async (_e, partial: any) => {

--- a/electron/onboarding.ts
+++ b/electron/onboarding.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import fs from "node:fs";
+import path from "node:path";
+import { getBaseUserDataDir } from "./featureFlags";
+
+export type OnboardingState = {
+  /** 是否已经处理过启动时 YOLO 权限模式推荐提示。 */
+  yoloPromptHandled?: boolean;
+};
+
+const ONBOARDING_FILE_NAME = "onboarding.json";
+const DEFAULT_STATE: OnboardingState = {
+  yoloPromptHandled: false,
+};
+
+/**
+ * 解析并归一化引导状态。
+ */
+function normalizeState(raw: unknown): OnboardingState {
+  try {
+    const obj = raw && typeof raw === "object" ? (raw as any) : {};
+    return {
+      ...DEFAULT_STATE,
+      yoloPromptHandled: obj.yoloPromptHandled === true,
+    };
+  } catch {
+    return { ...DEFAULT_STATE };
+  }
+}
+
+/**
+ * 获取全局引导状态文件路径。
+ */
+export function getOnboardingStatePath(): string {
+  return path.join(getBaseUserDataDir(), ONBOARDING_FILE_NAME);
+}
+
+/**
+ * 读取引导状态（失败回退默认值）。
+ */
+export function getOnboardingState(): OnboardingState {
+  try {
+    const p = getOnboardingStatePath();
+    if (!fs.existsSync(p)) return { ...DEFAULT_STATE };
+    const raw = fs.readFileSync(p, "utf8");
+    return normalizeState(JSON.parse(raw || "{}"));
+  } catch {
+    return { ...DEFAULT_STATE };
+  }
+}
+
+/**
+ * 更新引导状态（原子写入；失败回退当前值）。
+ */
+export function updateOnboardingState(patch: Partial<OnboardingState>): OnboardingState {
+  try {
+    const prev = getOnboardingState();
+    const next = normalizeState({ ...prev, ...(patch || {}) });
+    const p = getOnboardingStatePath();
+    try { fs.mkdirSync(path.dirname(p), { recursive: true }); } catch {}
+    const tmp = `${p}.tmp-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    fs.writeFileSync(tmp, JSON.stringify(next, null, 2), "utf8");
+    try { fs.renameSync(tmp, p); } catch {
+      try { fs.rmSync(p, { force: true }); } catch {}
+      fs.renameSync(tmp, p);
+    }
+    return next;
+  } catch {
+    return getOnboardingState();
+  }
+}
+
+export default { getOnboardingState, updateOnboardingState };

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -581,6 +581,14 @@ contextBridge.exposeInMainWorld('host', {
       return [] as string[];
     },
   },
+  onboarding: {
+    get: async () => {
+      return await ipcRenderer.invoke("onboarding.get");
+    },
+    update: async (partial: { yoloPromptHandled?: boolean }) => {
+      return await ipcRenderer.invoke("onboarding.update", partial);
+    },
+  },
   storage: {
     getAppDataInfo: async () => {
       return await ipcRenderer.invoke('storage.appData.info');

--- a/electron/storage.ts
+++ b/electron/storage.ts
@@ -766,6 +766,7 @@ async function clearAppData(options: ClearOptions = {}): Promise<ClearResult> {
   preserveNames.add('debug.config.jsonc');
   if (options.preserveSettings !== false) {
     preserveNames.add(SETTINGS_FILE);
+    preserveNames.add('onboarding.json');
     // 账号记录：Codex 登录备份（用于“记录账号/切换账号”等场景）
     preserveNames.add('codex-auth-backups');
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -99,7 +99,7 @@ import {
 import { normalizeProvidersSettings } from "@/lib/providers/normalize";
 import { isBuiltInSessionProviderId, openaiIconUrl, openaiDarkIconUrl, claudeIconUrl, geminiIconUrl } from "@/lib/providers/builtins";
 import { resolveProvider } from "@/lib/providers/resolve";
-import { resolveStartupCmdWithYolo } from "@/lib/providers/yolo";
+import { enableBuiltInYoloPresetItems, isAnyBuiltInYoloPresetEnabled, resolveStartupCmdWithYolo } from "@/lib/providers/yolo";
 import { injectCodexTraceEnv } from "@/providers/codex/commands";
 import { buildClaudeResumeStartupCmd } from "@/providers/claude/commands";
 import { buildGeminiResumeStartupCmd } from "@/providers/gemini/commands";
@@ -380,6 +380,12 @@ type CompletionSnapshot = {
   preview: string;
   ts: number;
   source: CompletionEventSource;
+};
+
+type YoloPromptDialogState = {
+  open: boolean;
+  loading: boolean;
+  handled: boolean;
 };
 
 type TabPointerDragState = {
@@ -4619,6 +4625,8 @@ export default function CodexFlowManagerUI() {
   const [legacyResumePrompt, setLegacyResumePrompt] = useState<LegacyResumePrompt | null>(null);
   const [legacyResumeLoading, setLegacyResumeLoading] = useState(false);
   const [blockingNotice, setBlockingNotice] = useState<BlockingNotice | null>(null);
+  const [yoloPromptDialog, setYoloPromptDialog] = useState<YoloPromptDialogState>(() => ({ open: false, loading: false, handled: false }));
+  const [startupChecksComplete, setStartupChecksComplete] = useState(false);
 
   const themeMode = useThemeController(themeSetting);
 
@@ -4634,6 +4642,48 @@ export default function CodexFlowManagerUI() {
     try {
       await window.host.settings.update({ dragDrop: { warnOutsideProject: !!enabled } } as any);
     } catch {}
+  }, []);
+
+  /**
+   * 统一写入 YOLO 启用结果：将内置三引擎切换到预设命令，并持久化“一次性提示”状态。
+   */
+  const applyBuiltInYoloPresetAndPersist = useCallback(async (): Promise<boolean> => {
+    try {
+      const nextItems = enableBuiltInYoloPresetItems(providerItems);
+      const codexItem = nextItems.find((x) => x.id === "codex");
+      const codexResolved = resolveProvider(codexItem ?? { id: "codex" });
+      const codexEnv = providerEnvById.codex || { terminal: "wsl", distro: wslDistro };
+      const nextEnvById = { ...providerEnvById };
+      if (!nextEnvById.codex) nextEnvById.codex = { terminal: codexEnv.terminal, distro: codexEnv.distro };
+      if (!nextEnvById.claude) nextEnvById.claude = { terminal: codexEnv.terminal, distro: codexEnv.distro };
+      if (!nextEnvById.gemini) nextEnvById.gemini = { terminal: codexEnv.terminal, distro: codexEnv.distro };
+      const nextProviders = { activeId: activeProviderId, items: nextItems, env: nextEnvById };
+      await window.host.settings.update({
+        providers: nextProviders as any,
+        terminal: codexEnv.terminal,
+        distro: codexEnv.distro,
+        codexCmd: codexResolved.startupCmd || "codex",
+      } as any);
+      setProviderItems(nextItems);
+      setProviderEnvById(nextEnvById);
+      setCodexCmd(codexResolved.startupCmd || "codex");
+      await window.host.onboarding.update({ yoloPromptHandled: true });
+      setYoloPromptDialog({ open: false, loading: false, handled: true });
+      return true;
+    } catch (e) {
+      console.warn("applyBuiltInYoloPresetAndPersist failed", e);
+      return false;
+    }
+  }, [activeProviderId, providerEnvById, providerItems, wslDistro]);
+
+  /**
+   * 记录 YOLO 引导已被处理；用于用户手动选择“暂不启用”时避免重复打扰。
+   */
+  const dismissYoloPrompt = useCallback(async (): Promise<void> => {
+    try {
+      await window.host.onboarding.update({ yoloPromptHandled: true });
+    } catch {}
+    setYoloPromptDialog({ open: false, loading: false, handled: true });
   }, []);
 
   /**
@@ -5321,24 +5371,27 @@ export default function CodexFlowManagerUI() {
         setAppVersion(cur);
         const skip = String((globalThis as any).__cf_updates_skip__ || '').trim();
         const res = await checkForUpdate(cur, { force: false });
-	        if (res.status === "update" && res.latest && res.latest.version !== skip) {
-	          setUpdateDialog({
-	            show: true,
-	            current: cur,
-	            latest: {
-	              version: res.latest.version,
-	              notes: res.latest.notes,
-	              notesLocales: res.latest.notesLocales,
-	              url: res.latest.url
-	            }
-	          });
-	        } else if (res.status === "failed" || res.source !== "network") {
-	          // 中文说明：静默更新检查的降级路径属于“正常可用但无网络结果”的场景，避免在未开启调试时污染控制台。
-	          uiLog(`Silent update check fallback: ${String(res.error || res.source || "")}`);
-	        }
-	      } catch {}
-	    })();
-	  }, [uiLog]);
+        if (res.status === "update" && res.latest && res.latest.version !== skip) {
+          setUpdateDialog({
+            show: true,
+            current: cur,
+            latest: {
+              version: res.latest.version,
+              notes: res.latest.notes,
+              notesLocales: res.latest.notesLocales,
+              url: res.latest.url,
+            },
+          });
+        } else if (res.status === "failed" || res.source !== "network") {
+          // 中文说明：静默更新检查的降级路径属于“正常可用但无网络结果”的场景，避免在未开启调试时污染控制台。
+          uiLog(`Silent update check fallback: ${String(res.error || res.source || "")}`);
+        }
+      } catch {}
+      finally {
+        setStartupChecksComplete(true);
+      }
+    })();
+  }, [uiLog]);
 
   // 监听主进程语言变更事件，保持本地 locale 状态同步（用于设置面板默认值等）
   useEffect(() => {
@@ -9848,6 +9901,65 @@ export default function CodexFlowManagerUI() {
         return t("about:updateError.unknown");
     }
   }, [t, updateErrorDialog.reason, updateErrorDialog.show]);
+  const yoloPromptTitle = t("settings:providers.fields.yoloPrompt.title", "开启 YOLO 权限模式？");
+  const yoloPromptDescription = t(
+    "settings:providers.fields.yoloPrompt.desc",
+    "推荐开启后再使用 agent，可以更顺畅地运行而不被权限询问打断。请注意，这会降低安全边界，存在误操作与越权风险。我们会同时为 Codex、Claude、Gemini 开启 YOLO，并且仅提醒一次，后续可在设置中修改。",
+  );
+  const yoloPromptPrimary = t("settings:providers.fields.yoloPrompt.primary", "开启并继续");
+  const yoloPromptSecondary = t("settings:providers.fields.yoloPrompt.secondary", "暂不启用");
+
+  /**
+   * 启动后一次性展示 YOLO 推荐提示：
+   * - 仅在未被询问过、且内置三引擎都未开启 YOLO 时出现；
+   * - 避开 detached-tab 窗口，防止多窗口重复提示；
+   * - 不与更新提示同时抢位。
+   */
+  useEffect(() => {
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      void (async () => {
+        try {
+          if (cancelled) return;
+          if (isDetachedTabWindow) return;
+          if (!startupChecksComplete) return;
+          if (updateDialog.show || noUpdateDialog || updateErrorDialog.show || legacyResumePrompt || blockingNotice) return;
+          if (yoloPromptDialog.open || yoloPromptDialog.loading || yoloPromptDialog.handled) return;
+          const stateRes = await window.host.onboarding.get();
+          if (!stateRes?.ok) return;
+          if (cancelled) return;
+          if (stateRes.state?.yoloPromptHandled) {
+            setYoloPromptDialog({ open: false, loading: false, handled: true });
+            return;
+          }
+          const items = Array.isArray(providerItems) ? providerItems : [];
+          if (isAnyBuiltInYoloPresetEnabled(items)) {
+            await window.host.onboarding.update({ yoloPromptHandled: true });
+            setYoloPromptDialog({ open: false, loading: false, handled: true });
+            return;
+          }
+          setYoloPromptDialog({ open: true, loading: false, handled: false });
+        } catch {}
+      })();
+    }, 1800);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [
+    blockingNotice,
+    isDetachedTabWindow,
+    legacyResumePrompt,
+    noUpdateDialog,
+    startupChecksComplete,
+    providerItems,
+    updateDialog.show,
+    updateErrorDialog.show,
+    yoloPromptDialog.handled,
+    yoloPromptDialog.loading,
+    yoloPromptDialog.open,
+  ]);
+
   const closeTabLabel = t('common:close') as string;
   const closeTabConfirmKind = closeWorkingTabConfirm.isWorking
     ? (closeWorkingTabConfirm.hasPromptInput ? "workingInput" : "working")
@@ -14047,6 +14159,53 @@ export default function CodexFlowManagerUI() {
           </div>
           <div className="flex justify-end border-t border-slate-200 bg-slate-50 px-4 py-3">
             <Button onClick={() => setUpdateErrorDialog({ show: false, reason: "unknown" })}>{t('about:updateError.confirm')}</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={yoloPromptDialog.open}
+        onOpenChange={(open) => {
+          if (open) return;
+          if (yoloPromptDialog.loading) return;
+          void dismissYoloPrompt();
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>{yoloPromptTitle}</DialogTitle>
+            <DialogDescription>{yoloPromptDescription}</DialogDescription>
+          </DialogHeader>
+          <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-slate-700 dark:border-amber-400/30 dark:bg-amber-500/10 dark:text-amber-50">
+            <div className="flex items-start gap-2">
+              <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-300" />
+              <span>{t("settings:providers.fields.yoloHelp", "启用后将锁定启动命令为预设（危险）；取消则恢复默认命令。")}</span>
+            </div>
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              variant="outline"
+              data-cf-dialog-cancel="true"
+              onClick={() => void dismissYoloPrompt()}
+              disabled={yoloPromptDialog.loading}
+            >
+              {yoloPromptSecondary}
+            </Button>
+            <Button
+              data-cf-dialog-primary="true"
+              disabled={yoloPromptDialog.loading}
+              onClick={async () => {
+                setYoloPromptDialog((prev) => ({ ...prev, loading: true }));
+                const ok = await applyBuiltInYoloPresetAndPersist();
+                if (!ok)
+                  setYoloPromptDialog((prev) => ({ ...prev, loading: false }));
+              }}
+            >
+              {yoloPromptDialog.loading ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : null}
+              {yoloPromptPrimary}
+            </Button>
           </div>
         </DialogContent>
       </Dialog>

--- a/web/src/lib/providers/yolo.test.ts
+++ b/web/src/lib/providers/yolo.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  BUILT_IN_YOLO_PROVIDER_IDS,
+  enableBuiltInYoloPresetItems,
+  isAnyBuiltInYoloPresetEnabled,
+  isYoloPresetEnabled,
+} from "./yolo";
+
+describe("providers/yolo（YOLO 预设工具）", () => {
+  it("批量启用时只修改内置三引擎的启动命令", () => {
+    const items = enableBuiltInYoloPresetItems([
+      { id: "codex", startupCmd: "codex" },
+      { id: "claude", startupCmd: "claude --foo" },
+      { id: "gemini", startupCmd: "gemini" },
+      { id: "custom-a", startupCmd: "custom-a --run" },
+    ]);
+
+    expect(items.find((it) => it.id === "codex")?.startupCmd).toBe("codex --yolo");
+    expect(items.find((it) => it.id === "claude")?.startupCmd).toBe("claude --dangerously-skip-permissions");
+    expect(items.find((it) => it.id === "gemini")?.startupCmd).toBe("gemini --yolo");
+    expect(items.find((it) => it.id === "custom-a")?.startupCmd).toBe("custom-a --run");
+  });
+
+  it("可识别是否已存在任意一个内置 YOLO 预设", () => {
+    expect(isAnyBuiltInYoloPresetEnabled([
+      { id: "codex", startupCmd: "codex --yolo" },
+      { id: "claude", startupCmd: "claude" },
+      { id: "gemini", startupCmd: "gemini" },
+    ])).toBe(true);
+
+    expect(isAnyBuiltInYoloPresetEnabled([
+      { id: "codex", startupCmd: "codex" },
+      { id: "claude", startupCmd: "claude" },
+      { id: "gemini", startupCmd: "gemini" },
+    ])).toBe(false);
+  });
+
+  it("预设识别严格按内置引擎范围生效", () => {
+    for (const providerId of BUILT_IN_YOLO_PROVIDER_IDS) {
+      expect(isYoloPresetEnabled(providerId, providerId === "claude" ? "claude --dangerously-skip-permissions" : `${providerId} --yolo`)).toBe(true);
+    }
+    expect(isYoloPresetEnabled("custom", "custom --yolo")).toBe(false);
+  });
+});

--- a/web/src/lib/providers/yolo.ts
+++ b/web/src/lib/providers/yolo.ts
@@ -3,6 +3,13 @@
 
 export type YoloProviderId = "codex" | "claude" | "gemini";
 
+export const BUILT_IN_YOLO_PROVIDER_IDS: readonly YoloProviderId[] = ["codex", "claude", "gemini"];
+
+type ProviderStartupItem = {
+  id?: string;
+  startupCmd?: string;
+};
+
 /**
  * 判断指定 Provider 是否支持 YOLO 预设命令。
  */
@@ -52,6 +59,43 @@ export function isYoloPresetEnabled(providerId: string, startupCmd: string | nul
   if (!preset) return false;
   const cur = normalizeCliCommandForCompare(String(startupCmd || ""));
   return cur.length > 0 && cur === normalizeCliCommandForCompare(preset);
+}
+
+/**
+ * 判断内置三引擎中是否已有任意一个启用 YOLO 预设。
+ */
+export function isAnyBuiltInYoloPresetEnabled(items: readonly ProviderStartupItem[] | null | undefined): boolean {
+  const list = Array.isArray(items) ? items : [];
+  return BUILT_IN_YOLO_PROVIDER_IDS.some((providerId) => {
+    const item = list.find((it) => String(it?.id || "").trim() === providerId);
+    return isYoloPresetEnabled(providerId, item?.startupCmd);
+  });
+}
+
+/**
+ * 将内置三引擎的启动命令统一切换为 YOLO 预设，同时保留其它 Provider 配置。
+ */
+export function enableBuiltInYoloPresetItems<T extends ProviderStartupItem>(items: readonly T[] | null | undefined): T[] {
+  const source = Array.isArray(items) ? items : [];
+  const next = source.map((item) => ({ ...item })) as T[];
+  const byId = new Map<string, T>();
+  for (const item of next) {
+    const id = String(item?.id || "").trim();
+    if (id && !byId.has(id)) byId.set(id, item);
+  }
+
+  for (const providerId of BUILT_IN_YOLO_PROVIDER_IDS) {
+    const preset = getYoloPresetStartupCmd(providerId);
+    if (!preset) continue;
+    const existing = byId.get(providerId);
+    if (existing) {
+      existing.startupCmd = preset;
+      continue;
+    }
+    next.push({ id: providerId, startupCmd: preset } as T);
+  }
+
+  return next;
 }
 
 /**

--- a/web/src/locales/en/settings.json
+++ b/web/src/locales/en/settings.json
@@ -97,6 +97,12 @@
       "startupCmdHelpTerminal": "Terminal does not support a startup command (always opens a shell).",
       "yolo": "YOLO",
       "yoloHelp": "When enabled, the startup command is locked to a preset (dangerous); disabling restores the default command.",
+      "yoloPrompt": {
+        "title": "Enable YOLO permission mode?",
+        "desc": "We recommend enabling this before using agents so they can run smoothly without permission prompts. This lowers the safety boundary and carries a risk of mistakes or overreach. We will enable YOLO for Codex, Claude, and Gemini, ask only once, and you can change it later in Settings.",
+        "primary": "Enable and continue",
+        "secondary": "Not now"
+      },
       "icon": "Icon",
       "iconLight": "Light icon",
       "iconDark": "Dark icon",

--- a/web/src/locales/zh/settings.json
+++ b/web/src/locales/zh/settings.json
@@ -97,6 +97,12 @@
       "startupCmdHelpTerminal": "Terminal 不支持启动命令（始终仅打开 shell）。",
       "yolo": "YOLO",
       "yoloHelp": "启用后将锁定启动命令为预设（危险）；取消则恢复默认命令。",
+      "yoloPrompt": {
+        "title": "开启 YOLO 权限模式？",
+        "desc": "推荐开启后再使用 agent，可以更顺畅地运行而不被权限询问打断。请注意，这会降低安全边界，存在误操作与越权风险。我们会同时为 Codex、Claude、Gemini 开启 YOLO，并且仅提醒一次，后续可在设置中修改。",
+        "primary": "开启并继续",
+        "secondary": "暂不启用"
+      },
       "icon": "图标",
       "iconLight": "亮色图标",
       "iconDark": "暗色图标",

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -51,6 +51,11 @@ export type ClaudeCodeSettings = {
   readAgentHistory?: boolean;
 };
 
+export type OnboardingSettings = {
+  /** 是否已经处理过启动时 YOLO 权限模式推荐提示。 */
+  yoloPromptHandled?: boolean;
+};
+
 export type ProvidersSettings = {
   activeId: ProviderId;
   items: ProviderItem[];
@@ -88,6 +93,8 @@ export type AppSettings = {
     /** 拖拽添加的资源不在当前项目目录时提醒（默认开启） */
     warnOutsideProject?: boolean;
   };
+  /** 一次性引导提示状态。 */
+  onboarding?: OnboardingSettings;
   /** ChatGPT/Codex 账号相关设置（记录账号、切换备份等） */
   codexAccount?: {
     recordEnabled?: boolean;
@@ -678,6 +685,11 @@ export interface SettingsAPI {
   sessionRoots?(args: { providerId: "codex" | "claude" | "gemini" }): Promise<string[]>;
 }
 
+export interface OnboardingAPI {
+  get(): Promise<{ ok: boolean; state?: { yoloPromptHandled?: boolean }; error?: string }>;
+  update(partial: { yoloPromptHandled?: boolean }): Promise<{ ok: boolean; state?: { yoloPromptHandled?: boolean }; error?: string }>;
+}
+
 export interface StorageAPI {
   getAppDataInfo(): Promise<{
     ok: boolean;
@@ -1101,6 +1113,7 @@ declare global {
       gitWorkbench?: GitWorkbenchAPI;
       history: HistoryAPI;
       settings: SettingsAPI;
+      onboarding: OnboardingAPI;
       storage: StorageAPI;
       utils: UtilsAPI;
       i18n: I18nAPI;


### PR DESCRIPTION
启动后在用户未处理过且内置 Provider 未启用 YOLO 时，展示一次性权限模式推荐提示。
新增 onboarding.json 持久化提示状态，并通过 preload 暴露受限 IPC 读写接口。 批量启用 Codex、Claude、Gemini 的 YOLO 预设命令，同时保持 Provider env、legacy codexCmd 与设置持久化一致。 补充 YOLO 预设工具函数单测与中英文文案。