### PR TITLE
fix(worktree): 按仓库规模估算创建超时

### DIFF
--- a/electron/git/exec.test.ts
+++ b/electron/git/exec.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { normalizeGitCommandTimeoutMs } from "./exec";
+
+describe("git exec timeout", () => {
+  it("普通 Git 命令应维持 30 分钟上限", () => {
+    expect(normalizeGitCommandTimeoutMs(6 * 60 * 60_000)).toBe(30 * 60_000);
+    expect(normalizeGitCommandTimeoutMs(6 * 60 * 60_000, false)).toBe(30 * 60_000);
+  });
+
+  it("显式长任务应允许 6 小时上限", () => {
+    expect(normalizeGitCommandTimeoutMs(6 * 60 * 60_000, true)).toBe(6 * 60 * 60_000);
+  });
+
+  it("过小超时应提升到最小安全值", () => {
+    expect(normalizeGitCommandTimeoutMs(1, false)).toBe(200);
+  });
+});

--- a/electron/git/exec.ts
+++ b/electron/git/exec.ts
@@ -5,6 +5,17 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
+const DEFAULT_MAX_GIT_COMMAND_TIMEOUT_MS = 30 * 60_000;
+const LONG_MAX_GIT_COMMAND_TIMEOUT_MS = 6 * 60 * 60_000;
+
+/**
+ * 归一化 Git 子进程超时，默认保留常规命令上限，避免后台命令长时间悬挂拖慢 UI。
+ */
+export function normalizeGitCommandTimeoutMs(timeoutMs?: number, allowLongTimeout?: boolean): number {
+  const timeoutCapMs = allowLongTimeout === true ? LONG_MAX_GIT_COMMAND_TIMEOUT_MS : DEFAULT_MAX_GIT_COMMAND_TIMEOUT_MS;
+  return Math.max(200, Math.min(timeoutCapMs, Number(timeoutMs ?? 8000)));
+}
+
 export type GitExecResult = {
   ok: boolean;
   stdout: string;
@@ -28,6 +39,8 @@ export type GitExecOptions = {
   envPatch?: NodeJS.ProcessEnv;
   /** 可选标准输入内容；用于 `update-index --index-info` 这类需要通过 stdin 传参的 Git 命令。 */
   stdin?: string | Buffer;
+  /** 是否允许超过常规 30 分钟上限；仅用于 worktree 创建/清理等明确的大任务。 */
+  allowLongTimeout?: boolean;
 };
 
 /**
@@ -70,6 +83,7 @@ export async function execGitAsync(opts: GitExecOptions): Promise<GitExecResult>
     timeoutMs: opts?.timeoutMs,
     envPatch: opts?.envPatch,
     stdin: opts?.stdin,
+    allowLongTimeout: opts?.allowLongTimeout,
   });
 }
 
@@ -155,7 +169,7 @@ export async function spawnGitAsync(opts: GitSpawnOptions): Promise<GitExecResul
   const gitPath = String(opts?.gitPath || "").trim() || "git";
   const argv = Array.isArray(opts?.argv) ? opts.argv.map((x) => String(x)) : [];
   const cwd = typeof opts?.cwd === "string" && opts.cwd.trim().length > 0 ? opts.cwd : undefined;
-  const timeoutMs = Math.max(200, Math.min(30 * 60_000, Number(opts?.timeoutMs ?? 8000)));
+  const timeoutMs = normalizeGitCommandTimeoutMs(opts?.timeoutMs, opts?.allowLongTimeout);
 
   return await new Promise<GitExecResult>((resolve) => {
     let stdout = "";
@@ -317,7 +331,7 @@ export async function spawnGitStdoutToFileAsync(opts: GitSpawnStdoutToFileOption
   const argv = Array.isArray(opts?.argv) ? opts.argv.map((x) => String(x)) : [];
   const cwd = typeof opts?.cwd === "string" && opts.cwd.trim().length > 0 ? opts.cwd : undefined;
   const outFile = String(opts?.outFile || "").trim();
-  const timeoutMs = Math.max(200, Math.min(30 * 60_000, Number(opts?.timeoutMs ?? 8000)));
+  const timeoutMs = normalizeGitCommandTimeoutMs(opts?.timeoutMs, opts?.allowLongTimeout);
   const signal = opts?.signal;
   if (!outFile) {
     return { ok: false, stdout: "", stderr: "", exitCode: -1, error: "missing outFile" };

--- a/electron/git/featureService.ts
+++ b/electron/git/featureService.ts
@@ -59,6 +59,7 @@ import * as gitExec from "./exec";
 import type { GitExecResult } from "./exec";
 import { parseGitUnifiedPatch } from "./diffHunks";
 import { parseWorktreeListPorcelain } from "./worktreeList";
+import { estimateWorktreeTimeoutAsync } from "./worktreeTimeout";
 import { toFsPathAbs, toFsPathKey } from "./pathKey";
 import { buildGitCapabilityState, type GitCapabilityState } from "./git-capabilities";
 import {
@@ -582,6 +583,7 @@ async function runGitSpawnAsync(
   timeoutMs: number = 300_000,
   envPatch?: NodeJS.ProcessEnv,
   stdin?: string | Buffer,
+  allowLongTimeout?: boolean,
 ): Promise<GitExecResult> {
   const normalizedArgv = buildNormalizedGitArgv(argv);
   const startedAt = Date.now();
@@ -597,6 +599,7 @@ async function runGitSpawnAsync(
     timeoutMs,
     envPatch,
     stdin,
+    allowLongTimeout,
     signal: ctx.abortSignal,
     onStdout: (chunk) => {
       gitConsoleStore.appendRunningOutput(consoleEntry.id, { stdoutChunk: chunk });
@@ -10517,7 +10520,14 @@ async function addWorktreeAsync(ctx: GitFeatureContext, repoRoot: string, payloa
   const argv = ["worktree", "add"];
   if (createBranch && branchName) argv.push("-b", branchName);
   argv.push(worktreePath, ref);
-  const res = await runGitSpawnAsync(ctx, repoRoot, argv, 300_000);
+  const timeoutEstimate = await estimateWorktreeTimeoutAsync({
+    repoRoot,
+    gitPath: ctx.gitPath,
+    ref,
+    worktreeCount: 1,
+    maxParallel: 1,
+  });
+  const res = await runGitSpawnAsync(ctx, repoRoot, argv, timeoutEstimate.perWorktreeAddTimeoutMs, undefined, undefined, true);
   if (!res.ok) return { ok: false, error: toGitErrorMessage(res, "新增 Worktree 失败") };
   return { ok: true };
 }

--- a/electron/git/worktreeCreateTasks.ts
+++ b/electron/git/worktreeCreateTasks.ts
@@ -5,6 +5,7 @@ import { promises as fsp } from "node:fs";
 import { toFsPathAbs, toFsPathKey } from "./pathKey";
 import { execGitAsync, spawnGitAsync } from "./exec";
 import { createWorktreesAsync, type CreatedWorktree } from "./worktreeOps";
+import { estimateWorktreeTimeoutAsync, type WorktreeTimeoutEstimate } from "./worktreeTimeout";
 import { deleteWorktreeMeta } from "../stores/worktreeMetaStore";
 
 export type WorktreeCreateTaskStatus = "running" | "canceling" | "canceled" | "success" | "error";
@@ -41,6 +42,7 @@ export type WorktreeCreateTaskSnapshot = {
   failedCount: number;
   allCompleted: boolean;
   worktreeStates: WorktreeCreateTaskItemSnapshot[];
+  timeoutEstimate?: WorktreeTimeoutEstimate;
   error?: string;
   items?: CreatedWorktree[];
 };
@@ -127,6 +129,7 @@ export class WorktreeCreateTaskManager {
       failedCount: 0,
       allCompleted: totalCount <= 0,
       worktreeStates: [],
+      timeoutEstimate: undefined,
       log: "",
       cancelRequested: false,
       abortController: new AbortController(),
@@ -305,6 +308,11 @@ export class WorktreeCreateTaskManager {
         copyRules: args.copyRules === true,
         onLog: append,
         signal: t.abortController.signal,
+        onTimeoutEstimated: (estimate) => {
+          t.timeoutEstimate = estimate;
+          t.updatedAt = Date.now();
+          this.refreshTaskProgress(taskId);
+        },
         onItemCreated: (item) => {
           try { t.createdSoFar.push(item); } catch {}
           t.items = [...t.createdSoFar];
@@ -480,6 +488,13 @@ export class WorktreeCreateTaskManager {
 
     const failures: string[] = [];
     log(`\n开始清理（共 ${targets.size} 项）…\n`);
+    const cleanupTimeoutEstimate = await estimateWorktreeTimeoutAsync({
+      repoRoot: repoDirAbs,
+      gitPath,
+      worktreeCount: targets.size,
+      maxParallel: 1,
+    });
+    const removeTimeoutMs = cleanupTimeoutEstimate.perWorktreeAddTimeoutMs;
 
     for (const { worktreePath, wtBranch } of targets.values()) {
       const wt = toFsPathAbs(worktreePath);
@@ -490,7 +505,8 @@ export class WorktreeCreateTaskManager {
         let rm = await spawnGitAsync({
           gitPath,
           argv: buildWorktreeRemoveArgv(wt, 1),
-          timeoutMs: 15 * 60_000,
+          timeoutMs: removeTimeoutMs,
+          allowLongTimeout: true,
           onStdout: log,
           onStderr: log,
         });
@@ -503,7 +519,8 @@ export class WorktreeCreateTaskManager {
             rm = await spawnGitAsync({
               gitPath,
               argv: buildWorktreeRemoveArgv(wt, 2),
-              timeoutMs: 15 * 60_000,
+              timeoutMs: removeTimeoutMs,
+              allowLongTimeout: true,
               onStdout: log,
               onStderr: log,
             });
@@ -599,6 +616,7 @@ export class WorktreeCreateTaskManager {
       failedCount: t.failedCount,
       allCompleted: t.allCompleted,
       worktreeStates: Array.isArray(t.worktreeStates) ? [...t.worktreeStates] : [],
+      timeoutEstimate: t.timeoutEstimate,
       error: t.error,
       items: t.items,
     };

--- a/electron/git/worktreeOps.ts
+++ b/electron/git/worktreeOps.ts
@@ -11,6 +11,7 @@ import { toFsPathAbs, toFsPathKey } from "./pathKey";
 import { parseWorktreeListPorcelain } from "./worktreeList";
 import { pickRepoMainPathFromSnapshot, readWorktreeListSnapshotAsync, resolveRepoMainPathForBranchAsync, resolveRepoMainPathFromWorktreeAsync, resolveWorktreeBranchNameAsync } from "./worktreeMetaResolve";
 import { buildRestoreCommandsForWorktreeStateSnapshot, cleanupWorktreeStateSnapshotAsync, createWorktreeStateSnapshotAsync, restoreWorktreeStateSnapshotAsync, type WorktreeStateSnapshot } from "./worktreeStateSnapshot";
+import { estimateWorktreeTimeoutAsync, formatWorktreeTimeoutEstimate, type WorktreeTimeoutEstimate } from "./worktreeTimeout";
 import { buildNextWorktreeMeta, deleteWorktreeMeta, getWorktreeMeta, setWorktreeMeta, type WorktreeMeta } from "../stores/worktreeMetaStore";
 
 export type GitWorktreeBranchInfo = {
@@ -47,6 +48,8 @@ export type CreateWorktreesRequest = {
   }) => void;
   /** 在尝试创建某个 worktree 前回调（用于捕获“中断时的目标目录/分支”）。 */
   onWorktreePlanned?: (args: { providerId: "codex" | "claude" | "gemini"; repoMainPath: string; worktreePath: string; baseBranch: string; wtBranch: string; index: number }) => void;
+  /** 创建超时估算完成后回调，供后台任务快照和 UI 等待兜底复用。 */
+  onTimeoutEstimated?: (estimate: WorktreeTimeoutEstimate) => void;
 };
 
 export type CreatedWorktree = {
@@ -389,7 +392,6 @@ export async function createWorktreesAsync(req: CreateWorktreesRequest): Promise
   const gitPath = req.gitPath;
   const timeoutMs = 15_000;
   const listTimeoutMs = 30_000;
-  const worktreeAddTimeoutMs = 15 * 60_000;
   const signal = req.signal;
   let abortLogged = false;
 
@@ -608,6 +610,18 @@ export async function createWorktreesAsync(req: CreateWorktreesRequest): Promise
     }
   }
 
