### PR TITLE
feat(terminal): 接入 CMD 运行环境

### DIFF
--- a/electron/claude/usage.ts
+++ b/electron/claude/usage.ts
@@ -36,7 +36,7 @@ export type ClaudeUsageSnapshot = {
   };
 };
 
-type ProviderRuntimeEnv = { terminal: "wsl" | "windows" | "pwsh"; distro?: string };
+type ProviderRuntimeEnv = { terminal: "wsl" | "windows" | "pwsh" | "cmd"; distro?: string };
 
 type ClaudeApiUsageCache = {
   five_hour_utilization?: number;
@@ -246,7 +246,7 @@ export async function getClaudeUsageSnapshotAsync(env: ProviderRuntimeEnv): Prom
       throw new Error("Claude 用量信息不可用（未找到缓存，且 WSL 抓取失败）");
     }
 
-    if (terminal === "windows" || terminal === "pwsh") {
+    if (terminal === "windows" || terminal === "pwsh" || terminal === "cmd") {
       const cache = await readClaudeCacheFileWindowsAsync();
       const parsed = cache ? parseClaudeCclineCache(cache) : null;
       if (parsed) return parsed;

--- a/electron/gemini/projectTemp.ts
+++ b/electron/gemini/projectTemp.ts
@@ -7,7 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { getDistroHomeSubPathUNCAsync } from "../wsl";
 
-export type GeminiRuntimeEnv = "wsl" | "windows" | "pwsh";
+export type GeminiRuntimeEnv = "wsl" | "windows" | "pwsh" | "cmd";
 
 export type ResolveGeminiProjectTempOptions = {
   projectWinRoot?: string;
@@ -258,7 +258,7 @@ async function claimGeminiProjectId(
 /**
  * 中文说明：根据运行环境选择当前 Gemini 项目的“真实项目根路径”。
  * - WSL 优先使用 WSL 根路径
- * - Windows/Pwsh 优先使用 Windows 根路径
+ * - Windows/Pwsh/CMD 优先使用 Windows 根路径
  */
 function resolveGeminiProjectRoot(options: ResolveGeminiProjectTempOptions): string {
   const runtimeEnv = options.runtimeEnv || "windows";
@@ -322,7 +322,7 @@ async function resolveConfiguredGeminiHomeForWindowsWsl(
  * - Windows 主进程 + WSL 运行时若 `GEMINI_CLI_HOME` 为 POSIX 路径，则转成 UNC
  * - WSL on Windows 返回 UNC 路径
  * - WSL 单元测试/非 Windows 环境优先使用 `GEMINI_CLI_HOME`，否则返回 POSIX `~/.gemini`
- * - Windows/Pwsh 返回本机 `%USERPROFILE%\\.gemini`
+ * - Windows/Pwsh/CMD 返回本机 `%USERPROFILE%\\.gemini`
  */
 async function resolveGeminiHomePath(
   options: ResolveGeminiProjectTempOptions,

--- a/electron/gemini/usage.ts
+++ b/electron/gemini/usage.ts
@@ -23,7 +23,7 @@ export type GeminiQuotaSnapshot = {
   buckets: GeminiQuotaBucket[];
 };
 
-type ProviderRuntimeEnv = { terminal: "wsl" | "windows" | "pwsh"; distro?: string };
+type ProviderRuntimeEnv = { terminal: "wsl" | "windows" | "pwsh" | "cmd"; distro?: string };
 
 type GeminiOauthCredsFile = {
   access_token?: string;
@@ -233,7 +233,7 @@ async function readGeminiOauthCredsWslAsync(distro?: string): Promise<GeminiOaut
 async function resolveGeminiOauthCredsAsync(env: ProviderRuntimeEnv): Promise<GeminiOauthCredsFile | null> {
   // 说明：不做跨环境回退，严格按当前 Provider 运行环境读取对应路径。
   // - terminal=wsl：读取 WSL 内 `~/.gemini/oauth_creds.json`
-  // - terminal=windows/pwsh：读取 Windows 内 `%USERPROFILE%\\.gemini\\oauth_creds.json`
+  // - terminal=windows/pwsh/cmd：读取 Windows 内 `%USERPROFILE%\\.gemini\\oauth_creds.json`
   if (env.terminal === "wsl") return readGeminiOauthCredsWslAsync(env.distro);
   return readGeminiOauthCredsWindowsAsync();
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -24,7 +24,7 @@ import { historyItemBelongsToScope } from "./historyScope";
 import { perfLogger } from "./log";
 import settings, { ensureSettingsAutodetect, ensureFirstRunTerminalSelection, type ThemeSetting as SettingsThemeSetting, type AppSettings, type IdeOpenSettings } from "./settings";
 import { getOnboardingState, updateOnboardingState } from "./onboarding";
-import { normalizeTerminal, resolveWindowsShell, detectPwshExecutable } from "./shells";
+import { normalizeTerminal, resolveWindowsShell, detectPwshExecutable, type TerminalMode } from "./shells";
 import { resolveActiveProviderId, resolveProviderRuntimeEnvFromSettings, resolveProviderStartupCmdFromSettings } from "./providers/runtime";
 import i18n from "./i18n";
 import wsl from "./wsl";
@@ -2363,7 +2363,7 @@ function setupAppMenu() {
 
 // -------- IPC: PTY bridge (I/O only) --------
 ipcMain.handle('pty:open', async (_event, args: {
-  terminal?: 'wsl' | 'windows' | 'pwsh'; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string>;
+  terminal?: TerminalMode; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string>;
 }) => {
   const id = ptyManager.openWSLConsole({
     terminal: args?.terminal as any,
@@ -2431,7 +2431,7 @@ ipcMain.handle('fileIndex.ensure', async (_e, { root, excludes }: { root: string
 });
 
 // 打开外部控制台（根据设置选择 WSL 或 Windows 终端）
-ipcMain.handle('utils.openExternalConsole', async (_e, args: { terminal?: 'wsl' | 'windows' | 'pwsh'; wslPath?: string; winPath?: string; distro?: string; startupCmd?: string; title?: string }) => {
+ipcMain.handle('utils.openExternalConsole', async (_e, args: { terminal?: TerminalMode; wslPath?: string; winPath?: string; distro?: string; startupCmd?: string; title?: string }) => {
   try {
     const platform = process.platform;
     const cfg = settings.getSettings();
@@ -2479,7 +2479,7 @@ ipcMain.handle('utils.openExternalConsole', async (_e, args: { terminal?: 'wsl' 
     ].join("|");
     if (shouldSkipExternalConsoleLaunch(guardKey)) return { ok: true, skipped: true } as const;
 
-    if (platform === 'win32' && (terminal === 'windows' || terminal === 'pwsh')) {
+    if (platform === 'win32' && (terminal === 'windows' || terminal === 'pwsh' || terminal === 'cmd')) {
       // 计算工作目录：优先使用 winPath，其次从 wslPath 推导
       let cwd = String(args?.winPath || '').trim();
       const wslPathRaw = String(args?.wslPath || '').trim();
@@ -2491,6 +2491,30 @@ ipcMain.handle('utils.openExternalConsole', async (_e, args: { terminal?: 'wsl' 
       try { cwd = wsl.normalizeWinPath(cwd); } catch {}
       if (!cwd) { try { cwd = require('node:os').homedir(); } catch { cwd = process.cwd(); } }
       extLog(`[external] windows-shell cwd='${cwd}'`);
+
+      if (terminal === 'cmd') {
+        const resolvedShell = resolveWindowsShell('cmd');
+        const hasStartupCmd = startupCmd.trim().length > 0;
+        const cmdArgs = hasStartupCmd ? ['/d', '/v:off', '/k', startupCmd] : ['/d', '/v:off'];
+        const wtArgs = ['-w', '0', 'new-tab', '--title', title, '--startingDirectory', cwd, '--', resolvedShell.command, ...cmdArgs];
+        {
+          const ok = await spawnDetachedSafe('wt.exe', wtArgs, WT_VISIBLE_SPAWN_OPTS);
+          extLog(`[external] launch wt.exe(cmd) ok=${ok ? 1 : 0}`);
+          if (ok) return { ok: true } as const;
+        }
+        {
+          const ok = await spawnDetachedSafe('WindowsTerminal.exe', wtArgs, WT_VISIBLE_SPAWN_OPTS);
+          extLog(`[external] launch WindowsTerminal.exe(cmd) ok=${ok ? 1 : 0}`);
+          if (ok) return { ok: true } as const;
+        }
+        {
+          const cmdExe = resolveSystemBinary('cmd.exe');
+          const ok = await spawnDetachedSafe(cmdExe, ['/c', 'start', '', resolvedShell.command, ...cmdArgs], { windowsHide: false, cwd });
+          extLog(`[external] launch cmd.exe(start cmd.exe) ok=${ok ? 1 : 0}`);
+          if (ok) return { ok: true } as const;
+        }
+        return { ok: false, error: 'failed to launch external CMD console' } as const;
+      }
 
       // 优先 Windows Terminal
       const resolvedShell = resolveWindowsShell(terminal === 'pwsh' ? 'pwsh' : 'windows');
@@ -4497,7 +4521,7 @@ ipcMain.handle('utils.geminiWindowsEditor.readStatus', async (_e, args: {
  * 中文说明：探测当前 Gemini CLI 版本，并返回外部编辑器快捷键策略。
  */
 ipcMain.handle('utils.gemini.versionShortcut', async (_e, args: {
-  terminal?: 'wsl' | 'windows' | 'pwsh';
+  terminal?: TerminalMode;
   distro?: string;
   startupCmd?: string;
 }) => {
@@ -4610,7 +4634,7 @@ ipcMain.handle('images.saveDataURL', async (_e, {
   ext?: string;
   prefix?: string;
   providerId?: string;
-  runtimeEnv?: "wsl" | "windows" | "pwsh";
+  runtimeEnv?: TerminalMode;
   distro?: string;
 }) => {
   try {
@@ -4649,7 +4673,7 @@ ipcMain.handle('images.saveFromClipboard', async (_e, {
   projectName?: string;
   prefix?: string;
   providerId?: string;
-  runtimeEnv?: "wsl" | "windows" | "pwsh";
+  runtimeEnv?: TerminalMode;
   distro?: string;
 }) => {
   try {
@@ -6024,7 +6048,7 @@ ipcMain.handle("codex.rateLimit", async () => {
 /**
  * 读取设置中的 Provider 环境（若缺失则回退到全局 terminal/distro）。
  */
-function resolveProviderRuntimeEnv(providerId: "claude" | "gemini"): { terminal: "wsl" | "windows" | "pwsh"; distro?: string } {
+function resolveProviderRuntimeEnv(providerId: "claude" | "gemini"): { terminal: TerminalMode; distro?: string } {
   const cfg = settings.getSettings();
   return resolveProviderRuntimeEnvFromSettings(cfg, providerId);
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -4,7 +4,8 @@
 const { contextBridge, ipcRenderer } = require('electron');
 // preload 层：集中做 IPC 分发与安全封装
 
-type OpenArgs = { terminal?: 'wsl' | 'windows' | 'pwsh'; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string> };
+type TerminalMode = 'wsl' | 'windows' | 'pwsh' | 'cmd';
+type OpenArgs = { terminal?: TerminalMode; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string> };
 
 type PtyDataPayload = { id: string; data: string };
 type PtyExitPayload = { id: string; exitCode?: number };
@@ -743,7 +744,7 @@ contextBridge.exposeInMainWorld('host', {
      * 中文说明：探测当前 Gemini CLI 版本对应的外部编辑器快捷键策略。
      */
     resolveGeminiExternalEditorShortcut: async (args: {
-      terminal?: 'wsl' | 'windows' | 'pwsh';
+      terminal?: TerminalMode;
       distro?: string;
       startupCmd?: string;
     }) => {
@@ -809,11 +810,11 @@ contextBridge.exposeInMainWorld('host', {
     openExternalUrl: async (url: string) => {
       return await ipcRenderer.invoke('utils.openExternalUrl', { url });
     },
-    openExternalConsole: async (args: { terminal?: 'wsl' | 'windows' | 'pwsh'; wslPath?: string; winPath?: string; distro?: string; startupCmd?: string; title?: string }) => {
+    openExternalConsole: async (args: { terminal?: TerminalMode; wslPath?: string; winPath?: string; distro?: string; startupCmd?: string; title?: string }) => {
       return await ipcRenderer.invoke('utils.openExternalConsole', args);
     },
     // 兼容旧调用名
-    openExternalWSLConsole: async (args: { terminal?: 'wsl' | 'windows' | 'pwsh'; wslPath?: string; winPath?: string; distro?: string; startupCmd?: string; title?: string }) => {
+    openExternalWSLConsole: async (args: { terminal?: TerminalMode; wslPath?: string; winPath?: string; distro?: string; startupCmd?: string; title?: string }) => {
       return await ipcRenderer.invoke('utils.openExternalConsole', args);
     },
     pathExists: async (p: string, dirOnly?: boolean) => {
@@ -844,13 +845,13 @@ contextBridge.exposeInMainWorld('host', {
     }
   }
   , images: {
-    saveDataURL: async (args: { dataURL: string; projectWinRoot?: string; projectWslRoot?: string; projectName?: string; ext?: string; prefix?: string; providerId?: string; runtimeEnv?: 'wsl' | 'windows' | 'pwsh'; distro?: string }) => {
+    saveDataURL: async (args: { dataURL: string; projectWinRoot?: string; projectWslRoot?: string; projectName?: string; ext?: string; prefix?: string; providerId?: string; runtimeEnv?: TerminalMode; distro?: string }) => {
       return await ipcRenderer.invoke('images.saveDataURL', args);
     },
     clipboardHasImage: async () => {
       return await ipcRenderer.invoke('images.clipboardHasImage');
     },
-    saveFromClipboard: async (args: { projectWinRoot?: string; projectWslRoot?: string; projectName?: string; prefix?: string; providerId?: string; runtimeEnv?: 'wsl' | 'windows' | 'pwsh'; distro?: string }) => {
+    saveFromClipboard: async (args: { projectWinRoot?: string; projectWslRoot?: string; projectName?: string; prefix?: string; providerId?: string; runtimeEnv?: TerminalMode; distro?: string }) => {
       return await ipcRenderer.invoke('images.saveFromClipboard', args);
     },
     copyToClipboard: async (args: { localPath?: string; src?: string; fallbackSrc?: string }) => {

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -357,11 +357,11 @@ export class PTYManager {
         cwd: undefined,
         env
       });
-    } else if (termMode === 'windows' || termMode === 'pwsh') {
-      // Windows 本地终端（PowerShell / PowerShell 7）
-      const resolved = resolveWindowsShell(termMode === 'pwsh' ? 'pwsh' : 'windows');
+    } else if (termMode === 'windows' || termMode === 'pwsh' || termMode === 'cmd') {
+      // Windows 本地终端（Windows PowerShell / PowerShell 7 / CMD）
+      const resolved = resolveWindowsShell(termMode === 'pwsh' ? 'pwsh' : termMode === 'cmd' ? 'cmd' : 'windows');
       const shell = resolved.command;
-      const args: string[] = ['-NoLogo'];
+      const args: string[] = termMode === 'cmd' ? ['/d', '/v:off'] : ['-NoLogo'];
       const cwd = winPath && winPath.trim().length > 0 ? winPath : undefined;
       proc = pty.spawn(shell, args, {
         name: 'xterm-256color',
@@ -428,12 +428,12 @@ export class PTYManager {
     if (startupCmd) {
       const isWin = os.platform() === 'win32';
       const mode = isWin ? (termMode || 'wsl') : 'posix';
-      const isWinShell = mode === 'windows' || mode === 'pwsh';
+      const isWinShell = mode === 'windows' || mode === 'pwsh' || mode === 'cmd';
       setImmediate(() => {
         const p = this.sessions.get(id);
         if (!p) return; // PTY 可能已关闭
         if (isWinShell) {
-          // PowerShell / PowerShell 7 中直接执行命令（cwd 已设置）
+          // Windows 本地 shell 中直接执行命令（cwd 已设置）
           p.write(`${startupCmd}\r`);
           dlog(`[pty] startupCmd executed (windows) id=${id} shell=${mode}`);
         } else if (isWin) {

--- a/electron/settings.ts
+++ b/electron/settings.ts
@@ -685,7 +685,7 @@ export async function ensureFirstRunTerminalSelection(): Promise<AppSettings> {
     const hasStore = fs.existsSync(storePath);
     const current = getSettings();
     // 若已有设置且包含明确的 terminal，视为非首次，无需更改
-    if (hasStore && (current.terminal === 'wsl' || current.terminal === 'windows' || current.terminal === 'pwsh')) {
+    if (hasStore && (current.terminal === 'wsl' || current.terminal === 'windows' || current.terminal === 'pwsh' || current.terminal === 'cmd')) {
       return current;
     }
 

--- a/electron/shells.ts
+++ b/electron/shells.ts
@@ -4,9 +4,9 @@
 import fs from "node:fs";
 import { execFile } from "node:child_process";
 
-export type TerminalMode = "wsl" | "windows" | "pwsh";
+export type TerminalMode = "wsl" | "windows" | "pwsh" | "cmd";
 
-export type WindowsShellKind = "powershell" | "pwsh";
+export type WindowsShellKind = "powershell" | "pwsh" | "cmd";
 
 export type WindowsShellResolution = {
   command: string;
@@ -16,6 +16,7 @@ export type WindowsShellResolution = {
 export function normalizeTerminal(raw: unknown): TerminalMode {
   const v = typeof raw === "string" ? raw.trim().toLowerCase() : "";
   if (v === "pwsh") return "pwsh";
+  if (v === "cmd") return "cmd";
   if (v === "windows") return "windows";
   return "wsl";
 }
@@ -100,7 +101,10 @@ export async function hasPwsh(): Promise<boolean> {
   return !!hit;
 }
 
-export function resolveWindowsShell(mode: "windows" | "pwsh"): WindowsShellResolution {
+export function resolveWindowsShell(mode: "windows" | "pwsh" | "cmd"): WindowsShellResolution {
+  if (mode === "cmd") {
+    return { command: "cmd.exe", kind: "cmd" };
+  }
   if (mode === "pwsh") {
     const fast = cacheFresh() ? cachedPwsh : tryFastLocalPwsh();
     if (fast) return { command: fast, kind: "pwsh" };

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -109,7 +109,7 @@ import {
   getProviderRuleFileName,
   type BuiltInRuleProviderId,
 } from "@/lib/engine-rules";
-import { bashSingleQuote, buildPowerShellCall, powerShellArgToken, splitCommandLineToArgv } from "@/lib/shell";
+import { bashSingleQuote, buildCmdCall, buildPowerShellCall, isCmdTerminal, powerShellArgToken, splitCommandLineToArgv } from "@/lib/shell";
 import SettingsDialog from "@/features/settings/settings-dialog";
 import {
   DEFAULT_TERMINAL_FONT_FAMILY,
@@ -1613,7 +1613,7 @@ export default function CodexFlowManagerUI() {
     const snapshot = restoredConsoleSession?.tabEnvByTab || {};
     const next: Record<string, Required<ProviderEnv>> = {};
     for (const [tabId, item] of Object.entries(snapshot)) {
-      const terminal = item?.terminal === "windows" || item?.terminal === "pwsh" ? item.terminal : "wsl";
+      const terminal = normalizeTerminalMode(item?.terminal);
       next[tabId] = {
         terminal,
         distro: String(item?.distro || ""),
@@ -1756,7 +1756,7 @@ export default function CodexFlowManagerUI() {
         const nextEnvByTab: Record<string, Required<ProviderEnv>> = {};
         for (const [tabId, item] of Object.entries(nextSnapshot.tabEnvByTab || {})) {
           nextEnvByTab[tabId] = {
-            terminal: item?.terminal === "windows" || item?.terminal === "pwsh" ? item.terminal : "wsl",
+            terminal: normalizeTerminalMode(item?.terminal),
             distro: String(item?.distro || ""),
           };
         }
@@ -9471,6 +9471,19 @@ export default function CodexFlowManagerUI() {
               <span>{t("settings:terminalMode.pwsh")}</span>
               {terminalMode === "pwsh" ? <Check className="h-4 w-4 text-slate-600" /> : null}
             </DropdownMenuItem>
+            <DropdownMenuItem
+              className="flex items-center justify-between gap-2"
+              onClick={async () => {
+                const nextEnv: Required<ProviderEnv> = { ...getProviderEnv(activeProviderId), terminal: "cmd" };
+                const nextMap = { ...providerEnvById, [activeProviderId]: nextEnv };
+                setProviderEnvById(nextMap);
+                setTerminalMode("cmd" as any);
+                await persistProviders({ activeId: activeProviderId, items: providerItems, env: nextMap });
+              }}
+            >
+              <span>{t("settings:terminalMode.cmd")}</span>
+              {terminalMode === "cmd" ? <Check className="h-4 w-4 text-slate-600" /> : null}
+            </DropdownMenuItem>
 
             {terminalMode === "wsl" ? (
               <>
@@ -10590,6 +10603,18 @@ export default function CodexFlowManagerUI() {
 	      const resumeArg = `experimental_resume="${resumePath.replace(/"/g, '\\"')}"`;
 	      const baseArgv = splitCommandLineToArgv(baseCmd);
 	      const base = baseArgv.length > 0 ? baseArgv : ["codex"];
+	      if (isCmdTerminal(mode)) {
+	        const fallbackCall = buildCmdCall([...base, "-c", resumeArg]);
+	        const fallbackCmd = injectTrace(fallbackCall);
+	        if (!preferLegacyOnly && resumeSessionId) {
+	          const resumeCall = buildCmdCall([...base, "resume", resumeSessionId]);
+	          const resumeCmd = injectTrace(resumeCall);
+	          const startupCmd = `${resumeCmd} || ${fallbackCmd}`;
+	          return { providerId: "codex", startupCmd, session, resumeLabel: resumePath, sessionId: resumeSessionId, strategy: 'resume+fallback', resumeHint: resumeModeHint, forceLegacyCli: false };
+	        }
+	        const strategy = preferLegacyOnly ? 'legacy-only' : 'experimental_resume';
+	        return { providerId: "codex", startupCmd: fallbackCmd, session, resumeLabel: resumePath, sessionId: resumeSessionId, strategy, resumeHint: resumeModeHint, forceLegacyCli: false };
+	      }
 	      const fallbackCall = buildPowerShellCall([...base, "-c", resumeArg]);
 	      const fallbackCmd = injectTrace(fallbackCall);
 	      if (!preferLegacyOnly && resumeSessionId) {
@@ -14916,7 +14941,7 @@ function serializeConsoleTabsByProject(
  */
 function serializeConsoleTabEnvByTab(
   tabEnvByTab: Record<string, Required<ProviderEnv>>,
-): Record<string, { terminal?: "wsl" | "windows" | "pwsh"; distro?: string }> {
+): Record<string, { terminal?: "wsl" | "windows" | "pwsh" | "cmd"; distro?: string }> {
   return Object.fromEntries(
     Object.entries(tabEnvByTab || {}).map(([tabId, env]) => [
       tabId,

--- a/web/src/app/app-shared.tsx
+++ b/web/src/app/app-shared.tsx
@@ -74,7 +74,7 @@ import { resolveProvider } from "@/lib/providers/resolve";
 import { injectCodexTraceEnv } from "@/providers/codex/commands";
 import { buildClaudeResumeStartupCmd } from "@/providers/claude/commands";
 import { buildGeminiResumeStartupCmd } from "@/providers/gemini/commands";
-import { bashSingleQuote, buildPowerShellCall, powerShellArgToken, splitCommandLineToArgv } from "@/lib/shell";
+import { bashSingleQuote, buildCmdCall, buildPowerShellCall, cmdArgToken, isCmdTerminal, powerShellArgToken, splitCommandLineToArgv } from "@/lib/shell";
 import SettingsDialog from "@/features/settings/settings-dialog";
 import {
   DEFAULT_TERMINAL_FONT_FAMILY,
@@ -455,7 +455,7 @@ type HistoryTimelineGroup = {
 
 type ResumeExecutionMode = 'internal' | 'external';
 type LegacyResumePrompt = { filePath: string; mode: ResumeExecutionMode };
-type ShellLabel = 'PowerShell' | 'PowerShell 7' | 'WSL';
+type ShellLabel = 'PowerShell' | 'PowerShell 7' | 'CMD' | 'WSL';
 type BlockingNotice =
   | { type: 'shell-mismatch'; expected: ShellLabel; current: ShellLabel }
   | { type: 'external-console'; env: ShellLabel };
@@ -1056,7 +1056,7 @@ function areStringArraysEqual(a: string[] | null | undefined, b: string[] | null
  */
 function resolveWorktreePromptChipPath(args: { chip: PathChip; terminalMode?: TerminalMode }): string {
   const chipAny = args.chip as any;
-  const preferWindows = args.terminalMode === "windows" || args.terminalMode === "pwsh";
+  const preferWindows = args.terminalMode === "windows" || args.terminalMode === "pwsh" || args.terminalMode === "cmd";
   const candidates = preferWindows
     ? [chipAny?.winPath, chipAny?.wslPath, chipAny?.fileName]
     : [chipAny?.wslPath, chipAny?.winPath, chipAny?.fileName];
@@ -1164,6 +1164,23 @@ function buildProviderStartupCmdWithInitialPrompt(args: {
   const prompt = String(args.prompt || "");
   if (!base) return "";
   if (!prompt.trim()) return base;
+
+  if (isCmdTerminal(args.terminalMode)) {
+    const flattenedPrompt = prompt.replace(/\r\n/g, " ").replace(/\r/g, " ").replace(/\n/g, " ").trim();
+    if (!flattenedPrompt) return base;
+    if (args.providerId === "claude") {
+      const baseArgv = splitCommandLineToArgv(base);
+      const argv = baseArgv.length > 0 ? baseArgv : ["claude"];
+      return buildCmdCall([...argv, flattenedPrompt]);
+    }
+    if (args.providerId === "gemini") {
+      const baseArgv = splitCommandLineToArgv(base);
+      const argv = baseArgv.length > 0 ? baseArgv : ["gemini"];
+      const hasI = argv.includes("-i") || argv.includes("--interactive");
+      return buildCmdCall(hasI ? [...argv, flattenedPrompt] : [...argv, "-i", flattenedPrompt]);
+    }
+    return `${base} ${cmdArgToken(flattenedPrompt)}`.trim();
+  }
 
   if (args.terminalMode !== "wsl") {
     if (args.providerId === "claude") {
@@ -1282,6 +1299,7 @@ function buildAutoCommitMessage(source: "user" | "agent", text: string): string 
 	 */
 	const toShellLabel = (mode: TerminalMode): ShellLabel => {
 	  if (mode === "pwsh") return "PowerShell 7";
+	  if (mode === "cmd") return "CMD";
 	  if (mode === "windows") return "PowerShell";
 	  return "WSL";
 	};
@@ -1292,12 +1310,13 @@ function buildAutoCommitMessage(source: "user" | "agent", text: string): string 
 	const normalizeTerminalMode = (raw: any): TerminalMode => {
 	  const v = typeof raw === 'string' ? raw.trim().toLowerCase() : '';
 	  if (v === 'pwsh') return 'pwsh';
+	  if (v === 'cmd') return 'cmd';
 	  if (v === 'windows') return 'windows';
 	  return 'wsl';
 	};
 
 	/**
-	 * 中文说明：判断当前终端是否属于 Windows 家族（PowerShell / PowerShell 7）。
+	 * 中文说明：判断当前终端是否属于 Windows 家族（PowerShell / PowerShell 7 / CMD）。
 	 */
 	const isWindowsLike = (mode: TerminalMode): boolean => mode !== 'wsl';
 

--- a/web/src/components/topbar/claude-status.tsx
+++ b/web/src/components/topbar/claude-status.tsx
@@ -72,6 +72,7 @@ function resolveClaudeResetLabel(
 function resolveClaudeEnvKey(terminalMode?: TerminalMode, distro?: string): string {
   if (terminalMode === "wsl") return `wsl:${distro ?? ""}`;
   if (terminalMode === "pwsh") return "windows-pwsh";
+  if (terminalMode === "cmd") return "windows-cmd";
   if (terminalMode === "windows") return "windows";
   return "default";
 }

--- a/web/src/components/topbar/codex-status.tsx
+++ b/web/src/components/topbar/codex-status.tsx
@@ -37,6 +37,7 @@ type TerminalMode = NonNullable<AppSettings["terminal"]>;
 function resolveCodexEnvKey(terminalMode?: TerminalMode, distro?: string): string {
   if (terminalMode === "wsl") return `wsl:${distro ?? ""}`;
   if (terminalMode === "pwsh") return "windows-pwsh";
+  if (terminalMode === "cmd") return "windows-cmd";
   if (terminalMode === "windows") return "windows";
   return "default";
 }

--- a/web/src/components/topbar/gemini-status.tsx
+++ b/web/src/components/topbar/gemini-status.tsx
@@ -80,6 +80,7 @@ function clampPercent0To100(value: number): number {
 function resolveGeminiEnvKey(terminalMode?: TerminalMode, distro?: string): string {
   if (terminalMode === "wsl") return `wsl:${distro ?? ""}`;
   if (terminalMode === "pwsh") return "windows-pwsh";
+  if (terminalMode === "cmd") return "windows-cmd";
   if (terminalMode === "windows") return "windows";
   return "default";
 }

--- a/web/src/components/ui/path-chips-input.tsx
+++ b/web/src/components/ui/path-chips-input.tsx
@@ -53,7 +53,7 @@ export interface PathChipsInputProps extends Omit<React.InputHTMLAttributes<HTML
   /** 是否渲染为“多行区域”的外观与高度（保持原 UI 习惯） */
   multiline?: boolean;
   /** 运行环境：决定鼠标悬停时 title 显示路径风格（默认 windows） */
-  runEnv?: 'wsl' | 'windows' | 'pwsh';
+  runEnv?: 'wsl' | 'windows' | 'pwsh' | 'cmd';
   /** 当前输入框所属 Provider；仅 Gemini 会启用专用图片保存策略 */
   providerId?: string;
   /** 当前 WSL 发行版名称；仅 Gemini + WSL 时需要 */
@@ -124,7 +124,7 @@ function isLikelyRelativePath(s: string): boolean {
  * 中文说明：判断当前运行环境是否属于 Windows 原生终端。
  */
 function isWindowsLikeRunEnv(runEnv?: PathChipsInputProps["runEnv"]): boolean {
-  return runEnv === "windows" || runEnv === "pwsh";
+  return runEnv === "windows" || runEnv === "pwsh" || runEnv === "cmd";
 }
 
 /**
@@ -152,7 +152,7 @@ function toWindowsPathText(pathText: string): string {
 /**
  * 中文说明：根据当前终端环境与路径风格，生成应写入 Chip 的路径字段。
  * - `wsl`：保留 WSL 路径用于发送，同时尽量补充 Windows 路径便于预览与系统操作。
- * - `windows/pwsh`：优先保留 Windows 路径，避免把 Chip 文本转换成 WSL 风格。
+ * - `windows/pwsh/cmd`：优先保留 Windows 路径，避免把 Chip 文本转换成 WSL 风格。
  */
 function buildChipPaths(args: {
   rawPath: string;

--- a/web/src/features/settings/settings-dialog.tsx
+++ b/web/src/features/settings/settings-dialog.tsx
@@ -257,7 +257,7 @@ function normalizeProviderEnvMap(
     const key = String(id || "").trim();
     if (!key) continue;
     const terminal: TerminalMode =
-      v?.terminal === "wsl" || v?.terminal === "windows" || v?.terminal === "pwsh"
+      v?.terminal === "wsl" || v?.terminal === "windows" || v?.terminal === "pwsh" || v?.terminal === "cmd"
         ? v.terminal
         : fallback.terminal;
     const distro = String(v?.distro || fallback.distro).trim() || fallback.distro;
@@ -382,7 +382,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
       const cur = prev[id] || prev[providersActiveId] || { terminal: "wsl" as TerminalMode, distro: "Ubuntu-24.04" };
       const next: ProviderEnvMap = { ...prev };
       next[id] = {
-        terminal: (patch.terminal === "wsl" || patch.terminal === "windows" || patch.terminal === "pwsh") ? patch.terminal : cur.terminal,
+        terminal: (patch.terminal === "wsl" || patch.terminal === "windows" || patch.terminal === "pwsh" || patch.terminal === "cmd") ? patch.terminal : cur.terminal,
         distro: typeof patch.distro === "string" && patch.distro.trim().length > 0 ? patch.distro.trim() : cur.distro,
       };
       return next;
@@ -1859,6 +1859,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                               <SelectItem value="wsl">{t("settings:terminalMode.wsl")}</SelectItem>
                               <SelectItem value="pwsh" disabled={pwshAvailable === false}>{t("settings:terminalMode.pwsh")}</SelectItem>
                               <SelectItem value="windows">{t("settings:terminalMode.windows")}</SelectItem>
+                              <SelectItem value="cmd">{t("settings:terminalMode.cmd")}</SelectItem>
                             </SelectContent>
                           </Select>
                         </div>

--- a/web/src/lib/clipboardImages.ts
+++ b/web/src/lib/clipboardImages.ts
@@ -37,7 +37,7 @@ export type PersistImagesOptions = {
   projectName?: string;
   prefix?: string;
   providerId?: string;
-  runtimeEnv?: "wsl" | "windows" | "pwsh";
+  runtimeEnv?: "wsl" | "windows" | "pwsh" | "cmd";
   distro?: string;
 };
 

--- a/web/src/lib/console-session.ts
+++ b/web/src/lib/console-session.ts
@@ -36,7 +36,7 @@ export type PersistedConsoleSession = {
   bootId?: string;
   tabsByProject: Record<string, PersistedConsoleTab[]>;
   ptyByTab: Record<string, string>;
-  tabEnvByTab?: Record<string, { terminal?: "wsl" | "windows" | "pwsh"; distro?: string }>;
+  tabEnvByTab?: Record<string, { terminal?: "wsl" | "windows" | "pwsh" | "cmd"; distro?: string }>;
   windowUiStateById?: Record<string, PersistedWindowUiState>;
 };
 
@@ -63,16 +63,16 @@ function toNonEmptyString(value: unknown): string {
 /**
  * 归一化 tab 运行环境快照；仅保留当前渲染层真正依赖的字段。
  */
-function normalizeTabEnvByTab(input: unknown): Record<string, { terminal?: "wsl" | "windows" | "pwsh"; distro?: string }> {
-  const out: Record<string, { terminal?: "wsl" | "windows" | "pwsh"; distro?: string }> = {};
+function normalizeTabEnvByTab(input: unknown): Record<string, { terminal?: "wsl" | "windows" | "pwsh" | "cmd"; distro?: string }> {
+  const out: Record<string, { terminal?: "wsl" | "windows" | "pwsh" | "cmd"; distro?: string }> = {};
   if (!input || typeof input !== "object") return out;
   for (const [tabIdRaw, itemRaw] of Object.entries(input as Record<string, unknown>)) {
     const tabId = toNonEmptyString(tabIdRaw);
     if (!tabId || !itemRaw || typeof itemRaw !== "object") continue;
     const item = itemRaw as Record<string, unknown>;
     const terminalRaw = toNonEmptyString(item.terminal).toLowerCase();
-    const terminal = terminalRaw === "windows" || terminalRaw === "pwsh" || terminalRaw === "wsl"
-      ? (terminalRaw as "wsl" | "windows" | "pwsh")
+    const terminal = terminalRaw === "windows" || terminalRaw === "pwsh" || terminalRaw === "wsl" || terminalRaw === "cmd"
+      ? (terminalRaw as "wsl" | "windows" | "pwsh" | "cmd")
       : undefined;
     const distro = toNonEmptyString(item.distro);
     out[tabId] = {

--- a/web/src/lib/gemini-attachments.ts
+++ b/web/src/lib/gemini-attachments.ts
@@ -7,7 +7,7 @@ type GeminiAttachmentChipLike = {
   fileName?: string;
 };
 
-type GeminiTerminalMode = "wsl" | "windows" | "pwsh";
+type GeminiTerminalMode = "wsl" | "windows" | "pwsh" | "cmd";
 
 /**
  * 中文说明：判断当前 Chip 是否应按 Gemini 图片附件语义发送。
@@ -24,7 +24,7 @@ export function isGeminiImageChip(chip: GeminiAttachmentChipLike | null | undefi
 export function escapeGeminiAttachmentPath(pathText: string, terminalMode: GeminiTerminalMode): string {
   const raw = String(pathText || "");
   if (!raw) return "";
-  if (terminalMode === "windows" || terminalMode === "pwsh") {
+  if (terminalMode === "windows" || terminalMode === "pwsh" || terminalMode === "cmd") {
     if (/[\s&()[\]{}^=;!'+,`~%$@#]/.test(raw)) return `"${raw}"`;
     return raw;
   }

--- a/web/src/lib/providers/normalize.ts
+++ b/web/src/lib/providers/normalize.ts
@@ -63,7 +63,7 @@ export function normalizeProvidersSettings(
   for (const [id, v] of Object.entries(envInput || {})) {
     const key = String(id || "").trim();
     if (!key) continue;
-    const terminal = (v?.terminal === "pwsh" || v?.terminal === "windows" || v?.terminal === "wsl") ? v.terminal : legacy.terminal;
+    const terminal = (v?.terminal === "pwsh" || v?.terminal === "windows" || v?.terminal === "wsl" || v?.terminal === "cmd") ? v.terminal : legacy.terminal;
     const distro = String(v?.distro || legacy.distro).trim() || legacy.distro;
     env[key] = { terminal, distro };
   }

--- a/web/src/lib/shell.test.ts
+++ b/web/src/lib/shell.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildPowerShellCall } from "./shell";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { buildCmdCall, buildPowerShellCall } from "./shell";
 
 describe("shell 工具：PowerShell 参数安全拼接", () => {
   it("包含换行的参数会被编码为单行表达式（避免 PTY 把多行拆坏）", () => {
@@ -26,6 +30,46 @@ describe("shell 工具：PowerShell 参数安全拼接", () => {
     expect(m).not.toBeNull();
     const decoded = Buffer.from(m?.[1] || "", "base64").toString("utf8");
     expect(decoded).toBe(prompt);
+  });
+
+  it("CMD 参数会按 cmd.exe 规则转义", () => {
+    const cmd = buildCmdCall(["tool", "a b", "x\"y", "100%", "a&b"]);
+    expect(cmd).toBe("tool \"a b\" \"x\"\"y\" \"100\"^% \"a&b\"");
+  });
+
+  it("CMD 引号参数不会污染普通元字符", () => {
+    const cmd = buildCmdCall(["tool", "a<b", "a|b", "caret^", "bang!"]);
+    expect(cmd).toBe("tool \"a<b\" \"a|b\" \"caret^\" \"bang!\"");
+  });
+
+  it("CMD 不应保留换行参数", () => {
+    const cmd = buildCmdCall(["tool", "a\nb"]);
+    expect(cmd).toBe("tool \"a b\"");
+  });
+
+  it.runIf(process.platform === "win32")("CMD 参数会按真实 cmd.exe 语义传给子进程", () => {
+    const args = ["a b", "x\"y", "%PATH%", "100%", "a&b", "a|b", "caret^", "bang!"];
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codexflow-cmd-argv-"));
+    const scriptPath = path.join(tempDir, "argv.js");
+    try {
+      fs.writeFileSync(scriptPath, "console.log('ARGV_JSON:' + JSON.stringify(process.argv.slice(2)));\n", "utf8");
+      const command = buildCmdCall([process.execPath, scriptPath, ...args]);
+      const result = spawnSync("cmd.exe", ["/q", "/d", "/v:off"], {
+        input: `${command}\r\nexit\r\n`,
+        encoding: "utf8",
+        timeout: 2_000,
+      });
+      if (result.error) throw result.error;
+      expect(result.status).toBe(0);
+      const stdout = String(result.stdout || "").trim();
+      const marker = "ARGV_JSON:";
+      const markerIndex = stdout.indexOf(marker);
+      expect(markerIndex).toBeGreaterThanOrEqual(0);
+      const payload = stdout.slice(markerIndex + marker.length).split(/\r?\n/)[0] || "";
+      expect(JSON.parse(payload)).toEqual(args);
+    } finally {
+      try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch {}
+    }
   });
 });
 

--- a/web/src/lib/shell.ts
+++ b/web/src/lib/shell.ts
@@ -50,10 +50,20 @@ function hasNonAsciiOrControl(text: string): boolean {
 }
 
 /**
- * 判断是否为 Windows 系终端（PowerShell / PowerShell 7）。
+ * 判断是否为 Windows 系终端（PowerShell / PowerShell 7 / CMD）。
  */
 export function isWindowsLikeTerminal(mode: TerminalMode): boolean {
   return mode !== "wsl";
+}
+
+/**
+ * 判断是否为 CMD 终端。
+ *
+ * @param mode 终端模式
+ * @returns 是否 CMD
+ */
+export function isCmdTerminal(mode: TerminalMode): boolean {
+  return mode === "cmd";
 }
 
 /**
@@ -166,6 +176,35 @@ export function powerShellArgToken(value: string): string {
 }
 
 /**
+ * 将字符串转换为 cmd.exe 参数 token。
+ *
+ * @param value 参数值
+ * @returns 可拼接到 CMD 命令行中的参数文本
+ */
+export function cmdArgToken(value: string): string {
+  const raw = String(value ?? "").replace(/\r\n/g, " ").replace(/\r/g, " ").replace(/\n/g, " ");
+  if (raw.length === 0) return "\"\"";
+  if (!/[\s"&<>|^()%!]/.test(raw)) return raw;
+  const rendered: string[] = [];
+  let quotedPart = "";
+  const flushQuotedPart = () => {
+    if (!quotedPart) return;
+    rendered.push(`"${quotedPart.replace(/"/g, "\"\"")}"`);
+    quotedPart = "";
+  };
+  for (const ch of raw) {
+    if (ch === "%") {
+      flushQuotedPart();
+      rendered.push("^%");
+      continue;
+    }
+    quotedPart += ch;
+  }
+  flushQuotedPart();
+  return rendered.join("") || "\"\"";
+}
+
+/**
  * 基于 argv 构造 PowerShell 调用表达式（使用 call operator `&`）。
  * - 命令与参数会被转换为可安全粘贴/执行的 token（默认单引号；包含换行或非 ASCII 的参数自动 Base64 编码还原）。
  */
@@ -176,4 +215,16 @@ export function buildPowerShellCall(argv: string[]): string {
   const rendered = [`& ${powerShellArgToken(cmd)}`];
   for (const a of args) rendered.push(powerShellArgToken(a));
   return rendered.join(" ");
+}
+
+/**
+ * 基于 argv 构造 CMD 调用表达式。
+ *
+ * @param argv 命令与参数列表
+ * @returns 可直接在 cmd.exe 中执行的命令行
+ */
+export function buildCmdCall(argv: string[]): string {
+  const parts = (argv || []).map((x) => String(x || "")).filter((x) => x.length > 0);
+  if (parts.length === 0) return "";
+  return parts.map(cmdArgToken).join(" ");
 }

--- a/web/src/locales/en/settings.json
+++ b/web/src/locales/en/settings.json
@@ -195,7 +195,8 @@
     "wsl": "WSL",
     "pwsh": "Windows (PowerShell 7)",
     "windows": "Windows (PowerShell)",
-    "help": "Switch between WSL, PowerShell 7, and Windows PowerShell.",
+    "cmd": "Windows (CMD)",
+    "help": "Switch between WSL, PowerShell 7, Windows PowerShell, and CMD.",
     "pwshDetecting": "Detecting PowerShell 7 availability...",
     "pwshDetected": "PowerShell 7 detected:",
     "pwshUnavailable": "PowerShell 7 is not available. Falling back to Windows PowerShell."

--- a/web/src/locales/zh/settings.json
+++ b/web/src/locales/zh/settings.json
@@ -195,7 +195,8 @@
     "wsl": "WSL 终端",
     "pwsh": "Windows（PowerShell 7）",
     "windows": "Windows（PowerShell）",
-    "help": "在 WSL、PowerShell 7 与传统 PowerShell 之间切换命令执行环境。",
+    "cmd": "Windows（CMD）",
+    "help": "在 WSL、PowerShell 7、传统 PowerShell 与 CMD 之间切换命令执行环境。",
     "pwshDetecting": "正在检测 PowerShell 7 可用性…",
     "pwshDetected": "已检测到 PowerShell 7：",
     "pwshUnavailable": "未检测到 PowerShell 7，已回退到传统 PowerShell。"

--- a/web/src/providers/claude/commands.ts
+++ b/web/src/providers/claude/commands.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
 import type { AppSettings } from "@/types/host";
-import { bashSingleQuote, buildPowerShellCall, isWindowsLikeTerminal, splitCommandLineToArgv } from "@/lib/shell";
+import { bashSingleQuote, buildCmdCall, buildPowerShellCall, isCmdTerminal, isWindowsLikeTerminal, splitCommandLineToArgv } from "@/lib/shell";
 
 type TerminalMode = NonNullable<AppSettings["terminal"]>;
 
@@ -17,7 +17,7 @@ export function resolveClaudeStartupCmd(cmd: string | null | undefined): string 
 /**
  * 构造 Claude 的“继续对话”启动命令：
  * - 优先 `--resume <sessionId>`（若可用），失败时回退 `--continue`
- * - 适配 WSL（bash）与 Windows（PowerShell）两种执行环境
+ * - 适配 WSL（bash）、PowerShell 与 CMD 执行环境
  */
 export function buildClaudeResumeStartupCmd(args: {
   cmd: string | null | undefined;
@@ -27,6 +27,15 @@ export function buildClaudeResumeStartupCmd(args: {
   const baseCmdRaw = resolveClaudeStartupCmd(args.cmd);
   const sessionId = String(args.sessionId || "").trim();
   const hasSessionId = sessionId.length > 0;
+
+  if (isCmdTerminal(args.terminalMode)) {
+    const baseArgv = splitCommandLineToArgv(baseCmdRaw);
+    const base = baseArgv.length > 0 ? baseArgv : ["claude"];
+    const cont = buildCmdCall([...base, "--continue"]);
+    if (!hasSessionId) return cont;
+    const resume = buildCmdCall([...base, "--resume", sessionId]);
+    return `${resume} || ${cont}`;
+  }
 
   if (isWindowsLikeTerminal(args.terminalMode)) {
     const baseArgv = splitCommandLineToArgv(baseCmdRaw);

--- a/web/src/providers/codex/commands.ts
+++ b/web/src/providers/codex/commands.ts
@@ -17,6 +17,13 @@ export function injectCodexTraceEnv(args: {
   const base = raw.length > 0 ? raw : "codex";
   if (!args.traceEnabled) return base;
 
+  if (args.terminalMode === "cmd") {
+    if (/RUST_LOG\s*=/.test(base)) {
+      return base;
+    }
+    return `set "RUST_LOG=codex_tui=trace" && ${base}`;
+  }
+
   const isWindowsLike = args.terminalMode !== "wsl";
   if (isWindowsLike) {
     if (/RUST_LOG\s*=/.test(base) || base.includes("$env:RUST_LOG")) {

--- a/web/src/providers/gemini/commands.ts
+++ b/web/src/providers/gemini/commands.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
 import type { AppSettings } from "@/types/host";
-import { bashSingleQuote, buildPowerShellCall, isWindowsLikeTerminal, splitCommandLineToArgv } from "@/lib/shell";
+import { bashSingleQuote, buildCmdCall, buildPowerShellCall, isCmdTerminal, isWindowsLikeTerminal, splitCommandLineToArgv } from "@/lib/shell";
 
 type TerminalMode = NonNullable<AppSettings["terminal"]>;
 
@@ -17,7 +17,7 @@ export function resolveGeminiStartupCmd(cmd: string | null | undefined): string 
 /**
  * 构造 Gemini 的“继续对话”启动命令：
  * - 优先 `--resume <sessionId>`（若 sessionId 缺失则使用 `latest`）
- * - 适配 WSL（bash）与 Windows（PowerShell）两种执行环境
+ * - 适配 WSL（bash）、PowerShell 与 CMD 执行环境
  */
 export function buildGeminiResumeStartupCmd(args: {
   cmd: string | null | undefined;
@@ -27,6 +27,12 @@ export function buildGeminiResumeStartupCmd(args: {
   const baseCmdRaw = resolveGeminiStartupCmd(args.cmd);
   const sid = String(args.sessionId || "").trim();
   const resumeArg = sid.length > 0 ? sid : "latest";
+
+  if (isCmdTerminal(args.terminalMode)) {
+    const baseArgv = splitCommandLineToArgv(baseCmdRaw);
+    const base = baseArgv.length > 0 ? baseArgv : ["gemini"];
+    return buildCmdCall([...base, "--resume", resumeArg]);
+  }
 
   if (isWindowsLikeTerminal(args.terminalMode)) {
     const baseArgv = splitCommandLineToArgv(baseCmdRaw);

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -10,6 +10,8 @@ export type ThemeSetting = 'light' | 'dark' | 'system';
 
 export type ProviderId = string;
 
+export type TerminalMode = 'wsl' | 'windows' | 'pwsh' | 'cmd';
+
 export type ProviderItem = {
   id: ProviderId;
   displayName?: string;
@@ -19,7 +21,7 @@ export type ProviderItem = {
 };
 
 export type ProviderEnv = {
-  terminal?: 'wsl' | 'windows' | 'pwsh';
+  terminal?: TerminalMode;
   distro?: string;
 };
 
@@ -63,7 +65,7 @@ export type ProvidersSettings = {
 };
 
 export type AppSettings = {
-  terminal?: 'wsl' | 'windows' | 'pwsh';
+  terminal?: TerminalMode;
   terminalTheme?: TerminalThemeId;
   distro: string;
   codexCmd: string;
@@ -337,7 +339,7 @@ export type HistoryMessage = { role: string; content: MessageContent[] };
 
 // ---- Host API 声明 ----
 export interface PtyAPI {
-  openWSLConsole(args: { terminal?: 'wsl' | 'windows' | 'pwsh'; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string> }): Promise<{ id: string }>;
+  openWSLConsole(args: { terminal?: TerminalMode; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string> }): Promise<{ id: string }>;
   /** 读取 PTY 的尾部输出缓存（用于渲染进程 reload/HMR 后恢复终端滚动区）。 */
   backlog?: (id: string, args?: { maxChars?: number }) => Promise<{ ok: boolean; data?: string; error?: string }>;
   write(id: string, data: string): void;
@@ -884,7 +886,7 @@ export interface NotificationsAPI {
 export interface UtilsAPI {
   /** 探测当前 Gemini CLI 版本对应的外部编辑器快捷键策略。 */
   resolveGeminiExternalEditorShortcut(args: {
-    terminal?: "wsl" | "windows" | "pwsh";
+    terminal?: TerminalMode;
     distro?: string;
     startupCmd?: string;
   }): Promise<{
@@ -971,7 +973,7 @@ export interface UtilsAPI {
   /** 设置或清除指定项目根目录的 IDE 绑定（清除时需显式传入 null）。 */
   setProjectPreferredIde(projectPath: string, config: ProjectIdePreference | ProjectPreferredIde | null): Promise<{ ok: boolean; error?: string }>;
   openExternalUrl(url: string): Promise<{ ok: boolean; error?: string }>;
-  openExternalConsole(args: { terminal?: 'wsl' | 'windows' | 'pwsh'; wslPath?: string; winPath?: string; distro?: string; startupCmd?: string; title?: string }): Promise<{ ok: boolean; error?: string }>;
+  openExternalConsole(args: { terminal?: TerminalMode; wslPath?: string; winPath?: string; distro?: string; startupCmd?: string; title?: string }): Promise<{ ok: boolean; error?: string }>;
   // 兼容旧名
   openExternalWSLConsole?(args: { wslPath?: string; winPath?: string; distro?: string; startupCmd?: string }): Promise<{ ok: boolean; error?: string }>;
   pathExists(p: string, dirOnly?: boolean): Promise<{ ok: boolean; exists?: boolean; isDirectory?: boolean; isFile?: boolean; error?: string }>;
@@ -1035,9 +1037,9 @@ export interface GitRepoWatchAPI {
 }
 
 export interface ImagesAPI {
-  saveDataURL(args: { dataURL: string; projectWinRoot?: string; projectWslRoot?: string; projectName?: string; ext?: string; prefix?: string; providerId?: string; runtimeEnv?: "wsl" | "windows" | "pwsh"; distro?: string }): Promise<{ ok: boolean; winPath?: string; wslPath?: string; fileName?: string; error?: string }>;
+  saveDataURL(args: { dataURL: string; projectWinRoot?: string; projectWslRoot?: string; projectName?: string; ext?: string; prefix?: string; providerId?: string; runtimeEnv?: TerminalMode; distro?: string }): Promise<{ ok: boolean; winPath?: string; wslPath?: string; fileName?: string; error?: string }>;
   clipboardHasImage(): Promise<{ ok: boolean; has?: boolean; error?: string }>;
-  saveFromClipboard(args: { projectWinRoot?: string; projectWslRoot?: string; projectName?: string; prefix?: string; providerId?: string; runtimeEnv?: "wsl" | "windows" | "pwsh"; distro?: string }): Promise<{ ok: boolean; winPath?: string; wslPath?: string; fileName?: string; error?: string }>;
+  saveFromClipboard(args: { projectWinRoot?: string; projectWslRoot?: string; projectName?: string; prefix?: string; providerId?: string; runtimeEnv?: TerminalMode; distro?: string }): Promise<{ ok: boolean; winPath?: string; wslPath?: string; fileName?: string; error?: string }>;
   copyToClipboard(args: { localPath?: string; src?: string; fallbackSrc?: string }): Promise<{ ok: boolean; error?: string }>;
   materializePreviewURL(args: { src?: string }): Promise<{ ok: boolean; src?: string; mimeType?: string; error?: string }>;
   trash(args: { winPath: string }): Promise<{ ok: boolean; error?: string }>;


### PR DESCRIPTION
为终端运行环境补充 CMD 模式，使 Codex、Claude 与 Gemini 可以在 Windows CMD 下启动、恢复会话并处理运行时状态。

技术调整：
- 扩展 terminal/provider runtime 类型与设置归一化，新增 cmd 模式并同步 IPC、preload 与渲染层类型。
- 在设置页、顶部状态组件、会话持久化、路径/图片附件处理和 provider 命令构造中接入 CMD。
- 为 Codex、Claude、Gemini 分别适配 CMD 启动、继续对话与初始提示词命令拼接。
- 修复 CMD 参数转义，避免 %PATH% 被环境变量展开，且不污染 &、|、<、>、^、! 等普通实参。
- 内置 CMD PTY 使用 /v:off 禁用延迟变量展开，保持与外部 CMD 行为一致。

验证：
- npm run test -- web/src/lib/shell.test.ts --run
- npm run build:electron
- npm run i18n:check
- npm run test