### PR TITLE
fix(codex): 清理已删除会话的 SQLite 状态

### DIFF
--- a/electron/codexStateCleanup.test.ts
+++ b/electron/codexStateCleanup.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { promises as fsp } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+type TestDb = {
+  exec(sql: string): void;
+  prepare(sql: string): {
+    get(...params: unknown[]): Record<string, unknown> | undefined;
+    run(...params: unknown[]): { changes: number };
+  };
+  close(): void;
+};
+
+const wslMockState = vi.hoisted(() => ({
+  roots: {
+    windowsCodex: "",
+    windowsSessions: "",
+    wsl: [] as { distro: string; codexUNC: string; sessionsUNC: string }[],
+  },
+}));
+
+vi.mock("./wsl", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./wsl")>();
+  return {
+    ...actual,
+    getCodexRootsFastAsync: vi.fn(async () => wslMockState.roots),
+  };
+});
+
+import { __codexStateCleanupTestHooks, cleanupCodexStateForDeletedHistoryFiles, repairMissingCodexRolloutRows } from "./codexStateCleanup";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Database = require("better-sqlite3") as new (filename: string) => TestDb;
+
+const tempDirs: string[] = [];
+const originalCwd = process.cwd();
+const originalCodexSqliteHome = process.env.CODEX_SQLITE_HOME;
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  if (originalCodexSqliteHome === undefined) delete process.env.CODEX_SQLITE_HOME;
+  else process.env.CODEX_SQLITE_HOME = originalCodexSqliteHome;
+  for (const dir of tempDirs.splice(0)) {
+    await fsp.rm(dir, { recursive: true, force: true }).catch(() => undefined);
+  }
+  wslMockState.roots = { windowsCodex: "", windowsSessions: "", wsl: [] };
+  vi.restoreAllMocks();
+});
+
+/** 创建临时 Codex home。 */
+async function createCodexHome(): Promise<string> {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "codexflow-codex-state-"));
+  tempDirs.push(root);
+  const codexHome = path.join(root, ".codex");
+  await fsp.mkdir(codexHome, { recursive: true });
+  return codexHome;
+}
+
+/** 打开测试 SQLite DB。 */
+function openTestDb(filePath: string): TestDb {
+  return new Database(filePath);
+}
+
+/** 读取表行数。 */
+function countRows(db: TestDb, table: string): number {
+  const row = db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get();
+  return Number(row?.count || 0);
+}
+
+/** 列出目录中的 CodexFlow sqlite 备份文件。 */
+async function listCodexFlowBackupFiles(dir: string): Promise<string[]> {
+  const entries = await fsp.readdir(dir);
+  return entries.filter((name) => name.includes(".codexflow-backup-")).sort();
+}
+
+/** 创建当前和旧版兼容的 state DB 测试结构。 */
+function createStateDb(dbPath: string, rows: { id: string; rolloutPath: string }[]): void {
+  const db = openTestDb(dbPath);
+  try {
+    db.exec(`
+      CREATE TABLE threads (
+        id TEXT PRIMARY KEY,
+        rollout_path TEXT NOT NULL
+      );
+      CREATE TABLE thread_dynamic_tools (
+        thread_id TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        name TEXT NOT NULL,
+        PRIMARY KEY(thread_id, position)
+      );
+      CREATE TABLE thread_spawn_edges (
+        parent_thread_id TEXT NOT NULL,
+        child_thread_id TEXT NOT NULL PRIMARY KEY,
+        status TEXT NOT NULL
+      );
+    `);
+    const insertThread = db.prepare("INSERT INTO threads (id, rollout_path) VALUES (?, ?)");
+    for (const row of rows) insertThread.run(row.id, row.rolloutPath);
+  } finally {
+    db.close();
+  }
+}
+
+/** 创建 goals DB 测试结构。 */
+function createGoalsDb(dbPath: string, threadId: string): void {
+  const db = openTestDb(dbPath);
+  try {
+    db.exec("CREATE TABLE thread_goals (thread_id TEXT PRIMARY KEY, objective TEXT NOT NULL);");
+    db.prepare("INSERT INTO thread_goals (thread_id, objective) VALUES (?, ?)").run(threadId, "goal");
+  } finally {
+    db.close();
+  }
+}
+
+/** 创建 memories DB 测试结构。 */
+function createMemoriesDb(dbPath: string, threadId: string): void {
+  const db = openTestDb(dbPath);
+  try {
+    db.exec(`
+      CREATE TABLE stage1_outputs (thread_id TEXT PRIMARY KEY, raw_memory TEXT NOT NULL);
+      CREATE TABLE jobs (kind TEXT NOT NULL, job_key TEXT NOT NULL, status TEXT NOT NULL, PRIMARY KEY(kind, job_key));
+    `);
+    db.prepare("INSERT INTO stage1_outputs (thread_id, raw_memory) VALUES (?, ?)").run(threadId, "memory");
+    db.prepare("INSERT INTO jobs (kind, job_key, status) VALUES (?, ?, ?)").run("memory_stage1", threadId, "pending");
+  } finally {
+    db.close();
+  }
+}
+
+describe("codexStateCleanup", () => {
+  it("路径 key 保留 WSL UNC 前缀用于正确推导 Codex home", () => {
+    const threadId = "00000000-0000-0000-0000-000000000007";
+    const uncPath = `\\\\wsl.localhost\\Ubuntu-24.04\\home\\tester\\.codex\\sessions\\2026\\06\\07\\rollout-2026-06-07T01-02-08-${threadId}.jsonl`;
+
+    const key = __codexStateCleanupTestHooks.pathKey(uncPath);
+
+    expect(key).toBe(`//wsl.localhost/ubuntu-24.04/home/tester/.codex/sessions/2026/06/07/rollout-2026-06-07t01-02-08-${threadId}.jsonl`);
+    if (process.platform === "win32") {
+      expect(__codexStateCleanupTestHooks.accessPathFromKey(key)).toBe(`\\\\wsl.localhost\\ubuntu-24.04\\home\\tester\\.codex\\sessions\\2026\\06\\07\\rollout-2026-06-07t01-02-08-${threadId}.jsonl`);
+    }
+  });
+
+  it("精准清理已删除 rollout 对应的 state/goals/memories 记录", async () => {
+    const codexHome = await createCodexHome();
+    const threadId = "00000000-0000-0000-0000-000000000001";
+    const rolloutPath = path.join(
+      codexHome,
+      "sessions",
+      "2026",
+      "06",
+      "07",
+      `rollout-2026-06-07T01-02-03-${threadId}.jsonl`,
+    );
+    createStateDb(path.join(codexHome, "state_5.sqlite"), [{ id: threadId, rolloutPath }]);
+    createGoalsDb(path.join(codexHome, "goals_1.sqlite"), threadId);
+    createMemoriesDb(path.join(codexHome, "memories_1.sqlite"), threadId);
+
+    const stateDb = openTestDb(path.join(codexHome, "state_5.sqlite"));
+    try {
+      stateDb.prepare("INSERT INTO thread_dynamic_tools (thread_id, position, name) VALUES (?, ?, ?)").run(threadId, 1, "tool");
+      stateDb.prepare("INSERT INTO thread_spawn_edges (parent_thread_id, child_thread_id, status) VALUES (?, ?, ?)").run(threadId, "child", "open");
+    } finally {
+      stateDb.close();
+    }
+
+    const result = await cleanupCodexStateForDeletedHistoryFiles([rolloutPath]);
+
+    expect(result.ok).toBe(true);
+    expect(result.deletedThreadRows).toBe(1);
+    expect(await listCodexFlowBackupFiles(codexHome)).toHaveLength(0);
+    const afterState = openTestDb(path.join(codexHome, "state_5.sqlite"));
+    const afterGoals = openTestDb(path.join(codexHome, "goals_1.sqlite"));
+    const afterMemories = openTestDb(path.join(codexHome, "memories_1.sqlite"));
+    try {
+      expect(countRows(afterState, "threads")).toBe(0);
+      expect(countRows(afterState, "thread_dynamic_tools")).toBe(0);
+      expect(countRows(afterState, "thread_spawn_edges")).toBe(0);
+      expect(countRows(afterGoals, "thread_goals")).toBe(0);
+      expect(countRows(afterMemories, "stage1_outputs")).toBe(0);
+      expect(countRows(afterMemories, "jobs")).toBe(0);
+    } finally {
+      afterState.close();
+      afterGoals.close();
+      afterMemories.close();
+    }
+  });
+
+  it("按 CODEX_SQLITE_HOME 相对当前工作目录查找 sqlite home", async () => {
+    const codexHome = await createCodexHome();
+    const workspace = path.dirname(codexHome);
+    const sqliteHome = path.join(workspace, "sqlite-home");
+    await fsp.mkdir(sqliteHome, { recursive: true });
+    process.chdir(workspace);
+    process.env.CODEX_SQLITE_HOME = "sqlite-home";
+    const threadId = "00000000-0000-0000-0000-000000000005";
+    const rolloutPath = path.join(codexHome, "sessions", "2026", "06", "07", `rollout-2026-06-07T01-02-06-${threadId}.jsonl`);
+    createStateDb(path.join(sqliteHome, "state_5.sqlite"), [{ id: threadId, rolloutPath }]);
+
+    const result = await cleanupCodexStateForDeletedHistoryFiles([rolloutPath]);
+
+    expect(result.ok).toBe(true);
+    expect(result.deletedThreadRows).toBe(1);
+    const after = openTestDb(path.join(sqliteHome, "state_5.sqlite"));
+    try {
+      expect(countRows(after, "threads")).toBe(0);
+    } finally {
+      after.close();
+    }
+  });
+
+  it("解析 config.toml sqlite_home 时保留引号内的井号字符", async () => {
+    const codexHome = await createCodexHome();
+    const sqliteHome = path.join(path.dirname(codexHome), "sqlite#home");
+    await fsp.mkdir(sqliteHome, { recursive: true });
+    await fsp.writeFile(path.join(codexHome, "config.toml"), `sqlite_home = '${sqliteHome}' # comment\n`, "utf8");
+    const threadId = "00000000-0000-0000-0000-000000000006";
+    const rolloutPath = path.join(codexHome, "sessions", "2026", "06", "07", `rollout-2026-06-07T01-02-07-${threadId}.jsonl`);
+    createStateDb(path.join(sqliteHome, "state_5.sqlite"), [{ id: threadId, rolloutPath }]);
+
+    const result = await cleanupCodexStateForDeletedHistoryFiles([rolloutPath]);
+
+    expect(result.ok).toBe(true);
+    expect(result.deletedThreadRows).toBe(1);
+    const after = openTestDb(path.join(sqliteHome, "state_5.sqlite"));
+    try {
+      expect(countRows(after, "threads")).toBe(0);
+    } finally {
+      after.close();
+    }
+  });
+
+  it("自动补救只删除可确认缺失的 rollout，不删除仍存在的文件", async () => {
+    const codexHome = await createCodexHome();
+    const missingId = "00000000-0000-0000-0000-000000000002";
+    const existingId = "00000000-0000-0000-0000-000000000003";
+    const sessionDir = path.join(codexHome, "sessions", "2026", "06", "07");
+    await fsp.mkdir(sessionDir, { recursive: true });
+    const missingPath = path.join(sessionDir, `rollout-2026-06-07T01-02-03-${missingId}.jsonl`);
+    const existingPath = path.join(sessionDir, `rollout-2026-06-07T01-02-04-${existingId}.jsonl`);
+    await fsp.writeFile(existingPath, "{}\n", "utf8");
+    vi.spyOn(os, "homedir").mockReturnValue(path.dirname(codexHome));
+    createStateDb(path.join(codexHome, "state_5.sqlite"), [
+      { id: missingId, rolloutPath: missingPath },
+      { id: existingId, rolloutPath: existingPath },
+    ]);
+    wslMockState.roots = {
+      windowsCodex: codexHome,
+      windowsSessions: path.join(codexHome, "sessions"),
+      wsl: [],
+    };
+
+    const result = await repairMissingCodexRolloutRows();
+
+    expect(result.ok).toBe(true);
+    expect(result.repairedStaleRows).toBe(1);
+    const db = openTestDb(path.join(codexHome, "state_5.sqlite"));
+    try {
+      expect(countRows(db, "threads")).toBe(1);
+      const row = db.prepare("SELECT id FROM threads").get();
+      expect(row?.id).toBe(existingId);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("旧版缺少关联表时跳过不存在的表列并继续清理 threads", async () => {
+    const codexHome = await createCodexHome();
+    const threadId = "00000000-0000-0000-0000-000000000004";
+    const rolloutPath = path.join(codexHome, "sessions", "2026", "06", "07", `rollout-2026-06-07T01-02-05-${threadId}.jsonl`);
+    const db = openTestDb(path.join(codexHome, "state.sqlite"));
+    try {
+      db.exec("CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL);");
+      db.prepare("INSERT INTO threads (id, rollout_path) VALUES (?, ?)").run(threadId, rolloutPath);
+    } finally {
+      db.close();
+    }
+
+    const result = await cleanupCodexStateForDeletedHistoryFiles([rolloutPath]);
+
+    expect(result.ok).toBe(true);
+    expect(result.deletedThreadRows).toBe(1);
+    const after = openTestDb(path.join(codexHome, "state.sqlite"));
+    try {
+      expect(countRows(after, "threads")).toBe(0);
+    } finally {
+      after.close();
+    }
+  });
+});

--- a/electron/codexStateCleanup.ts
+++ b/electron/codexStateCleanup.ts
@@ -1,0 +1,593 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import fs from "node:fs";
+import { promises as fsp } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getCodexRootsFastAsync, isUNCPath, uncToWsl, wslToUNC } from "./wsl";
+
+type SqliteRunResult = { changes: number };
+type SqliteScalarRow = { count: number };
+type SqliteStatement = {
+  all(...params: unknown[]): Record<string, unknown>[];
+  get(...params: unknown[]): Record<string, unknown> | undefined;
+  run(...params: unknown[]): SqliteRunResult;
+};
+type SqliteDatabase = {
+  pragma(sql: string): unknown;
+  prepare(sql: string): SqliteStatement;
+  exec(sql: string): void;
+  transaction<T extends unknown[], R>(fn: (...args: T) => R): (...args: T) => R;
+  close(): void;
+};
+type SqliteCtor = new (
+  filename: string,
+  options?: { readonly?: boolean; fileMustExist?: boolean; timeout?: number },
+) => SqliteDatabase;
+
+type ThreadRow = {
+  id: string;
+  rolloutPath: string;
+};
+
+type TargetMatcher = {
+  ids: Set<string>;
+  pathKeys: Set<string>;
+};
+
+type CodexHomeWork = {
+  codexHome: string;
+  distro?: string;
+  source: string;
+  matcher: TargetMatcher;
+};
+
+type CleanupOptions = {
+  repairMissingRollouts?: boolean;
+};
+
+export type CodexStateCleanupResult = {
+  ok: boolean;
+  sqliteAvailable: boolean;
+  scannedDbPaths: string[];
+  deletedThreadIds: string[];
+  deletedThreadRows: number;
+  deletedAuxRows: number;
+  repairedStaleRows: number;
+  skippedRows: number;
+  errors: string[];
+};
+
+let sqliteCtorCache: SqliteCtor | null | undefined;
+
+/** 创建空的 Codex state 清理统计结果。 */
+function createResult(sqliteAvailable: boolean): CodexStateCleanupResult {
+  return {
+    ok: true,
+    sqliteAvailable,
+    scannedDbPaths: [],
+    deletedThreadIds: [],
+    deletedThreadRows: 0,
+    deletedAuxRows: 0,
+    repairedStaleRows: 0,
+    skippedRows: 0,
+    errors: [],
+  };
+}
+
+/** 懒加载 better-sqlite3，缺失或 ABI 不匹配时返回 null 并让调用方降级跳过。 */
+function loadSqlite(): SqliteCtor | null {
+  if (sqliteCtorCache !== undefined) return sqliteCtorCache;
+  try {
+    // 使用动态 require，避免主进程编译阶段强绑定原生模块。
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    sqliteCtorCache = require("better-sqlite3") as SqliteCtor;
+  } catch {
+    sqliteCtorCache = null;
+  }
+  return sqliteCtorCache;
+}
+
+/** 去重字符串数组，并过滤空字符串。 */
+function uniqueStrings(values: Iterable<string | undefined | null>): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const text = String(value || "").trim();
+    if (!text || seen.has(text)) continue;
+    seen.add(text);
+    out.push(text);
+  }
+  return out;
+}
+
+/** 将路径转换为适合跨 Windows/WSL 比较的稳定 key。 */
+function pathKey(value: string): string {
+  let text = String(value || "").trim();
+  if (!text) return "";
+  text = text.replace(/^\\\\\?\\UNC\\/i, "\\\\");
+  text = text.replace(/^\\\\\?\\/i, "");
+  text = text.replace(/\\/g, "/");
+  const isUnc = text.startsWith("//");
+  text = text.replace(/\/+/g, "/");
+  if (isUnc) text = `//${text.replace(/^\/+/, "")}`;
+  if (/^[a-zA-Z]:\//.test(text) || text.startsWith("//")) text = text.toLowerCase();
+  return text.replace(/\/+$/g, "");
+}
+
+/** 将规范化 key 尽量还原为当前 Node 可访问的路径。 */
+function accessPathFromKey(key: string): string {
+  if (process.platform === "win32" && key.startsWith("//"))
+    return key.replace(/\//g, "\\");
+  if (process.platform === "win32" && /^[a-z]:\//i.test(key))
+    return key.replace(/\//g, "\\");
+  return key;
+}
+
+/** 暴露给单测的路径规范化内部函数，避免跨 Windows/WSL 路径行为回归。 */
+export const __codexStateCleanupTestHooks = {
+  pathKey,
+  accessPathFromKey,
+};
+
+/** 判断文件是否是可访问的普通文件。 */
+function isExistingFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** 判断路径是否是可访问的目录。 */
+function isExistingDirectory(dirPath: string): boolean {
+  try {
+    return fs.statSync(dirPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** 从 rollout 文件名中提取 Codex thread UUID。 */
+function threadIdFromRolloutFileName(filePath: string): string | null {
+  const base = path.basename(filePath).replace(/\.jsonl$/i, "");
+  const match = base.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i);
+  return match ? match[1].toLowerCase() : null;
+}
+
+/** 将 Windows 盘符路径转换为 WSL /mnt 路径。 */
+function windowsDriveToWslPath(filePath: string): string | null {
+  const match = filePath.replace(/\\/g, "/").match(/^([a-zA-Z]):\/(.*)$/);
+  if (!match) return null;
+  return `/mnt/${match[1].toLowerCase()}/${match[2]}`;
+}
+
+/** 将 WSL /mnt 路径转换为 Windows 盘符路径。 */
+function wslMntToWindowsPath(filePath: string): string | null {
+  const match = filePath.match(/^\/mnt\/([a-zA-Z])\/(.+)$/);
+  if (!match) return null;
+  return `${match[1].toUpperCase()}:\\${match[2].replace(/\//g, "\\")}`;
+}
+
+/** 生成一个路径在 Codex/Windows/WSL 之间的等价比较 key。 */
+function equivalentPathKeys(filePath: string, distro?: string): Set<string> {
+  const keys = new Set<string>();
+  const add = (value?: string | null) => {
+    const key = pathKey(String(value || ""));
+    if (key) keys.add(key);
+  };
+  add(filePath);
+  add(filePath.replace(/\//g, "\\"));
+  add(filePath.replace(/\\/g, "/"));
+  add(windowsDriveToWslPath(filePath));
+  add(wslMntToWindowsPath(filePath));
+  if (isUNCPath(filePath)) {
+    const unc = uncToWsl(filePath);
+    add(unc?.wslPath);
+  }
+  if (filePath.startsWith("/") && process.platform === "win32") {
+    add(wslToUNC(filePath, distro || "Ubuntu-24.04"));
+  }
+  return keys;
+}
+
+/** 从 Codex sessions/archived_sessions 路径推导 Codex home。 */
+function codexHomeFromRolloutPath(filePath: string): { codexHome: string; distro?: string } | null {
+  const normalized = pathKey(filePath);
+  const marker = normalized.match(/^(.*?)(?:\/sessions|\/archived_sessions)\/.+$/);
+  if (!marker) return null;
+  let homeKey = marker[1];
+  if (!homeKey) return null;
+  const access = accessPathFromKey(homeKey);
+  const unc = isUNCPath(access) ? uncToWsl(access) : null;
+  return { codexHome: access, distro: unc?.distro };
+}
+
+/** 去掉 TOML 行尾注释，但保留引号内的 # 字符。 */
+function stripTomlLineComment(rawLine: string): string {
+  let quote: string | null = null;
+  let escaped = false;
+  for (let index = 0; index < rawLine.length; index++) {
+    const ch = rawLine[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quote) {
+      if (quote === "\"" && ch === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === "\"" || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === "#") return rawLine.slice(0, index);
+  }
+  return rawLine;
+}
+
+/** 安全解析 config.toml 中的 sqlite_home 顶层字符串。 */
+function readSqliteHomesFromConfig(codexHome: string, distro?: string): string[] {
+  try {
+    const configPath = path.join(codexHome, "config.toml");
+    if (!fs.existsSync(configPath)) return [];
+    const text = fs.readFileSync(configPath, "utf8");
+    for (const rawLine of text.split(/\r?\n/g)) {
+      const line = stripTomlLineComment(rawLine).trim();
+      const match = line.match(/^sqlite_home\s*=\s*(['"])(.*?)\1\s*$/);
+      if (!match) continue;
+      return resolveConfiguredSqliteHomes(match[2], codexHome, distro, "config");
+    }
+  } catch {}
+  return [];
+}
+
+/** 将 Codex 配置或环境变量里的 sqlite_home 转为当前进程可访问路径候选。 */
+function resolveConfiguredSqliteHomes(raw: string, codexHome: string, distro: string | undefined, source: "config" | "env"): string[] {
+  const value = String(raw || "").trim();
+  if (!value) return [];
+  if (process.platform === "win32" && value.startsWith("/"))
+    return uniqueStrings([wslToUNC(value, distro || "Ubuntu-24.04"), value]);
+  if (path.isAbsolute(value) || /^[a-zA-Z]:[\\/]/.test(value) || isUNCPath(value)) return [value];
+  if (source === "env")
+    return uniqueStrings([path.resolve(process.cwd(), value), path.join(codexHome, value)]);
+  return [path.join(codexHome, value)];
+}
+
+/** 解析一个 Codex home 可能使用的 sqlite home 候选。 */
+function resolveSqliteHomes(codexHome: string, distro?: string): string[] {
+  const configHomes = readSqliteHomesFromConfig(codexHome, distro);
+  const envHomes = resolveConfiguredSqliteHomes(String(process.env.CODEX_SQLITE_HOME || ""), codexHome, distro, "env");
+  return uniqueStrings([...configHomes, ...envHomes, codexHome]).filter(isExistingDirectory);
+}
+
+/** 创建用于精确匹配已删除 rollout 的 matcher。 */
+function matcherFromHistoryPath(filePath: string, distro?: string): TargetMatcher {
+  const ids = new Set<string>();
+  const pathKeys = equivalentPathKeys(filePath, distro);
+  const threadId = threadIdFromRolloutFileName(filePath);
+  if (threadId) ids.add(threadId);
+  return { ids, pathKeys };
+}
+
+/** 合并两个 matcher，保持路径和 thread id 去重。 */
+function mergeMatcher(target: TargetMatcher, source: TargetMatcher): void {
+  for (const id of source.ids) target.ids.add(id);
+  for (const key of source.pathKeys) target.pathKeys.add(key);
+}
+
+/** 构建空 matcher。 */
+function emptyMatcher(): TargetMatcher {
+  return { ids: new Set<string>(), pathKeys: new Set<string>() };
+}
+
+/** 把一个 Codex home 加入待处理集合。 */
+function upsertHomeWork(map: Map<string, CodexHomeWork>, home: Omit<CodexHomeWork, "matcher">): CodexHomeWork {
+  const key = pathKey(home.codexHome);
+  const existing = map.get(key);
+  if (existing) {
+    if (!existing.distro && home.distro) existing.distro = home.distro;
+    return existing;
+  }
+  const work: CodexHomeWork = { ...home, matcher: emptyMatcher() };
+  map.set(key, work);
+  return work;
+}
+
+/** 根据已删除的历史路径推导需要处理的 Codex home。 */
+function addHomeWorkForHistoryPath(map: Map<string, CodexHomeWork>, filePath: string): void {
+  const home = codexHomeFromRolloutPath(filePath);
+  if (!home) return;
+  const work = upsertHomeWork(map, { codexHome: home.codexHome, distro: home.distro, source: "history-path" });
+  mergeMatcher(work.matcher, matcherFromHistoryPath(filePath, home.distro));
+}
+
+/** 获取当前机器上可快速确认的 Codex home。 */
+async function addKnownCodexHomes(map: Map<string, CodexHomeWork>): Promise<void> {
+  try {
+    const roots = await getCodexRootsFastAsync();
+    if (roots.windowsCodex && isExistingDirectory(roots.windowsCodex))
+      upsertHomeWork(map, { codexHome: roots.windowsCodex, source: "windows" });
+    for (const item of roots.wsl) {
+      if (!item.codexUNC || !isExistingDirectory(item.codexUNC)) continue;
+      upsertHomeWork(map, { codexHome: item.codexUNC, distro: item.distro, source: "wsl" });
+    }
+  } catch {}
+  const fallback = path.join(os.homedir(), ".codex");
+  if (isExistingDirectory(fallback))
+    upsertHomeWork(map, { codexHome: fallback, source: "fallback" });
+}
+
+/** 列出 sqlite home 下某类 Codex runtime DB。 */
+async function listRuntimeDbs(sqliteHome: string, kind: "state" | "goals" | "memories"): Promise<string[]> {
+  let entries: string[] = [];
+  try {
+    entries = await fsp.readdir(sqliteHome);
+  } catch {
+    return [];
+  }
+  const pattern = kind === "state"
+    ? /^state(?:[_-]?\d+)?\.sqlite$/i
+    : kind === "goals"
+      ? /^goals(?:[_-]?\d+)?\.sqlite$/i
+      : /^memories(?:[_-]?\d+)?\.sqlite$/i;
+  return entries
+    .filter((name) => pattern.test(name))
+    .sort()
+    .map((name) => path.join(sqliteHome, name));
+}
+
+/** 打开 SQLite DB，并设置短忙等待以避开 Codex 正在写入的瞬时锁。 */
+function openDatabase(Database: SqliteCtor, dbPath: string): SqliteDatabase {
+  const db = new Database(dbPath, { fileMustExist: true, timeout: 5000 });
+  try { db.pragma("busy_timeout = 5000"); } catch {}
+  return db;
+}
+
+/** 判断 DB 中是否存在指定表。 */
+function hasTable(db: SqliteDatabase, table: string): boolean {
+  const row = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(table);
+  return !!row;
+}
+
+/** 安全引用 SQLite 标识符。 */
+function quoteIdentifier(name: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) throw new Error(`invalid sqlite identifier: ${name}`);
+  return `"${name}"`;
+}
+
+/** 判断指定表中是否存在指定列。 */
+function hasColumn(db: SqliteDatabase, table: string, column: string): boolean {
+  if (!hasTable(db, table)) return false;
+  const rows = db.prepare(`PRAGMA table_info(${quoteIdentifier(table)})`).all();
+  return rows.some((row) => String(row.name || "") === column);
+}
+
+/** 读取 state DB 中可用于清理判断的 threads 行。 */
+function readThreadRows(db: SqliteDatabase): ThreadRow[] {
+  if (!hasColumn(db, "threads", "id") || !hasColumn(db, "threads", "rollout_path")) return [];
+  return db.prepare("SELECT id, rollout_path FROM threads").all().map((row) => ({
+    id: String(row.id || ""),
+    rolloutPath: String(row.rollout_path || ""),
+  })).filter((row) => !!row.id && !!row.rolloutPath);
+}
+
+/** 判断 rollout_path 是否位于指定 Codex home 的 sessions 或 archived_sessions 下。 */
+function isPathUnderCodexSessions(rowPath: string, work: CodexHomeWork): boolean {
+  const rowKeys = equivalentPathKeys(rowPath, work.distro);
+  const homeKeys = equivalentPathKeys(work.codexHome, work.distro);
+  for (const rowKey of rowKeys) {
+    for (const homeKey of homeKeys) {
+      if (rowKey.startsWith(`${homeKey}/sessions/`) || rowKey.startsWith(`${homeKey}/archived_sessions/`))
+        return true;
+    }
+  }
+  return false;
+}
+
+/** 判断 rollout_path 对应文件是否可确认缺失。 */
+function isConfirmedMissingRollout(rowPath: string, work: CodexHomeWork): boolean {
+  if (!isExistingDirectory(work.codexHome)) return false;
+  if (!isPathUnderCodexSessions(rowPath, work)) return false;
+  const accessCandidates = Array.from(equivalentPathKeys(rowPath, work.distro)).map(accessPathFromKey);
+  return !accessCandidates.some(isExistingFile);
+}
+
+/** 判断 threads 行是否命中已删除文件或可安全补救的缺失文件。 */
+function shouldDeleteThreadRow(row: ThreadRow, work: CodexHomeWork, repairMissingRollouts: boolean): { delete: boolean; stale: boolean } {
+  const rowPathKeys = equivalentPathKeys(row.rolloutPath, work.distro);
+  const targetPathMatched = Array.from(rowPathKeys).some((key) => work.matcher.pathKeys.has(key));
+  const targetIdMatched = work.matcher.ids.has(row.id.toLowerCase());
+  if ((targetPathMatched || targetIdMatched) && isPathUnderCodexSessions(row.rolloutPath, work))
+    return { delete: true, stale: false };
+  if (repairMissingRollouts && isConfirmedMissingRollout(row.rolloutPath, work))
+    return { delete: true, stale: true };
+  return { delete: false, stale: false };
+}
+
+/** 分块处理 SQLite 参数，避免触发变量数量上限。 */
+function chunks<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+/** 如果表和列存在，则执行按 thread_id 删除的语句。 */
+function deleteByThreadId(db: SqliteDatabase, table: string, column: string, ids: string[]): number {
+  if (!hasColumn(db, table, column)) return 0;
+  let changed = 0;
+  for (const group of chunks(ids, 200)) {
+    const placeholders = group.map(() => "?").join(", ");
+    changed += db.prepare(`DELETE FROM ${quoteIdentifier(table)} WHERE ${quoteIdentifier(column)} IN (${placeholders})`).run(...group).changes;
+  }
+  return changed;
+}
+
+/** 如果表和列存在，则统计按 thread_id 命中的行数。 */
+function countByThreadId(db: SqliteDatabase, table: string, column: string, ids: string[]): number {
+  if (!hasColumn(db, table, column)) return 0;
+  let total = 0;
+  for (const group of chunks(ids, 200)) {
+    const placeholders = group.map(() => "?").join(", ");
+    const row = db.prepare(`SELECT COUNT(*) AS count FROM ${quoteIdentifier(table)} WHERE ${quoteIdentifier(column)} IN (${placeholders})`).get(...group) as SqliteScalarRow | undefined;
+    total += Number(row?.count || 0);
+  }
+  return total;
+}
+
+/** 统计独立 goals/memories DB 中和 thread id 直接相关的记录。 */
+function countAuxDbRows(db: SqliteDatabase, ids: string[]): number {
+  let total = 0;
+  total += countByThreadId(db, "thread_goals", "thread_id", ids);
+  total += countByThreadId(db, "stage1_outputs", "thread_id", ids);
+  if (hasColumn(db, "jobs", "kind") && hasColumn(db, "jobs", "job_key")) {
+    for (const group of chunks(ids, 200)) {
+      const placeholders = group.map(() => "?").join(", ");
+      const row = db.prepare(`SELECT COUNT(*) AS count FROM jobs WHERE kind = ? AND job_key IN (${placeholders})`).get("memory_stage1", ...group) as SqliteScalarRow | undefined;
+      total += Number(row?.count || 0);
+    }
+  }
+  return total;
+}
+
+/** 删除 state DB 中和 thread id 直接相关的记录。 */
+function deleteFromStateDb(db: SqliteDatabase, ids: string[]): { threadRows: number; auxRows: number } {
+  let threadRows = 0;
+  let auxRows = 0;
+  const run = db.transaction(() => {
+    auxRows += deleteByThreadId(db, "thread_dynamic_tools", "thread_id", ids);
+    if (hasColumn(db, "thread_spawn_edges", "parent_thread_id"))
+      auxRows += deleteByThreadId(db, "thread_spawn_edges", "parent_thread_id", ids);
+    if (hasColumn(db, "thread_spawn_edges", "child_thread_id"))
+      auxRows += deleteByThreadId(db, "thread_spawn_edges", "child_thread_id", ids);
+    auxRows += deleteByThreadId(db, "thread_goals", "thread_id", ids);
+    auxRows += deleteByThreadId(db, "stage1_outputs", "thread_id", ids);
+    if (hasColumn(db, "jobs", "kind") && hasColumn(db, "jobs", "job_key")) {
+      for (const group of chunks(ids, 200)) {
+        const placeholders = group.map(() => "?").join(", ");
+        auxRows += db.prepare(`DELETE FROM jobs WHERE kind = ? AND job_key IN (${placeholders})`).run("memory_stage1", ...group).changes;
+      }
+    }
+    threadRows += deleteByThreadId(db, "threads", "id", ids);
+  });
+  run();
+  return { threadRows, auxRows };
+}
+
+/** 删除 goals/memories 独立 DB 中和 thread id 直接相关的记录。 */
+function deleteFromAuxDb(db: SqliteDatabase, ids: string[]): number {
+  let changed = 0;
+  const run = db.transaction(() => {
+    changed += deleteByThreadId(db, "thread_goals", "thread_id", ids);
+    changed += deleteByThreadId(db, "stage1_outputs", "thread_id", ids);
+    if (hasColumn(db, "jobs", "kind") && hasColumn(db, "jobs", "job_key")) {
+      for (const group of chunks(ids, 200)) {
+        const placeholders = group.map(() => "?").join(", ");
+        changed += db.prepare(`DELETE FROM jobs WHERE kind = ? AND job_key IN (${placeholders})`).run("memory_stage1", ...group).changes;
+      }
+    }
+  });
+  run();
+  return changed;
+}
+
+/** 清理一个 sqlite home 下的 Codex state/goals/memories DB。 */
+async function cleanupSqliteHome(Database: SqliteCtor, work: CodexHomeWork, sqliteHome: string, options: Required<CleanupOptions>, result: CodexStateCleanupResult): Promise<void> {
+  const idsForAux = new Set<string>(Array.from(work.matcher.ids));
+  const stateDbs = await listRuntimeDbs(sqliteHome, "state");
+  for (const dbPath of stateDbs) {
+    result.scannedDbPaths.push(dbPath);
+    let db: SqliteDatabase | null = null;
+    try {
+      db = openDatabase(Database, dbPath);
+      const deadIds: string[] = [];
+      let staleCount = 0;
+      for (const row of readThreadRows(db)) {
+        const decision = shouldDeleteThreadRow(row, work, options.repairMissingRollouts);
+        if (!decision.delete) {
+          result.skippedRows++;
+          continue;
+        }
+        deadIds.push(row.id);
+        idsForAux.add(row.id);
+        if (decision.stale) staleCount++;
+      }
+      if (deadIds.length === 0) continue;
+      const changed = deleteFromStateDb(db, deadIds);
+      result.deletedThreadRows += changed.threadRows;
+      result.deletedAuxRows += changed.auxRows;
+      result.repairedStaleRows += staleCount;
+      for (const id of deadIds) result.deletedThreadIds.push(id);
+    } catch (error) {
+      result.ok = false;
+      result.errors.push(`${dbPath}: ${String(error)}`);
+    } finally {
+      try { db?.close(); } catch {}
+    }
+  }
+
+  const ids = Array.from(idsForAux).filter(Boolean);
+  if (ids.length === 0) return;
+  for (const kind of ["goals", "memories"] as const) {
+    const auxDbs = await listRuntimeDbs(sqliteHome, kind);
+    for (const dbPath of auxDbs) {
+      result.scannedDbPaths.push(dbPath);
+      let db: SqliteDatabase | null = null;
+      try {
+        db = openDatabase(Database, dbPath);
+        const plannedRows = countAuxDbRows(db, ids);
+        if (plannedRows === 0) continue;
+        result.deletedAuxRows += deleteFromAuxDb(db, ids);
+      } catch (error) {
+        result.ok = false;
+        result.errors.push(`${dbPath}: ${String(error)}`);
+      } finally {
+        try { db?.close(); } catch {}
+      }
+    }
+  }
+}
+
+/** 合并清理结果中的重复 thread id 和 DB 路径。 */
+function finalizeResult(result: CodexStateCleanupResult): CodexStateCleanupResult {
+  result.deletedThreadIds = uniqueStrings(result.deletedThreadIds);
+  result.scannedDbPaths = uniqueStrings(result.scannedDbPaths);
+  return result;
+}
+
+/** 清理已删除历史文件对应的 Codex sqlite 状态，并可顺带修复旧残留。 */
+export async function cleanupCodexStateForDeletedHistoryFiles(filePaths: string[], options?: CleanupOptions): Promise<CodexStateCleanupResult> {
+  const Database = loadSqlite();
+  const result = createResult(!!Database);
+  if (!Database) {
+    result.ok = false;
+    result.errors.push("better-sqlite3 is unavailable; skipped Codex sqlite cleanup");
+    return result;
+  }
+
+  const normalizedOptions: Required<CleanupOptions> = {
+    repairMissingRollouts: options?.repairMissingRollouts ?? false,
+  };
+  const works = new Map<string, CodexHomeWork>();
+  for (const filePath of uniqueStrings(filePaths)) addHomeWorkForHistoryPath(works, filePath);
+  if (normalizedOptions.repairMissingRollouts) await addKnownCodexHomes(works);
+
+  for (const work of works.values()) {
+    const sqliteHomes = resolveSqliteHomes(work.codexHome, work.distro);
+    for (const sqliteHome of sqliteHomes)
+      await cleanupSqliteHome(Database, work, sqliteHome, normalizedOptions, result);
+  }
+  return finalizeResult(result);
+}
+
+/** 扫描已知 Codex home，自动修复已删除 rollout 文件留下的 sqlite 残留。 */
+export async function repairMissingCodexRolloutRows(): Promise<CodexStateCleanupResult> {
+  return cleanupCodexStateForDeletedHistoryFiles([], {
+    repairMissingRollouts: true,
+  });
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -39,6 +39,7 @@ import { CodexBridge, type CodexBridgeOptions } from "./codex/bridge";
 import { applyCodexAuthBackupAsync, deleteCodexAuthBackupAsync, isSafeAuthBackupId, listCodexAuthBackupsAsync, readCodexAuthBackupMetaAsync, resolveCodexAccountSignature, resolveCodexAuthJsonPathAsync, upsertCodexAuthBackupAsync, upsertCodexAuthBackupMetaOnlyAsync } from "./codex/authBackups";
 import { ensureAllCodexNotifications } from "./codex/config";
 import { startCodexNotificationBridge, stopCodexNotificationBridge } from "./codex/notifications";
+import { cleanupCodexStateForDeletedHistoryFiles, repairMissingCodexRolloutRows, type CodexStateCleanupResult } from "./codexStateCleanup";
 import { ensureAllClaudeNotifications, startClaudeNotificationBridge, stopClaudeNotificationBridge } from "./claude/notifications";
 import { getClaudeUsageSnapshotAsync } from "./claude/usage";
 import { ensureAllGeminiNotifications, startGeminiNotificationBridge, stopGeminiNotificationBridge } from "./gemini/notifications";
@@ -75,6 +76,68 @@ import {
 } from "./stores/projectIdeStore";
 
 // 使用 CommonJS 编译输出时，运行时环境会提供 `__dirname`，直接使用即可
+
+let codexStateRepairStarted = false;
+
+/**
+ * 汇总 Codex sqlite 清理结果，便于主进程日志快速定位问题。
+ */
+function summarizeCodexStateCleanup(result: CodexStateCleanupResult): string {
+  return [
+    `ok=${result.ok}`,
+    `sqlite=${result.sqliteAvailable}`,
+    `dbs=${result.scannedDbPaths.length}`,
+    `threads=${result.deletedThreadRows}`,
+    `aux=${result.deletedAuxRows}`,
+    `stale=${result.repairedStaleRows}`,
+    `errors=${result.errors.length}`,
+  ].join(" ");
+}
+
+/**
+ * 记录 Codex sqlite 清理结果；成功且无变更时保持安静。
+ */
+function logCodexStateCleanupResult(reason: string, result: CodexStateCleanupResult): void {
+  const changed = result.deletedThreadRows > 0 || result.deletedAuxRows > 0 || result.repairedStaleRows > 0;
+  if (changed || !result.ok) {
+    try { perfLogger.log(`[CODEX_STATE_CLEANUP] ${reason} ${summarizeCodexStateCleanup(result)}`); } catch {}
+  }
+  if (result.errors.length > 0) {
+    try { console.warn(`codex state cleanup ${reason} had errors`, result.errors.slice(0, 5)); } catch {}
+  }
+}
+
+/**
+ * 安全清理本次已删除历史路径对应的 Codex sqlite 状态。
+ */
+async function cleanupCodexStateForDeletedPathsSafely(filePaths: string[], reason: string): Promise<void> {
+  const paths = Array.from(new Set(filePaths.filter((item) => typeof item === "string" && item.trim())));
+  if (paths.length === 0) return;
+  try {
+    const result = await cleanupCodexStateForDeletedHistoryFiles(paths, {
+      repairMissingRollouts: false,
+    });
+    logCodexStateCleanupResult(reason, result);
+  } catch (error) {
+    try { console.warn(`codex state cleanup ${reason} failed`, error); } catch {}
+  }
+}
+
+/**
+ * 启动一次独立的 Codex sqlite 残留修复任务，避免要求用户手动跑 SQL。
+ */
+function startCodexStateRepairOnce(reason: string): void {
+  if (codexStateRepairStarted) return;
+  codexStateRepairStarted = true;
+  const timer = setTimeout(() => {
+    void repairMissingCodexRolloutRows()
+      .then((result) => logCodexStateCleanupResult(reason, result))
+      .catch((error) => {
+        try { console.warn(`codex state repair ${reason} failed`, error); } catch {}
+      });
+  }, 10_000);
+  try { (timer as any).unref?.(); } catch {}
+}
 
 /**
  * 中文说明：本次主进程启动的唯一标识，用于让渲染层区分：
@@ -2227,6 +2290,7 @@ if (!gotLock) {
       // 启动历史索引器：后台并发解析、缓存、监听变更
       try { purgeHistoryCacheIfOutdated(); } catch {}
       try { await startHistoryIndexer(() => mainWindow); } catch (e) { console.warn('indexer start failed', e); }
+      try { startCodexStateRepairOnce('boot'); } catch {}
       // 启动后立刻触发一次 UI 强制刷新，确保首次 ready 后显示索引内容
       try { mainWindow?.webContents.send('history:index:add', { items: [] }); } catch {}
       try { perfLogger.log(`[BOOT] background init done`); } catch {}
@@ -4212,6 +4276,7 @@ ipcMain.handle('history.findEmptySessions', async () => {
 ipcMain.handle('history.trashMany', async (_e, { filePaths }: { filePaths: string[] }) => {
   try {
     const results: { filePath: string; ok: boolean; notFound?: boolean; error?: string }[] = [];
+    const codexStateCleanupPaths = new Set<string>();
     let okCount = 0; let notFoundCount = 0; let failCount = 0;
     const list = Array.isArray(filePaths) ? filePaths.slice() : [];
     // 并发限制器：避免一次性对大量文件触发过多 I/O / shell 调用
@@ -4229,6 +4294,11 @@ ipcMain.handle('history.trashMany', async (_e, { filePaths }: { filePaths: strin
       };
     };
     const limit = pLimitLocal(6);
+    const rememberCodexStateCleanupPaths = (paths: string[]) => {
+      for (const item of paths) {
+        if (item && typeof item === 'string') codexStateCleanupPaths.add(item);
+      }
+    };
 
     // 单个文件删除逻辑（保持原候选顺序）：彻底删除
     const handleOne = async (filePath: string) => {
@@ -4246,7 +4316,10 @@ ipcMain.handle('history.trashMany', async (_e, { filePaths }: { filePaths: strin
       }
       push(normSlashes(p0));
       const anyExists = candidates.some((c) => { try { return fs.existsSync(c); } catch { return false; } });
-      if (!anyExists) return { filePath: p0, ok: true, notFound: true };
+      if (!anyExists) {
+        rememberCodexStateCleanupPaths([p0, ...candidates]);
+        return { filePath: p0, ok: true, notFound: true };
+      }
       let deleted = false; const failed: { cand: string; err: any }[] = [];
       for (const cand of candidates) {
         try {
@@ -4256,6 +4329,7 @@ ipcMain.handle('history.trashMany', async (_e, { filePaths }: { filePaths: strin
             try { const idx = require('./indexer'); if (typeof idx.removeFromIndex === 'function') idx.removeFromIndex(cand); } catch {}
             try { const hist = require('./history').default; await hist.removePathFromCache(cand); } catch {}
             try { const win = BrowserWindow.getFocusedWindow(); win?.webContents.send('history:index:remove', { filePath: cand }); } catch {}
+            rememberCodexStateCleanupPaths([p0, cand, ...candidates]);
             deleted = true; break;
           } catch (e1: any) {
             failed.push({ cand, err: e1 });
@@ -4282,6 +4356,7 @@ ipcMain.handle('history.trashMany', async (_e, { filePaths }: { filePaths: strin
         if ((r as any).notFound) notFoundCount++; else okCount++;
       } else failCount++;
     }
+    await cleanupCodexStateForDeletedPathsSafely(Array.from(codexStateCleanupPaths), 'history.trashMany');
 
     return { ok: true, results, summary: { ok: okCount, notFound: notFoundCount, failed: failCount } } as any;
   } catch (e: any) {
@@ -4311,7 +4386,10 @@ ipcMain.handle('history.trash', async (_e, { filePath }: { filePath: string }) =
     push(normSlashes(p0));
     // 候选均不存在则视为成功（无需删除）
     const anyExists = candidates.some((c) => { try { return fs.existsSync(c); } catch { return false; } });
-    if (!anyExists) return { ok: true, notFound: true } as any;
+    if (!anyExists) {
+      await cleanupCodexStateForDeletedPathsSafely([p0, ...candidates], 'history.trash.notFound');
+      return { ok: true, notFound: true } as any;
+    }
     // 依次尝试候选：永久删除
     const failed: { cand: string; err: any }[] = [];
     for (const cand of candidates) {
@@ -4323,6 +4401,7 @@ ipcMain.handle('history.trash', async (_e, { filePath }: { filePath: string }) =
           try { const idx = require('./indexer'); if (typeof idx.removeFromIndex === 'function') idx.removeFromIndex(cand); } catch {}
           try { const hist = require('./history').default; await hist.removePathFromCache(cand); } catch {}
           try { const win = BrowserWindow.getFocusedWindow(); win?.webContents.send('history:index:remove', { filePath: cand }); } catch {}
+          await cleanupCodexStateForDeletedPathsSafely([p0, cand, ...candidates], 'history.trash');
           return { ok: true };
         } catch (e1: any) {
           failed.push({ cand, err: e1 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@lydell/node-pty": "^1.1.0",
+        "better-sqlite3": "^11.10.0",
         "chokidar": "^3.6.0",
         "iconv-lite": "^0.6.3",
         "opentype.js": "^1.3.4",
@@ -2783,7 +2784,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2798,6 +2798,17 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
@@ -2819,12 +2830,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -2906,7 +2924,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3652,7 +3669,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -3667,7 +3683,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -3682,6 +3697,15 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/defer-to-connect": {
@@ -3745,6 +3769,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-node": {
@@ -4146,7 +4179,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -4316,6 +4348,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
@@ -4420,6 +4461,12 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/filelist": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -4498,9 +4545,7 @@
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -4644,6 +4689,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.5.0",
@@ -5222,7 +5273,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5241,9 +5291,13 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -6914,7 +6968,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6971,6 +7024,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/monaco-editor": {
       "version": "0.55.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
@@ -7015,6 +7074,36 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-addon-api": {
@@ -7090,7 +7179,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -7538,6 +7626,32 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -7582,7 +7696,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -7627,6 +7740,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
       }
     },
     "node_modules/react": {
@@ -7744,8 +7872,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -8122,7 +8248,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8136,8 +8261,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -8298,6 +8422,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -8436,8 +8605,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -8514,6 +8681,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/style-to-js": {
@@ -8666,12 +8842,28 @@
         "node": ">=10"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -8922,6 +9114,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -9113,8 +9317,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/verror": {
       "version": "1.10.1",
@@ -9467,8 +9670,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
       "version": "8.18.3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@lydell/node-pty": "^1.1.0",
+    "better-sqlite3": "^11.10.0",
     "chokidar": "^3.6.0",
     "iconv-lite": "^0.6.3",
     "opentype.js": "^1.3.4",
@@ -104,7 +105,8 @@
       "buildResources": "build"
     },
     "asarUnpack": [
-      "node_modules/@lydell/node-pty/build/Release/**"
+      "node_modules/@lydell/node-pty/build/Release/**",
+      "node_modules/better-sqlite3/build/Release/**"
     ],
     "extraResources": [
       {


### PR DESCRIPTION
删除 Codex 历史文件后，同步清理 state/goals/memories SQLite
中的 thread、goal 和 memory 残留记录，避免已删除会话继续保留
在 Codex 运行时状态中。

启动后增加一次后台修复，扫描已知 Codex home 并移除确认缺失的
rollout 记录；通过 better-sqlite3 读取运行时 DB，兼容
state/goals/memories 旧表结构，并在打包配置中解包原生模块。

修复 UNC 路径 key 规范化，保留 WSL UNC 前缀，确保 Windows 下
WSL Codex home 能被正确推导；增加 Codex state cleanup 单测覆盖
精确清理、sqlite_home、config.toml、旧表结构、残留修复与 UNC 路径。