+  const maxParallel = Math.max(1, Math.min(4, plans.length));
+  const timeoutEstimate = await estimateWorktreeTimeoutAsync({
+    repoRoot,
+    gitPath,
+    ref: baseBranch,
+    worktreeCount: plans.length,
+    maxParallel,
+  });
+  try { req.onTimeoutEstimated?.(timeoutEstimate); } catch {}
+  log(`${formatWorktreeTimeoutEstimate(timeoutEstimate)}\n\n`);
+  const worktreeAddTimeoutMs = timeoutEstimate.perWorktreeAddTimeoutMs;
+
   /**
    * 判断 `git worktree add` 失败是否属于并发可重试的锁冲突。
    */
@@ -654,6 +668,7 @@ export async function createWorktreesAsync(req: CreateWorktreesRequest): Promise
         gitPath,
         argv: ["-C", repoRoot, "worktree", "add", "-b", plan.wtBranch, plan.targetDir, req.baseBranch],
         timeoutMs: worktreeAddTimeoutMs,
+        allowLongTimeout: true,
         onStdout: (chunk) => log(`[${plan.providerId}#${plan.index}] ${chunk}`),
         onStderr: (chunk) => log(`[${plan.providerId}#${plan.index}] ${chunk}`),
         signal,
@@ -745,7 +760,6 @@ export async function createWorktreesAsync(req: CreateWorktreesRequest): Promise
     try { req.onItemCreated?.(item); } catch {}
   };
 
