### PR TITLE
fix(git): 修复提交树右键菜单的删除与跳转源规则

### DIFF
--- a/web/src/features/git/commit-panel/context-menu-model.test.ts
+++ b/web/src/features/git/commit-panel/context-menu-model.test.ts
@@ -61,6 +61,27 @@ describe("commit tree context menu model", () => {
     expect(localHistory?.disabled).toBe(true);
   });
 
+  it("多选可导航目录时应保留跳转到源入口", () => {
+    const sections = buildCommitTreeSharedMenuSections({
+      selection: {
+        canCommit: false,
+        canRollback: true,
+        canMoveToList: true,
+        canShowDiff: true,
+        canOpenSource: true,
+        canDelete: true,
+        canAddToVcs: true,
+        canIgnore: true,
+        canShowHistory: false,
+        canShelve: true,
+      },
+      singleSelection: false,
+    });
+
+    expect(sections[0].map((node) => node.id)).toContain("editSource");
+    expect(sections[0].find((node) => node.id === "editSource")).toMatchObject({ disabled: false });
+  });
+
   it("目录类单选应保留删除入口，并隐藏 edit-source", () => {
     const sections = buildCommitTreeSharedMenuSections({
       selection: {
@@ -89,12 +110,12 @@ describe("commit tree context menu model", () => {
     ]);
   });
 
-  it("删除入口显示规则应对目录类单选对齐 IDEA", () => {
+  it("删除入口显示规则应对可解析删除目标的目录选择对齐 IDEA", () => {
     expect(shouldShowCommitTreeSharedDeleteAction({
       exactlySelectedFileCount: 0,
+      selectedDeleteTargetCount: 1,
       singleSelection: true,
       selectedNodeKind: "directory",
-      selectedNodeDisplayPath: ".serena",
     })).toBe(true);
     expect(shouldShowCommitTreeSharedDeleteAction({
       exactlySelectedFileCount: 0,
@@ -103,17 +124,27 @@ describe("commit tree context menu model", () => {
     })).toBe(true);
     expect(shouldShowCommitTreeSharedDeleteAction({
       exactlySelectedFileCount: 0,
+      selectedDeleteTargetCount: 2,
       singleSelection: false,
       selectedNodeKind: "directory",
-    })).toBe(false);
+    })).toBe(true);
   });
 
-  it("折叠后的多级目录展示节点不应显示删除入口", () => {
+  it("折叠后的多级目录只要有真实删除目标就应显示删除入口", () => {
     expect(shouldShowCommitTreeSharedDeleteAction({
       exactlySelectedFileCount: 0,
+      selectedDeleteTargetCount: 1,
       singleSelection: true,
       selectedNodeKind: "directory",
-      selectedNodeDisplayPath: ".claude\\skills\\gitnexus",
+    })).toBe(true);
+  });
+
+  it("没有文件或删除目标的多选仍应隐藏删除入口", () => {
+    expect(shouldShowCommitTreeSharedDeleteAction({
+      exactlySelectedFileCount: 0,
+      selectedDeleteTargetCount: 0,
+      singleSelection: false,
+      selectedNodeKind: "directory",
     })).toBe(false);
   });
 

--- a/web/src/features/git/commit-panel/context-menu-model.ts
+++ b/web/src/features/git/commit-panel/context-menu-model.ts
@@ -36,15 +36,6 @@ export type CommitTreeSharedMenuNode =
     children: CommitTreeSharedMenuNode[];
   };
 
-/**
- * 判断当前目录节点是否是“折叠后的多级路径展示”。
- * IDEA 会把连续单子目录折叠成展示文案，但这类节点的菜单能力不能简单等同于普通目录。
- */
-function isCollapsedDirectoryDisplayPath(pathText: string | undefined): boolean {
-  const normalized = String(pathText || "").trim();
-  return normalized.includes("\\") || normalized.includes("/");
-}
-
 type CommitTreeSharedSelectionSnapshot = Pick<
   CommitSelectionContext,
   | "canCommit"
@@ -61,19 +52,17 @@ type CommitTreeSharedSelectionSnapshot = Pick<
 
 /**
  * 对齐 IDEA 提交树共享菜单的删除入口显示规则。
- * 单文件精确选择始终显示；目录 / 模块 / 仓库节点单选时也保留删除入口。
+ * 只要当前冻结选区能解析出真实删除目标，就等价于 IDEA DataContext 中存在 VIRTUAL_FILE_ARRAY。
  */
 export function shouldShowCommitTreeSharedDeleteAction(args: {
   exactlySelectedFileCount: number;
+  selectedDeleteTargetCount?: number;
   singleSelection: boolean;
   selectedNodeKind?: string;
-  selectedNodeDisplayPath?: string;
 }): boolean {
   if (args.exactlySelectedFileCount > 0) return true;
+  if ((args.selectedDeleteTargetCount || 0) > 0) return true;
   if (!args.singleSelection) return false;
-  if (args.selectedNodeKind === "directory") {
-    return !isCollapsedDirectoryDisplayPath(args.selectedNodeDisplayPath);
-  }
   return args.selectedNodeKind === "directory"
     || args.selectedNodeKind === "module"
     || args.selectedNodeKind === "repository";
@@ -144,7 +133,7 @@ export function buildCommitTreeSharedMenuSections(args: {
       createActionNode("showDiff", { disabled: !selection.canShowDiff, shortcut: "Ctrl+D" }),
       createActionNode("showStandaloneDiff", { disabled: !selection.canShowDiff }),
       ...(showEditSource
-        ? [createActionNode("editSource", { disabled: !selection.canOpenSource || !singleSelection, shortcut: "F4" })]
+        ? [createActionNode("editSource", { disabled: !selection.canOpenSource, shortcut: "F4" })]
         : []),
     ],
     [

--- a/web/src/features/git/commit-panel/selection-model.ts
+++ b/web/src/features/git/commit-panel/selection-model.ts
@@ -554,7 +554,7 @@ export function deriveCommitSelectionContext(args: {
     canCompareStagedToLocal: canCompareWithStaged,
     canCompareStagedToHead: canCompareWithHead,
     canCompareThreeVersions: canCompareWithHead && canShowLocal,
-    canOpenSource: args.selectedPaths.length === 1,
+    canOpenSource: selectedVirtualPaths.length > 0,
     canDelete: actionableEntries.length > 0,
     canShowHistory,
     changeListsEnabled,

--- a/web/src/features/git/git-workbench.tsx
+++ b/web/src/features/git/git-workbench.tsx
@@ -17136,11 +17136,11 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
         showAddToVcs: showAddToVcsAction,
         showDelete: shouldShowCommitTreeSharedDeleteAction({
           exactlySelectedFileCount: selectionContext.exactlySelectedFiles.length,
+          selectedDeleteTargetCount: menuCommitSelectionSnapshot.selectedDeleteTargets.length,
           singleSelection: singleTreeSelection,
           selectedNodeKind: menuCommitSelectionSnapshot.selectedSingleNode?.kind,
-          selectedNodeDisplayPath: menuCommitSelectionSnapshot.selectedSingleNode?.textPresentation || menuCommitSelectionSnapshot.selectedSingleNode?.name,
         }),
-        showEditSource: selectionContext.exactlySelectedFiles.length === 1,
+        showEditSource: selectionContext.navigatablePaths.length > 0,
       });
       /**
        * 把提交树共享菜单模型渲染成具体菜单项，统一承接 IDEA 提交工具窗口层级与当前产品豁免映射。


### PR DESCRIPTION
- 按冻结选区中的真实可操作目标决定删除入口显示，覆盖多选目录与折叠目录场景
- 将“跳转到源”改为基于可导航路径判断，并与菜单执行逻辑保持一致
- 补充回归测试，覆盖多选可导航目录、可解析删除目标与无删除目标场景