-  const maxParallel = Math.max(1, Math.min(4, plans.length));
   const workers = Array.from({ length: maxParallel }, async () => {
     while (true) {
       const aborted = checkAborted();

--- a/electron/git/worktreeTimeout.test.ts
+++ b/electron/git/worktreeTimeout.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { calculateWorktreeTimeoutEstimate, parseGitCountObjectsOutput } from "./worktreeTimeout";
+
+describe("worktree timeout estimate", () => {
+  it("应解析 git count-objects 输出中的对象库大小", () => {
+    const parsed = parseGitCountObjectsOutput([
+      "count: 12",
+      "size: 34",
+      "in-pack: 56",
+      "packs: 1",
+      "size-pack: 789",
+    ].join("\n"));
+
+    expect(parsed.looseObjectBytes).toBe(34 * 1024);
+    expect(parsed.packedObjectBytes).toBe(789 * 1024);
+    expect(parsed.objectBytes).toBe((34 + 789) * 1024);
+  });
+
+  it("应为小仓库保留最小超时，避免过低误杀", () => {
+    const estimate = calculateWorktreeTimeoutEstimate({
+      metrics: {
+        trackedFileCount: 12,
+        checkoutFileCount: 12,
+        checkoutBytes: 64 * 1024,
+        indexBytes: 32 * 1024,
+        objectBytes: 2 * 1024 * 1024,
+      },
+      worktreeCount: 1,
+      maxParallel: 1,
+    });
+
+    expect(estimate.perWorktreeAddTimeoutMs).toBe(3 * 60_000);
+    expect(estimate.taskTimeoutMs).toBeGreaterThan(estimate.perWorktreeAddTimeoutMs);
+  });
+
+  it("仓库规模探测失败时应回退到旧的 15 分钟下限", () => {
+    const estimate = calculateWorktreeTimeoutEstimate({
+      metrics: {},
+      worktreeCount: 1,
+      maxParallel: 1,
+    });
+
+    expect(estimate.perWorktreeAddTimeoutMs).toBe(15 * 60_000);
+    expect(estimate.taskTimeoutMs).toBeGreaterThan(estimate.perWorktreeAddTimeoutMs);
+  });
+
+  it("应随仓库规模和实际创建数量增加超时", () => {
+    const small = calculateWorktreeTimeoutEstimate({
+      metrics: {
+        trackedFileCount: 1000,
+        checkoutFileCount: 1000,
+        checkoutBytes: 20 * 1024 * 1024,
+        indexBytes: 1 * 1024 * 1024,
+        objectBytes: 50 * 1024 * 1024,
+      },
+      worktreeCount: 1,
+      maxParallel: 1,
+    });
+    const large = calculateWorktreeTimeoutEstimate({
+      metrics: {
+        trackedFileCount: 120_000,
+        checkoutFileCount: 120_000,
+        checkoutBytes: 24 * 1024 * 1024 * 1024,
+        indexBytes: 180 * 1024 * 1024,
+        objectBytes: 8 * 1024 * 1024 * 1024,
+      },
+      worktreeCount: 8,
+      maxParallel: 4,
+    });
+
+    expect(large.perWorktreeAddTimeoutMs).toBeGreaterThan(small.perWorktreeAddTimeoutMs);
+    expect(large.taskTimeoutMs).toBeGreaterThan(large.perWorktreeAddTimeoutMs);
+    expect(large.worktreeCount).toBe(8);
+    expect(large.maxParallel).toBe(4);
+  });
+});

--- a/electron/git/worktreeTimeout.ts
+++ b/electron/git/worktreeTimeout.ts
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import { promises as fsp } from "node:fs";
+import path from "node:path";
+import { execGitAsync } from "./exec";
+import { toFsPathAbs } from "./pathKey";
+
+const KIB = 1024;
+const MIB = 1024 * 1024;
+const MIN_WORKTREE_ADD_TIMEOUT_MS = 3 * 60_000;
+const FALLBACK_WORKTREE_ADD_TIMEOUT_MS = 15 * 60_000;
+const MAX_WORKTREE_ADD_TIMEOUT_MS = 4 * 60 * 60_000;
+const MAX_WORKTREE_TASK_TIMEOUT_MS = 6 * 60 * 60_000;
+
+export type WorktreeRepoSizeMetrics = {
+  trackedFileCount: number;
+  checkoutFileCount: number;
+  checkoutBytes: number;
+  indexBytes: number;
+  looseObjectBytes: number;
+  packedObjectBytes: number;
+  objectBytes: number;
+};
+
+export type WorktreeTimeoutEstimate = {
+  worktreeCount: number;
+  maxParallel: number;
+  perWorktreeAddTimeoutMs: number;
+  taskTimeoutMs: number;
+  metrics: WorktreeRepoSizeMetrics;
+};
+
+/**
+ * 解析 `git count-objects -v` 输出，提取对象库规模。
+ */
+export function parseGitCountObjectsOutput(output: string): Pick<WorktreeRepoSizeMetrics, "looseObjectBytes" | "packedObjectBytes" | "objectBytes"> {
+  const values = new Map<string, number>();
+  for (const line of String(output || "").split(/\r?\n/)) {
+    const match = /^([^:]+):\s*(\d+)/.exec(line.trim());
+    if (!match) continue;
+    values.set(match[1], Math.max(0, Math.floor(Number(match[2]) || 0)));
+  }
+  const looseObjectBytes = (values.get("size") || 0) * KIB;
+  const packedObjectBytes = (values.get("size-pack") || 0) * KIB;
+  return {
+    looseObjectBytes,
+    packedObjectBytes,
+    objectBytes: looseObjectBytes + packedObjectBytes,
+  };
+}
+
+/**
+ * 根据仓库规模代理指标和本次创建数量计算 worktree 创建超时。
+ */
+export function calculateWorktreeTimeoutEstimate(args: {
+  metrics: Partial<WorktreeRepoSizeMetrics>;
+  worktreeCount: number;
+  maxParallel?: number;
+}): WorktreeTimeoutEstimate {
+  const worktreeCount = Math.max(1, Math.floor(Number(args.worktreeCount) || 1));
+  const maxParallel = Math.max(1, Math.min(4, Math.floor(Number(args.maxParallel || worktreeCount) || 1), worktreeCount));
+  const trackedFileCount = Math.max(0, Math.floor(Number(args.metrics?.trackedFileCount) || 0));
+  const checkoutFileCount = Math.max(0, Math.floor(Number(args.metrics?.checkoutFileCount) || trackedFileCount));
+  const checkoutBytes = Math.max(0, Math.floor(Number(args.metrics?.checkoutBytes) || 0));
+  const indexBytes = Math.max(0, Math.floor(Number(args.metrics?.indexBytes) || 0));
+  const looseObjectBytes = Math.max(0, Math.floor(Number(args.metrics?.looseObjectBytes) || 0));
+  const packedObjectBytes = Math.max(0, Math.floor(Number(args.metrics?.packedObjectBytes) || 0));
+  const objectBytes = Math.max(0, Math.floor(Number(args.metrics?.objectBytes) || looseObjectBytes + packedObjectBytes));
+  const hasRepoSizeMetric =
+    trackedFileCount > 0 ||
+    checkoutFileCount > 0 ||
+    checkoutBytes > 0 ||
+    indexBytes > 0 ||
+    looseObjectBytes > 0 ||
+    packedObjectBytes > 0 ||
+    objectBytes > 0;
+
+  const effectiveFileCount = checkoutFileCount > 0 ? checkoutFileCount : trackedFileCount;
+  const fileCostMs = Math.ceil(effectiveFileCount / 1000) * 2_500;
+  const checkoutContentCostMs = checkoutBytes > 0 ? Math.ceil(checkoutBytes / MIB) * 120 : 0;
+  const indexCostMs = Math.ceil(indexBytes / MIB) * 2_000;
+  const objectFallbackCostMs = checkoutBytes > 0 ? 0 : Math.ceil(Math.min(objectBytes, 8 * 1024 * MIB) / MIB) * 80;
+  const countContentionFactor = 1 + Math.min(7, worktreeCount - 1) * 0.12;
+  const rawPerWorktreeMs = (90_000 + fileCostMs + checkoutContentCostMs + indexCostMs + objectFallbackCostMs) * countContentionFactor;
+  const minWorktreeAddTimeoutMs = hasRepoSizeMetric ? MIN_WORKTREE_ADD_TIMEOUT_MS : FALLBACK_WORKTREE_ADD_TIMEOUT_MS;
+  const perWorktreeAddTimeoutMs = clampTimeoutMs(roundUpToSecond(rawPerWorktreeMs), minWorktreeAddTimeoutMs, MAX_WORKTREE_ADD_TIMEOUT_MS);
+
+  const waves = Math.max(1, Math.ceil(worktreeCount / maxParallel));
+  const rawTaskTimeoutMs = perWorktreeAddTimeoutMs * waves + worktreeCount * 30_000 + 5 * 60_000;
+  const taskTimeoutMs = clampTimeoutMs(roundUpToSecond(rawTaskTimeoutMs), perWorktreeAddTimeoutMs + 60_000, MAX_WORKTREE_TASK_TIMEOUT_MS);
+
+  return {
+    worktreeCount,
+    maxParallel,
+    perWorktreeAddTimeoutMs,
+    taskTimeoutMs,
+    metrics: {
+      trackedFileCount,
+      checkoutFileCount,
+      checkoutBytes,
+      indexBytes,
+      looseObjectBytes,
+      packedObjectBytes,
+      objectBytes,
+    },
+  };
+}
+
+/**
+ * 读取仓库规模并生成 worktree 创建超时估算；探测失败时回退到保守默认值。
+ *
+ * 说明：这里刻意不枚举目标引用的整棵 tree。`git ls-tree -r -l` 在大仓库会产生
+ * 大量 stdout，Electron 主进程需要拼接和解析整段文本，容易造成应用短时间卡死。
+ * 因此默认只使用 index 条目数、index 体积和对象库规模作为低成本代理指标。
+ */
+export async function estimateWorktreeTimeoutAsync(args: {
+  repoRoot: string;
+  gitPath?: string;
+  ref?: string;
+  worktreeCount: number;
+  maxParallel?: number;
+  probeTimeoutMs?: number;
+}): Promise<WorktreeTimeoutEstimate> {
+  const repoRoot = toFsPathAbs(args.repoRoot);
+  const probeTimeoutMs = Math.max(1000, Math.min(30_000, Math.floor(Number(args.probeTimeoutMs) || 8000)));
+  const [objects, index] = await Promise.all([
+    readObjectMetricsAsync({ repoRoot, gitPath: args.gitPath, timeoutMs: probeTimeoutMs }),
+    readIndexMetricsAsync({ repoRoot, gitPath: args.gitPath, timeoutMs: probeTimeoutMs }),
+  ]);
+  return calculateWorktreeTimeoutEstimate({
+    metrics: {
+      ...objects,
+      ...index,
+      checkoutFileCount: index.trackedFileCount,
+      checkoutBytes: 0,
+    },
+    worktreeCount: args.worktreeCount,
+    maxParallel: args.maxParallel,
+  });
+}
+
+/**
+ * 格式化超时估算，供创建日志展示和问题诊断。
+ */
+export function formatWorktreeTimeoutEstimate(estimate: WorktreeTimeoutEstimate): string {
+  const metrics = estimate.metrics;
+  return [
+    `超时估算：单个 git worktree add ${formatDuration(estimate.perWorktreeAddTimeoutMs)}`,
+    `任务等待 ${formatDuration(estimate.taskTimeoutMs)}`,
+    `数量 ${estimate.worktreeCount}`,
+    `并发 ${estimate.maxParallel}`,
+    `checkout ${metrics.checkoutFileCount || metrics.trackedFileCount}`,
+    `content ${formatBytes(metrics.checkoutBytes)}`,
+    `index ${formatBytes(metrics.indexBytes)}`,
+    `objects ${formatBytes(metrics.objectBytes)}(fallback)`,
+  ].join("，");
+}
+
+/**
+ * 读取 Git 对象库规模。
+ */
+async function readObjectMetricsAsync(args: {
+  repoRoot: string;
+  gitPath?: string;
+  timeoutMs: number;
+}): Promise<Pick<WorktreeRepoSizeMetrics, "looseObjectBytes" | "packedObjectBytes" | "objectBytes">> {
+  const res = await execGitAsync({
+    gitPath: args.gitPath,
+    argv: ["-C", args.repoRoot, "count-objects", "-v"],
+    timeoutMs: args.timeoutMs,
+  });
+  if (!res.ok) return { looseObjectBytes: 0, packedObjectBytes: 0, objectBytes: 0 };
+  return parseGitCountObjectsOutput(res.stdout);
+}
+
+/**
+ * 读取 Git index 的条目数和文件大小，用作 checkout 工作量的低成本代理指标。
+ */
+async function readIndexMetricsAsync(args: {
+  repoRoot: string;
+  gitPath?: string;
+  timeoutMs: number;
+}): Promise<Pick<WorktreeRepoSizeMetrics, "trackedFileCount" | "indexBytes">> {
+  const res = await execGitAsync({
+    gitPath: args.gitPath,
+    argv: ["-C", args.repoRoot, "rev-parse", "--git-path", "index"],
+    timeoutMs: args.timeoutMs,
+  });
+  if (!res.ok) return { trackedFileCount: 0, indexBytes: 0 };
+  const indexPath = resolveGitPath(args.repoRoot, String(res.stdout || "").trim());
+  if (!indexPath) return { trackedFileCount: 0, indexBytes: 0 };
+
+  try {
+    const st = await fsp.stat(indexPath);
+    const trackedFileCount = await readIndexEntryCountAsync(indexPath);
+    return { trackedFileCount, indexBytes: st.size };
+  } catch {
+    return { trackedFileCount: 0, indexBytes: 0 };
+  }
+}
+
+/**
+ * 从 Git index 头部读取 tracked entry 数量。
+ */
+async function readIndexEntryCountAsync(indexPath: string): Promise<number> {
+  let handle: Awaited<ReturnType<typeof fsp.open>> | null = null;
+  try {
+    handle = await fsp.open(indexPath, "r");
+    const buf = Buffer.alloc(12);
+    const read = await handle.read(buf, 0, buf.length, 0);
+    if (read.bytesRead < 12) return 0;
+    if (buf.toString("ascii", 0, 4) !== "DIRC") return 0;
+    return Math.max(0, buf.readUInt32BE(8));
+  } catch {
+    return 0;
+  } finally {
+    try { await handle?.close(); } catch {}
+  }
+}
+
+/**
+ * 解析 `git rev-parse --git-path` 返回值为绝对路径。
+ */
+function resolveGitPath(repoRoot: string, rawPath: string): string {
+  const p = String(rawPath || "").trim();
+  if (!p) return "";
+  if (path.isAbsolute(p)) return p;
+  return path.resolve(repoRoot, p);
+}
+
+/**
+ * 将超时取整到秒，避免日志中出现难读的小数。
+ */
+function roundUpToSecond(ms: number): number {
+  return Math.ceil(Math.max(0, Number(ms) || 0) / 1000) * 1000;
+}
+
+/**
+ * 将毫秒数限制在指定区间。
+ */
+function clampTimeoutMs(ms: number, minMs: number, maxMs: number): number {
+  return Math.max(minMs, Math.min(maxMs, Math.floor(Number(ms) || 0)));
+}
+
+/**
+ * 格式化持续时间。
+ */
+function formatDuration(ms: number): string {
+  const seconds = Math.max(0, Math.round(Number(ms) / 1000));
+  const minutes = Math.floor(seconds / 60);
+  const restSeconds = seconds % 60;
+  if (minutes <= 0) return `${restSeconds}s`;
+  if (restSeconds === 0) return `${minutes}m`;
+  return `${minutes}m${restSeconds}s`;
+}
+
+/**
+ * 格式化字节数。
+ */
+function formatBytes(bytes: number): string {
+  const value = Math.max(0, Number(bytes) || 0);
+  if (value >= MIB) return `${(value / MIB).toFixed(1)}MiB`;
+  if (value >= KIB) return `${(value / KIB).toFixed(1)}KiB`;
+  return `${Math.floor(value)}B`;
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1183,6 +1183,7 @@ export default function CodexFlowManagerUI() {
 	    failedCount: 0,
 	    allCompleted: false,
 	    worktreeStates: [],
+	    estimatedTaskTimeoutMs: undefined,
 	    postStateByKey: {},
 	    updatedAt: 0,
 	    error: undefined,
@@ -7621,6 +7622,7 @@ export default function CodexFlowManagerUI() {
       failedCount: 0,
       allCompleted: false,
       worktreeStates: [],
+      estimatedTaskTimeoutMs: undefined,
       postStateByKey: {},
       updatedAt: Date.now(),
       error: undefined,
@@ -7683,6 +7685,7 @@ export default function CodexFlowManagerUI() {
     let logText = "";
     let logOffset = 0;
     const startedAt = Date.now();
+    let waitTimeoutMs = 40 * 60_000;
     let stopPostCreate = false;
 
     /**
@@ -7854,6 +7857,9 @@ export default function CodexFlowManagerUI() {
           logOffset = Math.max(logOffset, Math.floor(Number(snapshot.logSize) || 0));
           stopPostCreateIfCanceled(snapshot.status);
           const worktreeStates = Array.isArray(snapshot.worktreeStates) ? snapshot.worktreeStates : [];
+          const estimatedTaskTimeoutMs = Math.max(0, Math.floor(Number(snapshot.timeoutEstimate?.taskTimeoutMs) || 0));
+          if (estimatedTaskTimeoutMs > 0)
+            waitTimeoutMs = estimatedTaskTimeoutMs;
           setWorktreeCreateProgress((prev) => {
             if (prev.taskId !== taskId) return prev;
             return {
@@ -7867,6 +7873,7 @@ export default function CodexFlowManagerUI() {
               failedCount: Math.max(0, Math.floor(Number(snapshot!.failedCount) || 0)),
               allCompleted: snapshot!.allCompleted === true,
               worktreeStates,
+              estimatedTaskTimeoutMs: estimatedTaskTimeoutMs || prev.estimatedTaskTimeoutMs,
               updatedAt: Math.floor(Number(snapshot!.updatedAt) || Date.now()),
               error: snapshot!.error ? String(snapshot!.error || "") : undefined,
             };
@@ -7877,7 +7884,7 @@ export default function CodexFlowManagerUI() {
       } catch {}
 
       // 兜底：避免无限等待
-      if (Date.now() - startedAt > 40 * 60_000) {
+      if (Date.now() - startedAt > waitTimeoutMs) {
         setWorktreeCreateProgress((prev) => {
           if (prev.taskId !== taskId) return prev;
           return {

--- a/web/src/app/app-shared.tsx
+++ b/web/src/app/app-shared.tsx
@@ -289,6 +289,7 @@ type WorktreeCreateProgressState = {
   failedCount: number;
   allCompleted: boolean;
   worktreeStates: WorktreeCreateTaskItemSnapshot[];
+  estimatedTaskTimeoutMs?: number;
   postStateByKey: Record<string, { status: "idle" | "running" | "success" | "error"; error?: string; projectId?: string; tabId?: string }>;
   updatedAt: number;
   error?: string;

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -508,6 +508,22 @@ export type WorktreeCreateTaskItemSnapshot = {
   warnings?: string[];
 };
 
+export type WorktreeTimeoutEstimate = {
+  worktreeCount: number;
+  maxParallel: number;
+  perWorktreeAddTimeoutMs: number;
+  taskTimeoutMs: number;
+  metrics: {
+    trackedFileCount: number;
+    checkoutFileCount: number;
+    checkoutBytes: number;
+    indexBytes: number;
+    looseObjectBytes: number;
+    packedObjectBytes: number;
+    objectBytes: number;
+  };
+};
+
 export type WorktreeCreateTaskSnapshot = {
   taskId: string;
   repoDir: string;
@@ -524,6 +540,7 @@ export type WorktreeCreateTaskSnapshot = {
   failedCount: number;
   allCompleted: boolean;
   worktreeStates: WorktreeCreateTaskItemSnapshot[];
+  timeoutEstimate?: WorktreeTimeoutEstimate;
   error?: string;
   items?: CreatedWorktree[];
 };


### PR DESCRIPTION
基于仓库 index 体积、tracked 文件数量和对象库规模估算 git worktree add 的单项超时与创建任务总等待时间，避免大仓库或多 worktree 并发创建时
被固定 15 分钟/40 分钟兜底误判失败。

超时估算保持低成本探测，不枚举目标引用的整棵 tree，避免
git ls-tree -r -l 在大仓库产生大量输出并拖慢 Electron 主进程。

将后台任务的超时估算透传到渲染进程，进度轮询复用主进程估算的任务
超时作为等待上限；取消清理 worktree 时复用同一估算逻辑，减少大目录
移除时的误杀风险。

普通 Git 命令仍保留 30 分钟最大上限，只有 worktree 创建和取消清理等
明确大任务显式启用 6 小时长超时，避免后台 Git 命令长期悬挂。

补充 worktree 超时估算的解析与计算单测，并增加 Git 命令超时归一化
测试，固定普通命令与长任务的上限差异。