### PR TITLE
feat(git): 完善工作台复制与分支目录视图

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10354,7 +10354,6 @@ export default function CodexFlowManagerUI() {
                   key={tab.id}
                   value={tab.id}
                   className="mt-1 flex flex-1 min-h-0 flex-col space-y-1"
-                  onContextMenu={(e: React.MouseEvent) => openTabContextMenu(e, tab.id, "tab-content")}
                 >
                   <Card className="relative flex flex-1 min-h-0 flex-col overflow-hidden">
                     <React.Suspense fallback={<div className="flex h-full items-center justify-center text-xs text-[var(--cf-text-secondary)]">{t("projects:gitModuleLoading", "正在加载 Git 模块...") as string}</div>}>
@@ -10384,7 +10383,6 @@ export default function CodexFlowManagerUI() {
                 key={tab.id}
                 value={tab.id}
                 className="mt-1 flex flex-1 min-h-0 min-w-0 flex-col overflow-hidden space-y-1"
-                onContextMenu={(e: React.MouseEvent) => openTabContextMenu(e, tab.id, "tab-content")}
               >
                 <Card className="flex flex-1 min-h-0 min-w-0 flex-col overflow-hidden">
                   <CardContent className="relative flex flex-1 min-h-0 min-w-0 flex-col overflow-hidden p-0">
@@ -10396,7 +10394,7 @@ export default function CodexFlowManagerUI() {
                         attachTerminal={attachTerminal}
                         onScrollToTop={(tid) => terminalManagerRef.current?.scrollToTop(tid)}
                         onScrollToBottom={(tid) => terminalManagerRef.current?.scrollToBottom(tid)}
-                        onContextMenuDebug={(event) => openTabContextMenu(event, tab.id, "terminal-body")}
+                        onContextMenuDebug={showNotifDebugMenu ? (event) => openTabContextMenu(event, tab.id, "terminal-body") : undefined}
                         theme={terminalThemeDef}
                       />
                     </div>

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -46,10 +46,17 @@ export function DropdownMenuContent({ align = 'start', className, children }: { 
   const ctx = React.useContext(Ctx);
   const contentRef = React.useRef<HTMLDivElement | null>(null);
   const [style, setStyle] = React.useState<React.CSSProperties>({});
+  const [positioned, setPositioned] = React.useState(false);
 
-  // 计算并更新弹层位置
+  /**
+   * 计算并更新弹层位置。
+   * @returns 是否已拿到触发器与内容节点并完成定位。
+   */
   const updatePosition = React.useCallback(() => {
-    if (!ctx?.open || !ctx.triggerRef.current || !contentRef.current) return;
+    if (!ctx?.open || !ctx.triggerRef.current || !contentRef.current) {
+      setPositioned(false);
+      return false;
+    }
     const triggerRect = ctx.triggerRef.current.getBoundingClientRect();
     const contentRect = contentRef.current.getBoundingClientRect();
     const viewportW = window.innerWidth;
@@ -74,10 +81,28 @@ export function DropdownMenuContent({ align = 'start', className, children }: { 
     }
 
     setStyle({ position: 'fixed', top, left, zIndex: 9999 });
+    setPositioned(true);
+    return true;
   }, [ctx?.open, align, ctx?.triggerRef]);
 
   React.useLayoutEffect(() => {
-    updatePosition();
+    if (!ctx?.open) {
+      setPositioned(false);
+      return;
+    }
+    setPositioned(false);
+    let frameId: number | null = null;
+    let attempts = 0;
+    // 在触发器或内容节点首帧尚未就绪时，短暂重试以避免菜单先显示到错误位置。
+    const retryPosition = () => {
+      attempts += 1;
+      if (updatePosition() || attempts >= 5) return;
+      frameId = window.requestAnimationFrame(retryPosition);
+    };
+    retryPosition();
+    return () => {
+      if (frameId != null) window.cancelAnimationFrame(frameId);
+    };
   }, [ctx?.open, updatePosition]);
 
   // 点击外部关闭
@@ -115,7 +140,15 @@ export function DropdownMenuContent({ align = 'start', className, children }: { 
     <div
       ref={contentRef}
       data-dropdown-menu-content="true"
-      style={style}
+      style={{
+        position: 'fixed',
+        left: 0,
+        top: 0,
+        zIndex: 9999,
+        visibility: positioned ? undefined : 'hidden',
+        pointerEvents: positioned ? undefined : 'none',
+        ...style,
+      }}
       className={cn(
         "min-w-[180px] rounded-apple-lg border border-[var(--cf-border)] bg-[var(--cf-surface)] backdrop-blur-apple p-1.5 shadow-apple-lg text-[var(--cf-text-primary)] dark:shadow-apple-dark-lg",
         className,

--- a/web/src/features/git/action-dialog-presets.ts
+++ b/web/src/features/git/action-dialog-presets.ts
@@ -172,7 +172,7 @@ export function buildUndoCommitDialogConfig(args?: {
 }
 
 /**
- * 生成“删除提交”确认弹窗配置，对齐 IDEA 在执行 drop 前的确认与“不再询问”入口。
+ * 生成“删除提交”确认弹窗配置，保持与参考实现一致，在执行 drop 前的确认与“不再询问”入口。
  */
 export function buildDeleteCommitDialogConfig(args: {
   commitCount: number;
@@ -211,7 +211,7 @@ export function buildDeleteCommitDialogConfig(args: {
 }
 
 /**
- * 生成“优选/还原所选更改”对话框配置；启用 changelist 时要求先选择目标更改列表，对齐 IDEA 的 committed changes patch 流程。
+ * 生成“优选/还原所选更改”对话框配置；启用 changelist 时要求先选择目标更改列表，保持与参考实现一致的 committed changes patch 流程。
  */
 export function buildCommitDetailsPatchDialogConfig(
   mode: "revert" | "apply",

--- a/web/src/features/git/api.ts
+++ b/web/src/features/git/api.ts
@@ -479,7 +479,7 @@ export async function setChangesViewOptionAsync(
 }
 
 /**
- * 设置提交面板 grouping key 集，用于对齐 IDEA 的 directory/module/repository 组合分组。
+ * 设置提交面板 grouping key 集，用于保持与参考实现一致的 directory/module/repository 组合分组。
  */
 export async function setCommitGroupingKeysAsync(
   repoPath: string,

--- a/web/src/features/git/branch-sync/popup-state.test.ts
+++ b/web/src/features/git/branch-sync/popup-state.test.ts
@@ -18,6 +18,7 @@ describe("branch popup state", () => {
         local: true,
         remote: true,
       },
+      panelGroupByDirectory: false,
     });
   });
 
@@ -31,6 +32,7 @@ describe("branch popup state", () => {
         local: false,
         remote: true,
       },
+      panelGroupByDirectory: true,
     });
 
     expect(loadGitBranchPopupState()).toEqual({
@@ -42,6 +44,7 @@ describe("branch popup state", () => {
         local: false,
         remote: true,
       },
+      panelGroupByDirectory: true,
     });
   });
 });

--- a/web/src/features/git/branch-sync/popup-state.ts
+++ b/web/src/features/git/branch-sync/popup-state.ts
@@ -13,6 +13,7 @@ export type GitBranchPopupPersistedState = {
   selectedRepoRoot: string;
   step: GitBranchPopupStep;
   groupOpen: BranchPopupGroupOpen;
+  panelGroupByDirectory: boolean;
 };
 
 function getStorage(): Storage | null {
@@ -34,6 +35,7 @@ function normalizeBranchPopupPersistedState(value: any): GitBranchPopupPersisted
       local: value?.groupOpen?.local !== false,
       remote: value?.groupOpen?.remote !== false,
     },
+    panelGroupByDirectory: value?.panelGroupByDirectory === true,
   };
 }
 
@@ -47,6 +49,7 @@ export function loadGitBranchPopupState(): GitBranchPopupPersistedState {
       selectedRepoRoot: "",
       step: "branches",
       groupOpen: createDefaultBranchPopupGroupOpen(),
+      panelGroupByDirectory: false,
     };
   }
   try {
@@ -56,6 +59,7 @@ export function loadGitBranchPopupState(): GitBranchPopupPersistedState {
         selectedRepoRoot: "",
         step: "branches",
         groupOpen: createDefaultBranchPopupGroupOpen(),
+        panelGroupByDirectory: false,
       };
     }
     return normalizeBranchPopupPersistedState(JSON.parse(raw));
@@ -64,6 +68,7 @@ export function loadGitBranchPopupState(): GitBranchPopupPersistedState {
       selectedRepoRoot: "",
       step: "branches",
       groupOpen: createDefaultBranchPopupGroupOpen(),
+      panelGroupByDirectory: false,
     };
   }
 }

--- a/web/src/features/git/branch-sync/presentation.test.ts
+++ b/web/src/features/git/branch-sync/presentation.test.ts
@@ -25,7 +25,7 @@ describe("branch sync presentation", () => {
     expect(presentation.tooltip).toContain("落后 2 个提交，领先 1 个提交");
   });
 
-  it("incoming / outgoing 标签应按 IDEA 规则格式化为 99+ 与空数字 incoming", () => {
+  it("incoming / outgoing 标签应按分支面板规则格式化为 99+ 与空数字 incoming", () => {
     const incoming = buildIncomingBranchSyncBadge({
       upstream: "origin/master",
       incoming: 124,

--- a/web/src/features/git/branch-sync/presentation.ts
+++ b/web/src/features/git/branch-sync/presentation.ts
@@ -101,7 +101,7 @@ function resolveBranchRowTooltip(item: GitBranchItem, resolveText?: GitBranchTex
 }
 
 /**
- * 按 IDEA `99+` 规则格式化同步计数。
+ * 按参考实现 `99+` 规则格式化同步计数。
  */
 export function formatBranchSyncCount(count: number): string {
   const normalized = Math.max(0, Math.floor(Number(count) || 0));
@@ -131,7 +131,7 @@ export function buildIncomingBranchSyncBadge(sync?: GitBranchSyncState, resolveT
 }
 
 /**
- * 构建 outgoing 标签展示模型；与 IDEA 一样只有存在待推送提交时才展示。
+ * 构建 outgoing 标签展示模型；与参考实现一样只有存在待推送提交时才展示。
  */
 export function buildOutgoingBranchSyncBadge(sync?: GitBranchSyncState, resolveText?: GitBranchTextResolver): GitBranchSyncBadgePresentation | null {
   if (!sync || sync.gone) return null;

--- a/web/src/features/git/branch-sync/tree-model.test.ts
+++ b/web/src/features/git/branch-sync/tree-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildBranchPanelRows, buildBranchPopupRows, resolveSelectedBranchPopupRepository } from "./tree-model";
+import { buildBranchPanelCopyText, buildBranchPanelRows, buildBranchPopupRows, resolveSelectedBranchPopupRepository } from "./tree-model";
 import type { GitBranchPopupSnapshot } from "../types";
 
 /**
@@ -46,8 +46,14 @@ function createBranchPopupSnapshot(): GitBranchPopupSnapshot {
         groups: {
           favorites: [{ name: "main", favorite: true, current: true, secondaryText: "origin/main" }],
           recent: [{ name: "feature/recent" }],
-          local: [{ name: "main", favorite: true, current: true, secondaryText: "origin/main" }],
-          remote: [{ name: "origin/main" }],
+          local: [
+            { name: "main", favorite: true, current: true, secondaryText: "origin/main" },
+            { name: "feature/api/refactor" },
+          ],
+          remote: [
+            { name: "origin/main" },
+            { name: "origin/feature/api/refactor" },
+          ],
         },
       },
       {
@@ -126,5 +132,80 @@ describe("branch tree model", () => {
     expect(selectedRepository?.rootName).toBe("lib");
     expect(rows.some((row) => row.kind === "branch" && row.repoRoot === "/workspace/root/modules/lib" && row.name === "release")).toBe(true);
     expect(rows.some((row) => row.kind === "branch" && row.repoRoot === "/workspace/root" && row.name === "main")).toBe(false);
+  });
+
+  it("分支面板关闭目录分组时应保持分支名平铺显示", () => {
+    const snapshot = createBranchPopupSnapshot();
+    const rows = buildBranchPanelRows(snapshot, "/workspace/root", {
+      favorites: true,
+      local: true,
+      remote: true,
+    });
+
+    expect(rows.some((row) => row.kind === "group" && row.directoryPath === "feature")).toBe(false);
+    expect(rows.some((row) => row.kind === "branch" && row.name === "feature/api/refactor" && row.displayName === "feature/api/refactor")).toBe(true);
+  });
+
+  it("分支面板开启目录分组后应按斜杠生成目录节点并保留完整动作分支名", () => {
+    const snapshot = createBranchPopupSnapshot();
+    const rows = buildBranchPanelRows(snapshot, "/workspace/root", {
+      favorites: true,
+      local: true,
+      remote: true,
+    }, true);
+
+    expect(rows.some((row) => row.kind === "group" && row.directoryPath === "feature")).toBe(true);
+    expect(rows.some((row) => row.kind === "group" && row.directoryPath === "feature/api")).toBe(true);
+    expect(rows.some((row) => row.kind === "branch" && row.name === "feature/api/refactor" && row.displayName === "refactor")).toBe(true);
+    expect(rows.some((row) => row.kind === "branch" && row.name === "origin/feature/api/refactor" && row.displayName === "refactor")).toBe(true);
+  });
+
+  it("分支面板目录分组下应保留完整分支名供 speed search 使用", () => {
+    const snapshot = createBranchPopupSnapshot();
+    const rows = buildBranchPanelRows(snapshot, "/workspace/root", {
+      favorites: true,
+      local: true,
+      remote: true,
+    }, true);
+    const branch = rows.find((row) => row.kind === "branch" && row.name === "feature/api/refactor");
+
+    if (!branch || branch.kind !== "branch")
+      throw new Error("missing feature branch row");
+    expect(branch.displayName).toBe("refactor");
+    expect(branch.textPresentation).toBe("feature/api/refactor");
+  });
+
+  it("分支面板目录节点收起后应隐藏子目录与子分支", () => {
+    const snapshot = createBranchPopupSnapshot();
+    const openRows = buildBranchPanelRows(snapshot, "/workspace/root", {
+      favorites: true,
+      local: true,
+      remote: true,
+    }, true);
+    const featureGroup = openRows.find((row) => row.kind === "group" && row.directoryPath === "feature");
+    expect(featureGroup?.kind).toBe("group");
+
+    const rows = buildBranchPanelRows(snapshot, "/workspace/root", {
+      favorites: true,
+      local: true,
+      remote: true,
+    }, true, featureGroup ? { [featureGroup.key]: false } : {});
+
+    expect(rows.some((row) => row.kind === "group" && row.directoryPath === "feature/api")).toBe(false);
+    expect(rows.some((row) => row.kind === "branch" && row.name === "feature/api/refactor")).toBe(false);
+  });
+
+  it("分支面板 copy provider 应复制当前聚焦行的显示文本", () => {
+    const snapshot = createBranchPopupSnapshot();
+    const rows = buildBranchPanelRows(snapshot, "/workspace/root", {
+      favorites: true,
+      local: true,
+      remote: true,
+    }, true);
+    const branch = rows.find((row) => row.kind === "branch" && row.name === "feature/api/refactor");
+    const group = rows.find((row) => row.kind === "group" && row.directoryPath === "feature/api");
+
+    expect(buildBranchPanelCopyText({ rows, focusedRowKey: branch?.key })).toBe("refactor");
+    expect(buildBranchPanelCopyText({ rows, focusedRowKey: group?.key })).toBe("feature/api");
   });
 });

--- a/web/src/features/git/branch-sync/tree-model.ts
+++ b/web/src/features/git/branch-sync/tree-model.ts
@@ -16,8 +16,27 @@ export type BranchPopupRow =
   | { kind: "branch"; name: string; section: "favorites" | "recent" | "local" | "remote"; repoRoot: string; item?: GitBranchItem };
 
 export type BranchPanelRow =
-  | { kind: "group"; key: string; label: string }
-  | { kind: "branch"; key: string; name: string; section: "favorites" | "local" | "remote"; repoRoot: string; textPresentation: string; item?: GitBranchItem };
+  | {
+      kind: "group";
+      key: string;
+      label: string;
+      section?: "favorites" | "local" | "remote";
+      depth?: number;
+      directoryPath?: string;
+      parentKey?: string;
+    }
+  | {
+      kind: "branch";
+      key: string;
+      name: string;
+      displayName: string;
+      section: "favorites" | "local" | "remote";
+      repoRoot: string;
+      textPresentation: string;
+      item?: GitBranchItem;
+      depth: number;
+      parentKey?: string;
+    };
 
 export type BranchPanelGroupOpen = {
   favorites: boolean;
@@ -32,8 +51,143 @@ export type BranchPopupGroupOpen = {
   remote: boolean;
 };
 
+type BranchPathNode = {
+  key: string;
+  label: string;
+  path: string;
+  depth: number;
+  children: BranchPathNode[];
+  item?: GitBranchItem;
+  isLeaf: boolean;
+};
+
 /**
- * 返回 branch popup 分组展开状态的默认值；默认全部展开，贴近 IDEA 首次打开体验。
+ * 统一规范化分支引用名，避免目录分组与复制文本在 Windows 路径分隔符上出现不一致。
+ */
+function normalizeBranchRefName(value: string): string {
+  return String(value || "").trim().replace(/\\/g, "/").replace(/\/+/g, "/").replace(/^\/+|\/+$/g, "");
+}
+
+/**
+ * 计算分支目录分组的稳定节点键；叶子节点保留完整引用名，目录节点按路径段递进生成。
+ */
+function buildBranchPathKey(section: string, repoRoot: string, path: string): string {
+  return `branch:${repoRoot}:${section}:${path}`;
+}
+
+/**
+ * 计算分支目录节点的稳定键，避免同名目录和同名分支叶子互相覆盖。
+ */
+function buildBranchDirectoryKey(section: string, repoRoot: string, path: string): string {
+  return `branch-dir:${repoRoot}:${section}:${path}`;
+}
+
+/**
+ * 把分支引用按 `/` 切成目录树，叶子仍保留完整分支名，供显示与动作复用。
+ */
+function buildBranchPathNodes(section: string, repoRoot: string, items: GitBranchItem[] | undefined): BranchPathNode[] {
+  const roots: BranchPathNode[] = [];
+  const directoryByKey = new Map<string, BranchPathNode>();
+  const branchByKey = new Set<string>();
+  if (!Array.isArray(items) || items.length <= 0) return [];
+  for (const item of items) {
+    const name = normalizeBranchRefName(item?.name || "");
+    if (!name) continue;
+    const segments = name.split("/").filter(Boolean);
+    if (segments.length <= 0) continue;
+    let parent: BranchPathNode | undefined;
+    let currentPath = "";
+    for (let index = 0; index < segments.length - 1; index += 1) {
+      const segment = segments[index] || "";
+      if (!segment) continue;
+      currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+      const nodeKey = buildBranchDirectoryKey(section, repoRoot, currentPath);
+      let node = directoryByKey.get(nodeKey);
+      if (!node) {
+        node = {
+          key: nodeKey,
+          label: segment,
+          path: currentPath,
+          depth: index,
+          children: [],
+          isLeaf: false,
+        };
+        directoryByKey.set(nodeKey, node);
+        if (parent) parent.children.push(node);
+        else roots.push(node);
+      }
+      parent = node;
+    }
+    const leafKey = buildBranchPathKey(section, repoRoot, name);
+    if (branchByKey.has(leafKey)) continue;
+    branchByKey.add(leafKey);
+    const leaf: BranchPathNode = {
+      key: leafKey,
+      label: name,
+      path: name,
+      depth: Math.max(0, segments.length - 1),
+      children: [],
+      item,
+      isLeaf: true,
+    };
+    if (parent) parent.children.push(leaf);
+    else roots.push(leaf);
+  }
+  return roots;
+}
+
+/**
+ * 递归收集目录树中所有分支叶子，保持当前面板的显示顺序与路径层级。
+ */
+function flattenBranchPathNodes(nodes: BranchPathNode[], depth = 0, parentKey?: string): BranchPanelRow[] {
+  const out: BranchPanelRow[] = [];
+  for (const node of nodes) {
+    if (node.isLeaf) {
+      const segments = node.path.split("/").filter(Boolean);
+      const displayName = segments[segments.length - 1] || node.label;
+      out.push({
+        kind: "branch",
+        key: node.key,
+        name: node.path,
+        displayName,
+        section: "local",
+        repoRoot: "",
+        textPresentation: node.path,
+        item: node.item,
+        depth,
+        parentKey,
+      });
+      continue;
+    }
+    out.push({
+      kind: "group",
+      key: node.key,
+      label: node.label,
+      depth,
+      directoryPath: node.path,
+      parentKey,
+    });
+    out.push(...flattenBranchPathNodes(node.children, depth + 1, node.key));
+  }
+  return out;
+}
+
+/**
+ * 按屏幕显示顺序导出分支面板选中行文本，用于工作台复制处理。
+ */
+export function buildBranchPanelCopyText(args: {
+  rows: BranchPanelRow[];
+  focusedRowKey?: string;
+}): string {
+  const focusedRowKey = String(args.focusedRowKey || "").trim();
+  const row = args.rows.find((item) => item.key === focusedRowKey);
+  if (!row) return "";
+  if (row.kind === "branch") return String(row.displayName || row.textPresentation || "").trim();
+  return String(row.directoryPath || row.label || "").trim();
+}
+
+/**
+ * 返回 branch popup 分组展开状态的默认值；默认全部展开，贴近常见分支弹窗体验。
  */
 export function createDefaultBranchPopupGroupOpen(): BranchPopupGroupOpen {
   return {
@@ -147,6 +301,8 @@ export function buildBranchPanelRows(
   snapshot: GitBranchPopupSnapshot | null,
   selectedRepoRoot: string,
   groupOpen: BranchPanelGroupOpen,
+  groupByDirectory: boolean = false,
+  directoryOpen: Record<string, boolean> = {},
   resolveText?: GitBranchTextResolver,
 ): BranchPanelRow[] {
   const resolveLabel = (key: string, fallback: string, values?: Record<string, unknown>): string => {
@@ -158,28 +314,53 @@ export function buildBranchPanelRows(
   const groups = selectedRepository.groups;
   const pushBranchRows = (section: "favorites" | "local" | "remote", items: GitBranchItem[] | undefined): void => {
     if (!Array.isArray(items) || items.length <= 0) return;
-    for (const item of items) {
-      const name = String(item?.name || "").trim();
-      if (!name) continue;
+    if (!groupByDirectory) {
+      for (const item of items) {
+        const name = normalizeBranchRefName(item?.name || "");
+        if (!name) continue;
+        rows.push({
+          kind: "branch",
+          key: buildBranchPathKey(section, selectedRepository.repoRoot, name),
+          name,
+          displayName: name,
+          section,
+          repoRoot: selectedRepository.repoRoot,
+          textPresentation: name,
+          item,
+          depth: 0,
+        });
+      }
+      return;
+    }
+    const groupedRows = buildBranchPathNodes(section, selectedRepository.repoRoot, items);
+    const flatRows = flattenBranchPathNodes(groupedRows);
+    const hiddenDirectoryKeys = new Set<string>();
+    for (const row of flatRows) {
+      const parentHidden = !!row.parentKey && (directoryOpen[row.parentKey] === false || hiddenDirectoryKeys.has(row.parentKey));
+      if (parentHidden) {
+        if (row.kind === "group") hiddenDirectoryKeys.add(row.key);
+        continue;
+      }
+      if (row.kind === "group") {
+        rows.push({ ...row, section });
+        if (directoryOpen[row.key] === false) hiddenDirectoryKeys.add(row.key);
+        continue;
+      }
       rows.push({
-        kind: "branch",
-        key: `branch:${selectedRepository.repoRoot}:${section}:${name}`,
-        name,
+        ...row,
         section,
         repoRoot: selectedRepository.repoRoot,
-        textPresentation: name,
-        item,
       });
     }
   };
 
   if ((groups?.favorites || []).length > 0) {
-    rows.push({ kind: "group", key: "group:favorites", label: resolveLabel("workbench.branches.common.groups.favorites", "收藏") });
+    rows.push({ kind: "group", key: "group:favorites", label: resolveLabel("workbench.branches.common.groups.favorites", "收藏"), section: "favorites" });
     if (groupOpen.favorites) pushBranchRows("favorites", groups.favorites);
   }
-  rows.push({ kind: "group", key: "group:local", label: resolveLabel("workbench.branches.common.groups.local", "本地") });
+  rows.push({ kind: "group", key: "group:local", label: resolveLabel("workbench.branches.common.groups.local", "本地"), section: "local" });
   if (groupOpen.local) pushBranchRows("local", groups?.local);
-  rows.push({ kind: "group", key: "group:remote", label: resolveLabel("workbench.branches.common.groups.remote", "远端") });
+  rows.push({ kind: "group", key: "group:remote", label: resolveLabel("workbench.branches.common.groups.remote", "远端"), section: "remote" });
   if (groupOpen.remote) pushBranchRows("remote", groups?.remote);
   return rows;
 }

--- a/web/src/features/git/branch-sync/widgets.tsx
+++ b/web/src/features/git/branch-sync/widgets.tsx
@@ -22,7 +22,7 @@ type BranchSyncBadgesProps = {
 type BranchSyncGlyphKind = "incoming" | "outgoing" | "diverged" | "unfetched";
 
 /**
- * 渲染当前分支入口的同步状态图标，参考上游“branch + incoming/outgoing 状态”的主视觉语义。
+ * 渲染当前分支入口的同步状态图标，参考实现中“branch + incoming/outgoing 状态”的主视觉语义。
  */
 export function BranchSyncStatusIcon(props: BranchSyncStatusIconProps): JSX.Element {
   const glyphKind = resolveBranchSyncGlyphKind(props.sync);
@@ -70,7 +70,7 @@ export function BranchSyncBadges(props: BranchSyncBadgesProps): JSX.Element | nu
 }
 
 /**
- * 根据同步状态选择顶栏入口的 companion glyph，贴近 IDEA 的分层 branch icon 语义。
+ * 根据同步状态选择顶栏入口的 companion glyph，贴近参考实现的分层 branch icon 语义。
  */
 function resolveBranchSyncGlyphKind(sync?: GitBranchSyncState): BranchSyncGlyphKind | null {
   if (!sync || sync.gone || sync.status === "synced" || sync.status === "untracked")
@@ -87,7 +87,7 @@ function resolveBranchSyncGlyphKind(sync?: GitBranchSyncState): BranchSyncGlyphK
 }
 
 /**
- * 渲染顶栏当前分支旁的同步状态 glyph，使用更粗更清楚的矢量笔画模拟 IDEA layered icon。
+ * 渲染顶栏当前分支旁的同步状态 glyph，使用更粗更清楚的矢量笔画模拟参考实现的 layered icon。
  */
 function BranchSyncGlyph(props: { kind: BranchSyncGlyphKind }): JSX.Element {
   return (

--- a/web/src/features/git/change-context-actions.ts
+++ b/web/src/features/git/change-context-actions.ts
@@ -43,7 +43,7 @@ export function collectSelectedConflictPaths(entries: GitConflictEntryLike[]): s
 }
 
 /**
- * 仅在当前选择包含冲突文件时暴露 IDEA 对齐的右键快捷动作，并固定顺序为 Merge/Theirs/Yours。
+ * 仅在当前选择包含冲突文件时暴露与参考实现一致的右键快捷动作，并固定顺序为 Merge/Theirs/Yours。
  */
 export function buildConflictContextActionKeys(entries: GitConflictEntryLike[]): GitConflictContextActionKey[] {
   return collectSelectedConflictPaths(entries).length > 0 ? CONFLICT_CONTEXT_ACTION_ORDER : [];

--- a/web/src/features/git/changelist-ui.ts
+++ b/web/src/features/git/changelist-ui.ts
@@ -40,7 +40,7 @@ export function buildChangeListSelectOptions(lists: GitChangeList[]): Array<{ va
 }
 
 /**
- * 按 IDEA 的单列表移动语义过滤候选列表；若仅从一个列表移动，则优先排除该源列表。
+ * 按参考实现的单列表移动语义过滤候选列表；若仅从一个列表移动，则优先排除该源列表。
  */
 export function resolveMoveDialogLists(lists: GitChangeList[], selectedEntries: GitStatusEntry[]): GitChangeList[] {
   const affectedIds = new Set(

--- a/web/src/features/git/commit-panel/amend-model.test.ts
+++ b/web/src/features/git/commit-panel/amend-model.test.ts
@@ -120,7 +120,7 @@ describe("commit amend model", () => {
     expect(buildCommitActionLabel(false, true, true)).toBe("提交并推送...");
   });
 
-  it("应按 IDEA 的 canonical Hash 语义做精确身份比较，而不是把短前缀视为同一提交", () => {
+  it("应按 canonical Hash 语义做精确身份比较，而不是把短前缀视为同一提交", () => {
     expect(isSameCommitHashIdentity(
       "64edc51214ddd76c3013e379e8e3ebfbaced1610",
       "64EDC51214DDD76C3013E379E8E3EBFBACED1610",

--- a/web/src/features/git/commit-panel/amend-model.ts
+++ b/web/src/features/git/commit-panel/amend-model.ts
@@ -38,7 +38,7 @@ function normalizeCommitHashIdentity(value: string): string {
 }
 
 /**
- * 按 IDEA `equalsIgnoreWhitespaces` 近似语义压平提交消息中的连续空白，供 amend 消息回填判定复用。
+ * 按参考实现 `equalsIgnoreWhitespaces` 近似语义压平提交消息中的连续空白，供 amend 消息回填判定复用。
  */
 function normalizeCommitAmendMessageForCompare(value: string): string {
   return String(value || "").replace(/\s+/g, " ").trim();
@@ -123,7 +123,7 @@ export function buildCommitAmendDetails(detail: GitLogDetailsSingle["detail"]): 
 
 /**
  * 判断两个提交哈希是否指向同一提交。
- * IDEA 比较的是 canonical `Hash` 对象；这里应保持同样的“精确身份”语义，不把短前缀适配成同一提交。
+ * 参考实现比较的是 canonical `Hash` 对象；这里应保持同样的“精确身份”语义，不把短前缀适配成同一提交。
  */
 export function isSameCommitHashIdentity(leftHash: string, rightHash: string): boolean {
   const left = normalizeCommitHashIdentity(leftHash);
@@ -158,7 +158,7 @@ export function isCommitAmendNode(
 }
 
 /**
- * 判断加载完成后是否需要用 amend 消息覆盖当前提交消息，对齐 IDEA non-modal amend 的“忽略空白差异”判定。
+ * 判断加载完成后是否需要用 amend 消息覆盖当前提交消息，保持与参考实现一致的 non-modal amend 的“忽略空白差异”判定。
  */
 export function shouldApplyCommitAmendMessage(currentMessage: string, amendMessage: string): boolean {
   const nextMessage = String(amendMessage || "");

--- a/web/src/features/git/commit-panel/changes-tree-view-model.test.ts
+++ b/web/src/features/git/commit-panel/changes-tree-view-model.test.ts
@@ -44,7 +44,7 @@ describe("commit panel tree view model", () => {
     expect(groups[0]?.sortWeight).toBe(0);
   });
 
-  it("conflict/resolved-conflict 节点应生成上游语义对应的 hover/open 动作", () => {
+  it("conflict/resolved-conflict 节点应生成参考实现语义对应的 hover/open 动作", () => {
     const treeGroups = buildCommitTreeGroups([
       {
         key: "special:conflicts",
@@ -109,7 +109,7 @@ describe("commit panel tree view model", () => {
     expect(rows.some((row) => row.node.fullPath === "src/app/a.ts")).toBe(true);
   });
 
-  it("连续单子目录应折叠为上游风格的组合路径显示", () => {
+  it("连续单子目录应折叠为参考实现风格的组合路径显示", () => {
     const tree = buildCommitTree([
       { path: "web/src/App.tsx", x: "M", y: ".", staged: true, unstaged: false, untracked: false, ignored: false, renamed: false, deleted: false, statusText: "已暂存", changeListId: "default" },
       { path: "web/src/lib/render.ts", x: "M", y: ".", staged: true, unstaged: false, untracked: false, ignored: false, renamed: false, deleted: false, statusText: "已暂存", changeListId: "default" },
@@ -304,7 +304,7 @@ describe("commit panel tree view model", () => {
     expect(rows[2]?.textPresentation).toBe("a.ts");
   });
 
-  it("ignored/unversioned 超过上游 many files 阈值时，不应继续在树中展开全部子节点", () => {
+  it("ignored/unversioned 超过参考实现 many files 阈值时，不应继续在树中展开全部子节点", () => {
     const entries = Array.from({ length: DEFAULT_COMMIT_PANEL_MANY_FILES_THRESHOLD + 1 }, (_, index) => ({
       path: `dist/${index}.txt`,
       x: "!",

--- a/web/src/features/git/commit-panel/changes-tree-view-model.ts
+++ b/web/src/features/git/commit-panel/changes-tree-view-model.ts
@@ -68,7 +68,7 @@ function buildCollapsedDirectoryTextPresentation(basePath: string, targetPath: s
 }
 
 /**
- * 对齐上游 `ChangesBrowserSpecificNode.isManyFiles()` 语义。
+ * 保持与参考实现一致的 `ChangesBrowserSpecificNode.isManyFiles()` 语义。
  */
 function isManySpecialFiles(entries: GitStatusEntry[], manyFilesThreshold: number): boolean {
   return entries.length > manyFilesThreshold;
@@ -205,7 +205,7 @@ export function getCommitNodeTextPresentation(node: Pick<CommitTreeNode, "textPr
 }
 
 /**
- * 按提交面板模式构建 section；结构对齐上游 changelist/helper node 思路，并预留 conflict/resolved conflict 扩展。
+ * 按提交面板模式构建 section；结构参考实现的 changelist/helper node 思路，并预留 conflict/resolved conflict 扩展。
  */
 export function buildChangeEntryGroups(args: BuildChangeEntryGroupsArgs): ChangeEntryGroup[] {
   const gt = args.translate;
@@ -418,7 +418,7 @@ function createMutableHelperNode(args: {
 }
 
 /**
- * 为折叠后的目录节点同步可见文案，确保提交树展示与上游的单子目录折叠路径一致。
+ * 为折叠后的目录节点同步可见文案，确保提交树展示与参考实现的单子目录折叠路径一致。
  */
 function applyCollapsedDirectoryPresentation(node: CommitTreeNode, textPresentation: string): CommitTreeNode {
   if (node.kind !== "directory") return node;
@@ -436,7 +436,7 @@ function applyCollapsedDirectoryPresentation(node: CommitTreeNode, textPresentat
 }
 
 /**
- * 对齐上游 `TreeModelBuilder.collapseDirectories()`，折叠连续的单子目录链，避免出现 `web -> src` 这类冗余层级。
+ * 保持与参考实现一致的 `TreeModelBuilder.collapseDirectories()`，折叠连续的单子目录链，避免出现 `web -> src` 这类冗余层级。
  */
 function collapseCommitDirectoryNodes(nodes: CommitTreeNode[], parentPath: string = ""): CommitTreeNode[] {
   return nodes.map((node) => {

--- a/web/src/features/git/commit-panel/commit-tree-pane.tsx
+++ b/web/src/features/git/commit-panel/commit-tree-pane.tsx
@@ -203,14 +203,14 @@ function resolveDragPayloadPaths(payload: CommitTreeDragPayload, kind: "change" 
 }
 
 /**
- * 对齐 IDEA `GitAddOperation.matches`，仅允许未暂存或未跟踪条目投放到 staged 分组。
+ * 保持与参考实现一致 `GitAddOperation.matches`，仅允许未暂存或未跟踪条目投放到 staged 分组。
  */
 function canStageDraggedEntry(entry: GitStatusEntry): boolean {
   return !entry.ignored && (entry.untracked || entry.unstaged || !entry.staged);
 }
 
 /**
- * 对齐 IDEA `GitResetOperation.matches`，仅允许已暂存条目投放到 unstaged 分组。
+ * 保持与参考实现一致 `GitResetOperation.matches`，仅允许已暂存条目投放到 unstaged 分组。
  */
 function canUnstageDraggedEntry(entry: GitStatusEntry): boolean {
   return !entry.ignored && entry.staged;
@@ -272,7 +272,7 @@ function resolveContextSelectionRowKeys(args: {
 }
 
 /**
- * 仅当提交树处于单选且命中当前节点时，才允许触发节点级 openHandler，对齐 IDEA 的 `selected(...).single()` 语义。
+ * 仅当提交树处于单选且命中当前节点时，才允许触发节点级 openHandler，保持与参考实现一致的 `selected(...).single()` 语义。
  */
 function canInvokeNodeOpenHandler(rowKey: string, selectedRowKeys: string[]): boolean {
   return selectedRowKeys.length === 1 && selectedRowKeys[0] === rowKey;
@@ -514,7 +514,7 @@ export function CommitTreePane(props: CommitTreePaneProps): React.ReactElement {
     if (!speedSearchOpen) return;
 
     /**
-     * 点击提交面板外部时按 IDEA `focusLost -> manageSearchPopup(null)` 语义关闭并清空搜索。
+     * 点击提交面板外部时按参考实现 `focusLost -> manageSearchPopup(null)` 语义关闭并清空搜索。
      */
     const handleDocumentMouseDown = (event: MouseEvent): void => {
       const root = paneRootRef.current;

--- a/web/src/features/git/commit-panel/config.ts
+++ b/web/src/features/git/commit-panel/config.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
 /**
- * 提交面板 many files 默认阈值，对齐上游 `ChangesBrowserSpecificNode` 的默认行为。
+ * 提交面板 many files 默认阈值，保持与参考实现一致的 `ChangesBrowserSpecificNode` 默认行为。
  */
 export const DEFAULT_COMMIT_PANEL_MANY_FILES_THRESHOLD = 1000;
 export const COMMIT_TREE_RESET_THRESHOLD = 30_000;
@@ -17,7 +17,7 @@ export const SPECIAL_FILES_ROW_HEIGHT = 28;
 export const DEFAULT_COMMIT_PANEL_CHANGE_LIST_ID = "default";
 
 /**
- * 归一化 many files 阈值；无效输入统一回退到上游默认值。
+ * 归一化 many files 阈值；无效输入统一回退到参考实现默认值。
  */
 export function normalizeCommitPanelManyFilesThreshold(value: unknown): number {
   const normalized = Number(value);

--- a/web/src/features/git/commit-panel/conflict-merge-dialog.tsx
+++ b/web/src/features/git/commit-panel/conflict-merge-dialog.tsx
@@ -166,7 +166,7 @@ function buildConflictMergeResolveHint(args: {
 }
 
 /**
- * 构造“应用”前的确认提示，贴近 IDEA 对“部分解决仍可继续应用”的收口语义。
+ * 构造“应用”前的确认提示，贴近参考实现对“部分解决仍可继续应用”的收口语义。
  */
 function buildConflictMergeResolvePromptMessage(args: {
   unresolvedChanges: number;
@@ -194,7 +194,7 @@ function buildConflictMergeAcceptSourcePromptMessage(label: string, gt?: GitTran
 }
 
 /**
- * 把当前未处理更改/冲突数量格式化成接近 IDEA 顶部状态栏的摘要文案。
+ * 把当前未处理更改/冲突数量格式化成接近参考实现 顶部状态栏的摘要文案。
  */
 function buildConflictMergeChangeSummaryText(args: {
   unresolvedChanges: number;
@@ -345,7 +345,7 @@ function getConflictRevision(
 }
 
 /**
- * 应用内冲突处理对话框，按接近 IDEA `TextMergeViewer` 的方式展示三栏来源、结果与块级处理入口。
+ * 应用内冲突处理对话框，按接近参考实现 `TextMergeViewer` 的方式展示三栏来源、结果与块级处理入口。
  */
 export function ConflictMergeDialog(props: ConflictMergeDialogProps): React.ReactElement {
   const { t } = useTranslation(["git", "common"]);
@@ -491,7 +491,7 @@ export function ConflictMergeDialog(props: ConflictMergeDialogProps): React.Reac
   }, [selectedBlock?.index, updateViewerState, viewerState]);
 
   /**
-   * 批量应用不冲突更改，完整覆盖 IDEA 菜单中的左侧/所有/右侧三种语义。
+   * 批量应用不冲突更改，完整覆盖参考实现菜单中的左侧/所有/右侧三种语义。
    */
   const handleApplyNonConflictedChanges = React.useCallback((target: "ours" | "all" | "theirs"): void => {
     setViewerState((prev) => {
@@ -507,7 +507,7 @@ export function ConflictMergeDialog(props: ConflictMergeDialogProps): React.Reac
   }, [props.loading, props.saving, requestConflictMergeScroll, selectedBlock?.index, selectedBlockIndex]);
 
   /**
-   * 批量自动处理简单块，对齐 IDEA merge viewer 的 `Resolve simple conflicts` 入口会同时吞掉可直接应用的普通更改。
+   * 批量自动处理简单块，保持与参考实现一致的 merge viewer `Resolve simple conflicts` 入口会同时吞掉可直接应用的普通更改。
    */
   const handleAutoResolveSimpleConflicts = React.useCallback((): void => {
     setViewerState((prev) => {
@@ -537,7 +537,7 @@ export function ConflictMergeDialog(props: ConflictMergeDialogProps): React.Reac
   }, [unresolvedBlocks]);
 
   /**
-   * 执行最终应用动作；若仍有未处理块，则先给出一次接近 IDEA 的部分解决确认。
+   * 执行最终应用动作；若仍有未处理块，则先给出一次接近参考实现的部分解决确认。
    */
   const handleResolve = React.useCallback((): void => {
     if (!viewerState || props.loading || props.saving) return;

--- a/web/src/features/git/commit-panel/conflict-merge-line-diff.ts
+++ b/web/src/features/git/commit-panel/conflict-merge-line-diff.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
-// Diff/Merge 行级比较流程参考 IntelliJ IDEA Community Edition / IntelliJ Platform 的 Apache-2.0 源码语义，并按本项目 React/TypeScript 架构重写。
+// Diff/Merge 行级比较流程借鉴参考实现的 Apache-2.0 源码语义，并按本项目 React/TypeScript 架构重写。
 
 export type ConflictMergeRange = {
   oursStart: number;
@@ -53,7 +53,7 @@ const CONFLICT_MERGE_DIFF_MATRIX_CELL_LIMIT = 4_000_000;
 const CONFLICT_MERGE_UNIMPORTANT_LINE_CHAR_COUNT = 3;
 
 /**
- * 去掉逐行 token 末尾的换行符，让行比较语义与 IDEA `LineOffsets.getLineEnd()` 一致。
+ * 去掉逐行 token 末尾的换行符，让行比较语义与参考实现 `LineOffsets.getLineEnd()` 一致。
  */
 function stripConflictMergeTokenLineEnding(token: string): string {
   return String(token || "").endsWith("\n")
@@ -75,7 +75,7 @@ function normalizeConflictMergeLineForPolicy(
 }
 
 /**
- * 统计一行中非空白字符数量，供 IDEA `unimportant line` 阈值裁剪复用。
+ * 统计一行中非空白字符数量，供参考实现 `unimportant line` 阈值裁剪复用。
  */
 function countConflictMergeNonSpaceChars(content: string): number {
   let count = 0;
@@ -119,7 +119,7 @@ function convertConflictMergeComparisonLinePolicy(
 }
 
 /**
- * 判断两行在当前策略下是否相等；与 IDEA `Line.equals` 的职责保持一致。
+ * 判断两行在当前策略下是否相等；与参考实现 `Line.equals` 的职责保持一致。
  */
 function isConflictMergeComparisonLineEqual(
   left: ConflictMergeComparisonLine | null | undefined,
@@ -291,7 +291,7 @@ function buildConflictMergeMyersDiffOperationsFromTrace<T>(
 }
 
 /**
- * 裁掉公共前后缀后再选 diff 算法，参考上游 line compare 常见路径里的性能折中。
+ * 裁掉公共前后缀后再选 diff 算法，参考实现 line compare 常见路径里的性能折中。
  */
 function buildConflictMergeDiffOperations<T>(
   left: T[],
@@ -327,7 +327,7 @@ function buildConflictMergeDiffOperations<T>(
 }
 
 /**
- * 创建 fair diff equal range builder；可选开启 gap trimming，参考上游 `ExpandChangeBuilder`。
+ * 创建 fair diff equal range builder；可选开启 gap trimming，参考实现 `ExpandChangeBuilder`。
  */
 function createConflictMergeEqualRangeBuilder<T>(args: {
   length1: number;
@@ -371,7 +371,7 @@ function pushConflictMergeEqualRange<T>(
 }
 
 /**
- * 裁掉 change gap 两端已经完全相等的前后缀，参考上游 `TrimUtil.expand` 在 line diff 里的语义。
+ * 裁掉 change gap 两端已经完全相等的前后缀，参考实现 `TrimUtil.expand` 在 line diff 里的语义。
  */
 function trimConflictMergeEqualEdges<T>(
   objects1: T[],
@@ -517,7 +517,7 @@ function buildConflictMergeFairDiff<T>(
 }
 
 /**
- * 提取“大行”集合，参考上游 `compareSmart` 里先用重要行建立骨架的策略。
+ * 提取“大行”集合，参考实现 `compareSmart` 里先用重要行建立骨架的策略。
  */
 function getConflictMergeBigLines(
   lines: ConflictMergeComparisonLine[],
@@ -586,7 +586,7 @@ function matchConflictMergeGap<T>(args: {
 }
 
 /**
- * 把大行 diff 投影回完整行序列，参考上游 `SmartLineChangeCorrector` 的纠偏路径。
+ * 把大行 diff 投影回完整行序列，参考实现 `SmartLineChangeCorrector` 的纠偏路径。
  */
 function buildConflictMergeSmartLineDiff(
   lines1: ConflictMergeComparisonLine[],
@@ -646,7 +646,7 @@ function buildConflictMergeSmartLineDiff(
 }
 
 /**
- * 计算两段等长观察窗口的公共前缀长度，参考上游 `TrimUtil.expandForward` 的块优化辅助逻辑。
+ * 计算两段等长观察窗口的公共前缀长度，参考实现 `TrimUtil.expandForward` 的块优化辅助逻辑。
  */
 function countConflictMergeForwardEquals<T>(
   objects1: T[],
@@ -720,7 +720,7 @@ function findPreviousConflictMergeUnimportantLine(
 }
 
 /**
- * 把前向/后向候选 shift 合成最终偏移量，参考上游 `LineChunkOptimizer.getShift`。
+ * 把前向/后向候选 shift 合成最终偏移量，参考实现 `LineChunkOptimizer.getShift`。
  */
 function resolveConflictMergeChunkShift(
   shiftForward: number,
@@ -732,7 +732,7 @@ function resolveConflictMergeChunkShift(
 }
 
 /**
- * 在 unchanged 区域中寻找更稳定的空白边界，让块在折叠未改动片段时更接近 IDEA 的块感知。
+ * 在 unchanged 区域中寻找更稳定的空白边界，让块在折叠未改动片段时更接近参考实现的块感知。
  */
 function getConflictMergeUnchangedBoundaryShift(args: {
   touchSide: "left" | "right";
@@ -793,7 +793,7 @@ function getConflictMergeChangedBoundaryShift(args: {
 }
 
 /**
- * 对相邻 equal chunks 做边界吸附与合并，参考上游 `LineChunkOptimizer` 的块稳定化逻辑。
+ * 对相邻 equal chunks 做边界吸附与合并，参考实现 `LineChunkOptimizer` 的块稳定化逻辑。
  */
 function optimizeConflictMergeLineChunks(
   lines1: ConflictMergeComparisonLine[],
@@ -932,7 +932,7 @@ function optimizeConflictMergeLineChunks(
 }
 
 /**
- * 在忽略空白的匹配结果上，尽量保留 exact-equal 的最大匹配，参考上游 `correctChangesSecondStep`。
+ * 在忽略空白的匹配结果上，尽量保留 exact-equal 的最大匹配，参考实现 `correctChangesSecondStep`。
  */
 function correctConflictMergeChangesSecondStep(
   lines1: ConflictMergeComparisonLine[],
@@ -966,7 +966,7 @@ function correctConflictMergeChangesSecondStep(
     let bestWeight = 0;
 
     /**
-     * 枚举所有递增组合，沿用 IDEA 原实现的小规模暴力策略。
+     * 枚举所有递增组合，沿用参考实现原实现的小规模暴力策略。
      */
     const combinations = (start: number, n: number, k: number): void => {
       if (k === size) {
@@ -1084,7 +1084,7 @@ function correctConflictMergeChangesSecondStep(
 }
 
 /**
- * 构造接近 IDEA `ByLine.merge` 的 pair fair diff；这是三方 merge ranges 的基础输入。
+ * 构造接近参考实现 `ByLine.merge` 的 pair fair diff；这是三方 merge ranges 的基础输入。
  */
 function buildConflictMergeLineFairDiff(
   baseTokens: string[],
@@ -1110,7 +1110,7 @@ function buildConflictMergeUnchangedRanges(
 }
 
 /**
- * 按 IDEA `ComparisonMergeUtil.buildSimple` 的 `FairMergeBuilder` 语义合成最终三方 merge ranges。
+ * 按参考实现 `ComparisonMergeUtil.buildSimple` 的 `FairMergeBuilder` 语义合成最终三方 merge ranges。
  */
 function buildConflictMergeRanges(args: {
   baseLength: number;
@@ -1168,7 +1168,7 @@ function buildConflictMergeRanges(args: {
   };
 
   /**
-   * 对齐一组左右 unchanged range；返回下一次应推进的侧别，与 IDEA `FairMergeBuilder.add` 同义。
+   * 对齐一组左右 unchanged range；返回下一次应推进的侧别，与参考实现 `FairMergeBuilder.add` 同义。
    */
   const addEqualOverlap = (
     leftRange: ConflictMergePairRange,
@@ -1207,7 +1207,7 @@ function buildConflictMergeRanges(args: {
 }
 
 /**
- * 对外暴露的三方 merge range 构建入口；统一参考上游 merge viewer 的块划分基础逻辑。
+ * 对外暴露的三方 merge range 构建入口；统一参考实现 merge viewer 的块划分基础逻辑。
  */
 export function buildConflictMergeLineRanges(args: {
   baseTokens: string[];

--- a/web/src/features/git/commit-panel/conflict-merge-model.test.ts
+++ b/web/src/features/git/commit-panel/conflict-merge-model.test.ts
@@ -202,7 +202,7 @@ describe("conflict-merge-model", () => {
     expect(applied.state.resultText).toBe("start\nours-left\nmid\ntheirs-right\nend\n");
   });
 
-  it("解决简单冲突应自动处理上游样例中的文本级可收敛冲突块", () => {
+  it("解决简单冲突应自动处理参考实现样例中的文本级可收敛冲突块", () => {
     const snapshot = createSnapshot({
       base: "version: 1.0.0\n",
       ours: "version: 2.0.0\n",

--- a/web/src/features/git/commit-panel/conflict-merge-model.ts
+++ b/web/src/features/git/commit-panel/conflict-merge-model.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
-// 三方冲突视图状态模型参考 IntelliJ IDEA Community Edition / IntelliJ Platform 的 Apache-2.0 源码语义，并按本项目 React/TypeScript 架构重写。
+// 三方冲突视图状态模型借鉴参考实现的 Apache-2.0 源码语义，并按本项目 React/TypeScript 架构重写。
 
 import { resolveConflictMergeSemanticBlocks } from "../../../../../electron/git/commitPanel/conflictMergeSemantic";
 import { tryResolveConflictMergeText } from "../../../../../electron/git/commitPanel/conflictMergeTextResolve";
@@ -459,7 +459,7 @@ function buildConflictMergeUnchangedRanges(
 }
 
 /**
- * 按 IDEA `ComparisonMergeUtil.buildSimple` 的 `FairMergeBuilder` 语义，把左右两侧相对 base 的 unchanged range 合成为三方 merge range。
+ * 按参考实现 `ComparisonMergeUtil.buildSimple` 的 `FairMergeBuilder` 语义，把左右两侧相对 base 的 unchanged range 合成为三方 merge range。
  */
 function buildConflictMergeRanges(args: {
   baseLength: number;
@@ -517,7 +517,7 @@ function buildConflictMergeRanges(args: {
   };
 
   /**
-   * 对齐一组左右 unchanged range；返回下一个应继续推进的侧别，与 IDEA `FairMergeBuilder.add` 保持同义。
+   * 对齐一组左右 unchanged range；返回下一个应继续推进的侧别，与参考实现 `FairMergeBuilder.add` 保持同义。
    */
   const addEqualOverlap = (
     leftRange: ConflictMergeUnchangedRange,
@@ -733,7 +733,7 @@ function hydrateConflictMergeViewerState(state: ConflictMergeViewerState): Confl
 }
 
 /**
- * 基于三方 revision 构造接近 IDEA `MergeConflictModel` 的前端块状态，结果列默认以基线文本初始化。
+ * 基于三方 revision 构造接近参考实现 `MergeConflictModel` 的前端块状态，结果列默认以基线文本初始化。
  */
 export function createConflictMergeViewerState(snapshot: GitConflictMergeSnapshot): ConflictMergeViewerState {
   const baseTokens = splitConflictMergeTokens(normalizeConflictMergeText(snapshot.base.text));
@@ -932,7 +932,7 @@ function combineConflictMergeBothTokens(oursTokens: string[], theirsTokens: stri
 }
 
 /**
- * 按块当前策略获取自动解决后的 token；`TEXT` 走 IDEA 对齐算法，`SEMANTIC` 直接采用 resolver 结果。
+ * 按块当前策略获取自动解决后的 token；`TEXT` 走与参考实现一致的算法，`SEMANTIC` 直接采用 resolver 结果。
  */
 function resolveConflictMergeBlockAutomatically(
   block: ConflictMergeBlock,
@@ -949,7 +949,7 @@ function resolveConflictMergeBlockAutomatically(
 }
 
 /**
- * 为普通更改块推导自动处理决议，参考上游 `canResolveChangeAutomatically(BASE)` 对 non-conflict change 的选择规则。
+ * 为普通更改块推导自动处理决议，参考实现 `canResolveChangeAutomatically(BASE)` 对 non-conflict change 的选择规则。
  */
 function resolveConflictMergeChangeAutoResolution(
   block: ConflictMergeBlock,
@@ -961,7 +961,7 @@ function resolveConflictMergeChangeAutoResolution(
 }
 
 /**
- * 判断当前块是否满足 IDEA `canResolveChangeAutomatically` 的前端等价条件；普通变更块与简单冲突块都纳入自动处理入口。
+ * 判断当前块是否满足参考实现 `canResolveChangeAutomatically` 的前端等价条件；普通变更块与简单冲突块都纳入自动处理入口。
  */
 export function canResolveConflictMergeBlockAutomatically(block: ConflictMergeBlock): boolean {
   if (block.isImportChange || block.onesideApplied) return false;
@@ -1062,14 +1062,14 @@ export function countConflictMergeUnresolvedChanges(state: ConflictMergeViewerSt
 }
 
 /**
- * 统计当前 state 中仍未解决的真正冲突块数量，供接近 IDEA 的“部分解决”提示复用。
+ * 统计当前 state 中仍未解决的真正冲突块数量，供接近参考实现的“部分解决”提示复用。
  */
 export function countConflictMergeUnresolvedConflicts(state: ConflictMergeViewerState): number {
   return state.blocks.filter((block) => block.kind === "conflict" && !block.resolved).length;
 }
 
 /**
- * 对指定块执行快速采用动作，完整保留 IDEA 的单侧应用、单侧追加与最终 resolved 状态迁移语义。
+ * 对指定块执行快速采用动作，完整保留参考实现的单侧应用、单侧追加与最终 resolved 状态迁移语义。
  */
 export function applyConflictMergeBlockResolution(
   state: ConflictMergeViewerState,
@@ -1216,7 +1216,7 @@ export function ignoreConflictMergeBlockSide(
 }
 
 /**
- * 批量应用某个范围内的不冲突更改，对齐 IDEA `ApplyNonConflictsAction` 的左/所有/右三种语义。
+ * 批量应用某个范围内的不冲突更改，保持与参考实现一致的 `ApplyNonConflictsAction` 的左/所有/右三种语义。
  */
 export function applyConflictMergeNonConflictedChanges(
   state: ConflictMergeViewerState,
@@ -1238,7 +1238,7 @@ export function applyConflictMergeNonConflictedChanges(
 }
 
 /**
- * 批量处理所有可安全自动处理的块，对齐 IDEA `MagicResolvedConflictsAction` 会同时覆盖 non-conflict change 与 simple conflict 的行为。
+ * 批量处理所有可安全自动处理的块，保持与参考实现一致的 `MagicResolvedConflictsAction` 会同时覆盖 non-conflict change 与 simple conflict 的行为。
  */
 export function applyResolvableConflictMergeBlocks(
   state: ConflictMergeViewerState,

--- a/web/src/features/git/commit-panel/conflict-merge-three-way-editor.tsx
+++ b/web/src/features/git/commit-panel/conflict-merge-three-way-editor.tsx
@@ -230,7 +230,7 @@ function buildConflictMergeResolvedLineDecorations(
 }
 
 /**
- * 把指定块范围滚动到编辑区；强制模式对齐 IDEA `doScrollToChange(..., true)`，直接居中到目标块。
+ * 把指定块范围滚动到编辑区；强制模式保持与参考实现一致的 `doScrollToChange(..., true)`，直接居中到目标块。
  */
 function revealConflictMergeLineRange(
   editor: MonacoNS.editor.IStandaloneCodeEditor | null | undefined,
@@ -477,7 +477,7 @@ function buildConflictMergeFoldSeparatorPath(args: {
 }
 
 /**
- * 当一侧为空块时，把细锚点扩成与对侧等高的连接带，逼近 IDEA divider polygon 的 `withAlignedHeight` 效果。
+ * 当一侧为空块时，把细锚点扩成与对侧等高的连接带，逼近参考实现的 divider polygon 的 `withAlignedHeight` 效果。
  */
 function alignConflictMergeConnectorSpans(args: {
   source: { top: number; bottom: number; center: number };
@@ -521,7 +521,7 @@ function alignConflictMergeConnectorSpans(args: {
 }
 
 /**
- * 根据 gutter 控件语义返回对应图标，和 IDEA 的左右箭头 / 向下追加 / 删除操作保持一致。
+ * 根据 gutter 控件语义返回对应图标，和参考实现的左右箭头 / 向下追加 / 删除操作保持一致。
  */
 function renderConflictMergeGutterControlIcon(control: ConflictMergeGutterControl): React.ReactElement {
   if (control.icon === "apply-left") {
@@ -540,7 +540,7 @@ function renderConflictMergeGutterControlIcon(control: ConflictMergeGutterContro
 }
 
 /**
- * 更接近 IDEA `TextMergeViewer` 的三栏代码视图；左右为只读来源，中间为可编辑结果，并为每个未解决块渲染 gutter 操作。
+ * 更接近参考实现 `TextMergeViewer` 的三栏代码视图；左右为只读来源，中间为可编辑结果，并为每个未解决块渲染 gutter 操作。
  */
 export function ConflictMergeThreeWayEditor(props: ConflictMergeThreeWayEditorProps): React.ReactElement {
   const { t } = useTranslation(["git", "common"]);
@@ -663,7 +663,7 @@ export function ConflictMergeThreeWayEditor(props: ConflictMergeThreeWayEditorPr
   }, [paneLineCounts]);
 
   /**
-   * 按 IDEA `SyncScrollSupport` 的片段映射策略同步三栏纵向滚动，折叠后仍能保持块级错位关系可读。
+   * 按参考实现 `SyncScrollSupport` 的片段映射策略同步三栏纵向滚动，折叠后仍能保持块级错位关系可读。
    */
   const syncConflictMergeEditorScrollTop = React.useCallback((
     sourcePaneKey: ConflictMergeEditorPaneKey,
@@ -694,7 +694,7 @@ export function ConflictMergeThreeWayEditor(props: ConflictMergeThreeWayEditorPr
   }, [applyConflictMergeMappedScroll, resolveConflictMergeScrollAnchor, scrollMaps]);
 
   /**
-   * 根据块高亮、折叠分隔线与三栏真实位置计算所有叠层控件坐标，参考上游 merge viewer 的可视关联提示。
+   * 根据块高亮、折叠分隔线与三栏真实位置计算所有叠层控件坐标，参考实现 merge viewer 的可视关联提示。
    */
   const updateConflictMergeGutterControls = React.useCallback((): void => {
     const rootNode = rootRef.current;
@@ -1128,7 +1128,7 @@ export function ConflictMergeThreeWayEditor(props: ConflictMergeThreeWayEditorPr
   }, [editorMountStamp, props.blocks, props.selectedBlock, scheduleConflictMergeGutterControls]);
 
   /**
-   * 切换“收起未更改片段”时按同步 fold plan 更新三栏隐藏区域，参考上游 `FoldingModelSupport` 的同组折叠关系。
+   * 切换“收起未更改片段”时按同步 fold plan 更新三栏隐藏区域，参考实现 `FoldingModelSupport` 的同组折叠关系。
    */
   useEffect(() => {
     const monaco = monacoRef.current;

--- a/web/src/features/git/commit-panel/conflict-merge-viewer-layout.ts
+++ b/web/src/features/git/commit-panel/conflict-merge-viewer-layout.ts
@@ -74,7 +74,7 @@ export function countConflictMergeViewerLogicalLines(text: string): number {
 }
 
 /**
- * 基于三方块坐标构造左右-结果的同步滚动边界，参考上游 `BaseSyncScrollable` 使用的首尾边界对。
+ * 基于三方块坐标构造左右-结果的同步滚动边界，参考实现 `BaseSyncScrollable` 使用的首尾边界对。
  */
 export function buildConflictMergeViewerScrollMaps(args: {
   blocks: ConflictMergeBlock[];
@@ -103,7 +103,7 @@ export function buildConflictMergeViewerScrollMaps(args: {
 }
 
 /**
- * 把某一栏的逻辑行号映射到另一栏，沿用 IDEA `BaseSyncScrollable.transferLine` 的区间插值规则。
+ * 把某一栏的逻辑行号映射到另一栏，沿用参考实现 `BaseSyncScrollable.transferLine` 的区间插值规则。
  */
 export function transferConflictMergeViewerLine(
   line: number,
@@ -132,7 +132,7 @@ export function transferConflictMergeViewerLine(
 }
 
 /**
- * 按 IDEA `FoldingModelSupport` 的 unchanged group 语义，生成三栏同步折叠计划与分隔线锚点。
+ * 按参考实现 `FoldingModelSupport` 的 unchanged group 语义，生成三栏同步折叠计划与分隔线锚点。
  */
 export function buildConflictMergeViewerFoldingPlan(
   args: ConflictMergeViewerFoldPlanArgs,
@@ -210,7 +210,7 @@ function buildConflictMergeViewerChangedLineOffsets(
 }
 
 /**
- * 把起始/结束边界交错压成 scroll pair 列表，保持与 IDEA `processHelper` 一样的边界顺序。
+ * 把起始/结束边界交错压成 scroll pair 列表，保持与参考实现 `processHelper` 一样的边界顺序。
  */
 function buildConflictMergeViewerScrollPairs(
   starts: ConflictMergeViewerScrollPair[],
@@ -245,7 +245,7 @@ function reverseConflictMergeViewerScrollPairs(
 }
 
 /**
- * 基于 changed block 边界构造 unchanged fold group，参考上游 `FoldingBuilderBase.addGroup` 的范围裁切规则。
+ * 基于 changed block 边界构造 unchanged fold group，参考实现 `FoldingBuilderBase.addGroup` 的范围裁切规则。
  */
 function buildConflictMergeViewerFoldGroups(
   args: ConflictMergeViewerFoldPlanArgs,
@@ -339,7 +339,7 @@ function pushConflictMergeViewerFoldGroup(args: {
 }
 
 /**
- * 创建单栏折叠区间；不足两行的 unchanged 片段不进入折叠计划，和 IDEA 的 `createBlock` 条件一致。
+ * 创建单栏折叠区间；不足两行的 unchanged 片段不进入折叠计划，和参考实现的 `createBlock` 条件一致。
  */
 function createConflictMergeViewerFoldRange(
   start: number,
@@ -369,7 +369,7 @@ function convertConflictMergeViewerHiddenArea(
 }
 
 /**
- * 参考上游 `getRangeShift` 的 4/8/16 三层上下文裁切策略。
+ * 参考实现 `getRangeShift` 的 4/8/16 三层上下文裁切策略。
  */
 function resolveConflictMergeViewerRangeShift(
   contextRange: number,

--- a/web/src/features/git/commit-panel/context-menu-model.test.ts
+++ b/web/src/features/git/commit-panel/context-menu-model.test.ts
@@ -12,7 +12,7 @@ function flattenMenuIds(sections: ReturnType<typeof buildCommitTreeSharedMenuSec
 }
 
 describe("commit tree context menu model", () => {
-  it("应按 IDEA 提交工具窗口结构输出共享菜单，并移除 changelist 管理段", () => {
+  it("应按参考实现提交工具窗口结构输出共享菜单，并移除 changelist 管理段", () => {
     const sections = buildCommitTreeSharedMenuSections({
       selection: {
         canCommit: true,
@@ -110,7 +110,7 @@ describe("commit tree context menu model", () => {
     ]);
   });
 
-  it("删除入口显示规则应对可解析删除目标的目录选择对齐 IDEA", () => {
+  it("删除入口显示规则应对可解析删除目标的目录选择保持与参考实现一致", () => {
     expect(shouldShowCommitTreeSharedDeleteAction({
       exactlySelectedFileCount: 0,
       selectedDeleteTargetCount: 1,
@@ -148,7 +148,7 @@ describe("commit tree context menu model", () => {
     })).toBe(false);
   });
 
-  it("amend 来源应对齐 IDEA：启用提交/回滚，但继续禁用搁置", () => {
+  it("amend 来源应保持与参考实现一致：启用提交/回滚，但继续禁用搁置", () => {
     const sections = buildCommitTreeSharedMenuSections({
       selection: {
         canCommit: true,

--- a/web/src/features/git/commit-panel/context-menu-model.ts
+++ b/web/src/features/git/commit-panel/context-menu-model.ts
@@ -51,8 +51,8 @@ type CommitTreeSharedSelectionSnapshot = Pick<
 >;
 
 /**
- * 对齐 IDEA 提交树共享菜单的删除入口显示规则。
- * 只要当前冻结选区能解析出真实删除目标，就等价于 IDEA DataContext 中存在 VIRTUAL_FILE_ARRAY。
+ * 保持与参考实现一致的提交树共享菜单的删除入口显示规则。
+ * 只要当前冻结选区能解析出真实删除目标，就等价于参考实现 DataContext 中存在 VIRTUAL_FILE_ARRAY。
  */
 export function shouldShowCommitTreeSharedDeleteAction(args: {
   exactlySelectedFileCount: number;
@@ -109,7 +109,7 @@ function createSubmenuNode(
 }
 
 /**
- * 按 IDEA 提交工具窗口 `MultipleLocalChangeListsBrowser` 的结构构建主提交树共享右键菜单。
+ * 按参考实现提交工具窗口 `MultipleLocalChangeListsBrowser` 的结构构建主提交树共享右键菜单。
  * 这里故意不输出 changelist 管理项，只保留 commit tool window 实际会出现的公共动作与共享子菜单。
  */
 export function buildCommitTreeSharedMenuSections(args: {

--- a/web/src/features/git/commit-panel/ignore-target-dialog.tsx
+++ b/web/src/features/git/commit-panel/ignore-target-dialog.tsx
@@ -32,7 +32,7 @@ function resolvePopupPosition(anchor?: { x: number; y: number }): React.CSSPrope
 }
 
 /**
- * 展示 ignored special node 投放后的 ignore 目标 popup，对齐 IDEA 的 action popup 语义。
+ * 展示 ignored special node 投放后的 ignore 目标 popup，保持与参考实现一致的 action popup 语义。
  */
 export function IgnoreTargetDialog(props: IgnoreTargetDialogProps): React.ReactElement | null {
   const { open, paths, targets, repoRoot, repoIndex, repoCount, applyingTargetId, anchor, onOpenChange, onSelectTarget } = props;
@@ -86,7 +86,7 @@ export function IgnoreTargetDialog(props: IgnoreTargetDialogProps): React.ReactE
           <div className="mt-1 text-[11px] text-[var(--cf-text-secondary)]">
             {resolveGitText(
               "commit.ignoreTarget.description",
-              "选择要写入的 ignore 目标。该 popup 只接收未跟踪文件投放，对齐 IDEA 的 ignored special node 语义。",
+              "选择要写入的 ignore 目标。该 popup 只接收未跟踪文件投放，保持与参考实现一致的 ignored special node 语义。",
             )}
           </div>
           {normalizedRepoRoot ? (

--- a/web/src/features/git/commit-panel/inclusion-model.ts
+++ b/web/src/features/git/commit-panel/inclusion-model.ts
@@ -261,7 +261,7 @@ function isAutoIncludedActiveChangeItem(item: CommitInclusionItem, activeChangeL
 }
 
 /**
- * 把 resolved conflict 自动纳入当前 inclusion 集；即使用户未手动勾选，也要与 IDEA workflow 语义保持一致。
+ * 把 resolved conflict 自动纳入当前 inclusion 集；即使用户未手动勾选，也要与参考实现 workflow 语义保持一致。
  */
 function includeResolvedConflictItems(
   includedIds: Set<string>,
@@ -328,7 +328,7 @@ export function syncCommitInclusionState(
 }
 
 /**
- * 按 IDEA `CheckinActionUtil.setCommitState(initialChangeList, included, ...)` 语义重建提交入口的 inclusion 状态。
+ * 按参考实现 `CheckinActionUtil.setCommitState(initialChangeList, included, ...)` 语义重建提交入口的 inclusion 状态。
  * - 存在显式 selected changes / unversioned 时，只纳入这些显式选项，并保留 resolved conflict 自动纳入。
  * - 否则按 initial changelist 语义纳入目标 changelist 的普通 change，不默认纳入 unversioned。
  */
@@ -459,7 +459,7 @@ export function getCommitInclusionCheckState(
 }
 
 /**
- * 判断分组头部是否应显示 inclusion checkbox，对齐 IDEA changelist/unversioned/ignored 规则。
+ * 判断分组头部是否应显示 inclusion checkbox，保持与参考实现一致的 changelist/unversioned/ignored 规则。
  */
 export function isCommitGroupInclusionVisible(group: Pick<ChangeEntryGroup, "kind" | "entries">): boolean {
   if (group.kind === "ignored") return false;
@@ -478,7 +478,7 @@ export function isCommitNodeInclusionVisible(node: Pick<CommitTreeNode, "selecti
 }
 
 /**
- * 按 IDEA Space toggle 语义批量切换 inclusion；若目标集合存在任一未选项则整体纳入，否则整体排除。
+ * 按参考实现 Space toggle 语义批量切换 inclusion；若目标集合存在任一未选项则整体纳入，否则整体排除。
  */
 export function toggleCommitInclusionForItemIds(
   prev: CommitInclusionState,

--- a/web/src/features/git/commit-panel/interaction-model.ts
+++ b/web/src/features/git/commit-panel/interaction-model.ts
@@ -14,7 +14,7 @@ export function canOpenDiffForCommitEntry(entry: GitStatusEntry | null | undefin
 }
 
 /**
- * 按 IDEA 的判定顺序解析文件激活动作；`F4` 永远打开源文件，`Enter/双击` 先看“是否以 Diff 方式打开”配置。
+ * 按参考实现的判定顺序解析文件激活动作；`F4` 永远打开源文件，`Enter/双击` 先看“是否以 Diff 方式打开”配置。
  */
 export function resolveCommitOpenAction(
   viewOptions: GitViewOptions,

--- a/web/src/features/git/commit-panel/merge-precheck.ts
+++ b/web/src/features/git/commit-panel/merge-precheck.ts
@@ -21,7 +21,7 @@ function buildTrackedEntryKey(pathText: string, repoRoot?: string): string {
 }
 
 /**
- * 检查 merge 过程中是否仍有当前目标仓库的 tracked changes 被排除在本次提交之外，对齐 IDEA 的 excluded-changes 确认流。
+ * 检查 merge 过程中是否仍有当前目标仓库的 tracked changes 被排除在本次提交之外，保持与参考实现一致的 excluded-changes 确认流。
  */
 export function resolveMergeExclusionPrecheck(args: {
   status: GitStatusSnapshot | null | undefined;

--- a/web/src/features/git/commit-panel/selection-model.test.ts
+++ b/web/src/features/git/commit-panel/selection-model.test.ts
@@ -410,7 +410,7 @@ describe("commit panel selection model", () => {
     expect(ctx.canIgnore).toBe(true);
   });
 
-  it("单选 amend modifier 节点时，应按真实 amend 历史条目保留 IDEA 共享菜单动作", () => {
+  it("单选 amend modifier 节点时，应按真实 amend 历史条目保留参考实现共享菜单动作", () => {
     const ctx = deriveCommitSelectionContext({
       selectedEntries: [
         { path: "src/amend.ts", x: "M", y: ".", staged: false, unstaged: false, untracked: false, ignored: false, renamed: false, deleted: false, statusText: "已修改", changeListId: "__amend__" },

--- a/web/src/features/git/commit-panel/selection-model.ts
+++ b/web/src/features/git/commit-panel/selection-model.ts
@@ -254,7 +254,7 @@ export type CommitMenuSelectionSnapshot = {
 
 /**
  * 基于显式树行键生成一次性菜单选择快照。
- * - 对齐 IDEA `uiDataSnapshot(DataSink)` 的语义：弹出菜单后动作应读取“打开菜单当下”的选择，而不是后续漂移的全局状态。
+ * - 保持与参考实现一致的 `uiDataSnapshot(DataSink)` 的语义：弹出菜单后动作应读取“打开菜单当下”的选择，而不是后续漂移的全局状态。
  * - 同时收敛 selected entries / paths / delete targets / changelist ids，避免右键动作各自重复推导。
  */
 export function buildCommitMenuSelectionSnapshot(args: {
@@ -294,7 +294,7 @@ export function buildCommitMenuSelectionSnapshot(args: {
 }
 
 /**
- * 按 IDEA selectedDiffableNode 语义解析当前 diffable 文件节点；若旧 diffable 仍落在选中子树内，则优先保留。
+ * 按参考实现 selectedDiffableNode 语义解析当前 diffable 文件节点；若旧 diffable 仍落在选中子树内，则优先保留。
  */
 export function resolveSelectedDiffableCommitNodeKey(args: {
   selectedRowKeys: string[];
@@ -498,7 +498,7 @@ export function deriveCommitSelectionContext(args: {
     && args.selectedEntries.every((entry) => !entry.staged && !entry.unstaged && !entry.untracked && !entry.ignored)
   );
   /**
-   * amend helper 节点在 IDEA 里仍复用共享右键菜单；虽然它不是当前工作区状态条目，
+   * amend helper 节点在 参考实现里仍复用共享右键菜单；虽然它不是当前工作区状态条目，
    * 但提交 / 回滚 / 搁置等动作的可用性不应被 reference-only 规则整体拦截。
    */
   const amendSharedPopupSelection = amendOnlySelection && actionableEntries.length > 0;
@@ -569,7 +569,7 @@ export type CommitDiffSelection = {
 };
 
 /**
- * 按 IDEA diffable selection 语义为单选/多选结果构建可导航文件集合。
+ * 按参考实现 diffable selection 语义为单选/多选结果构建可导航文件集合。
  */
 export function buildCommitDiffSelection(args: {
   selectedEntries: GitStatusEntry[];

--- a/web/src/features/git/commit-panel/special-files-dialog.tsx
+++ b/web/src/features/git/commit-panel/special-files-dialog.tsx
@@ -124,7 +124,7 @@ function resolveBrowseLeadNodeKey(selectedNodeKeys: string[], rows: Array<{ node
 }
 
 /**
- * 按 IDEA Browse 首开语义生成默认展开态；仅当根下恰有一个目录节点时自动展开该单根节点。
+ * 按参考实现 Browse 首开语义生成默认展开态；仅当根下恰有一个目录节点时自动展开该单根节点。
  */
 function buildBrowseDefaultExpandedState(nodes: ReturnType<typeof buildCommitTree>): Record<string, boolean> {
   const firstNode = nodes[0];
@@ -189,7 +189,7 @@ function buildBrowseRenderRows(
 }
 
 /**
- * 提交面板 special node 的 Browse 对话框，使用树结构和 popup 动作收敛到 IDEA `SpecificFilesViewDialog`。
+ * 提交面板 special node 的 Browse 对话框，使用树结构和 popup 动作收敛到 参考实现 `SpecificFilesViewDialog`。
  */
 export function SpecialFilesDialog(props: SpecialFilesDialogProps): React.ReactElement {
   const { t } = useTranslation(["git", "common"]);
@@ -440,7 +440,7 @@ export function SpecialFilesDialog(props: SpecialFilesDialogProps): React.ReactE
   }, [actionMenuState]);
 
   /**
-   * 按当前选中结果执行 Browse 动作集；open 成功后关闭对话框，对齐 IDEA Browse 行为。
+   * 按当前选中结果执行 Browse 动作集；open 成功后关闭对话框，保持与参考实现一致的 Browse 行为。
    */
   const runCurrentActionAsync = async (action: "open" | "stage" | "ignore" | "delete"): Promise<void> => {
     const selectedNode = treeRows.find((row) => row.node.key === leadSelectedNodeKey)?.node || null;

--- a/web/src/features/git/commit-panel/tree-interactions.test.ts
+++ b/web/src/features/git/commit-panel/tree-interactions.test.ts
@@ -50,7 +50,7 @@ describe("commit tree interactions", () => {
     })).toBe("node:dir");
   });
 
-  it("speed search 应支持 IDEA 风格的宽松字符序列匹配", () => {
+  it("speed search 应支持宽松字符序列匹配", () => {
     expect(findCommitSpeedSearchRanges({
       text: "Font_cjkFonts_Medium_FontAssets.asset",
       query: "fc",

--- a/web/src/features/git/commit-panel/tree-state-strategy.ts
+++ b/web/src/features/git/commit-panel/tree-state-strategy.ts
@@ -37,7 +37,7 @@ function isSameExpandedState(
 }
 
 /**
- * 判断旧状态里是否已有“非默认 changelist 被展开”的情况，用于参考上游默认展开策略。
+ * 判断旧状态里是否已有“非默认 changelist 被展开”的情况，用于参考实现默认展开策略。
  */
 function hasExpandedNonDefaultChangeList(
   groups: ChangeEntryGroup[],
@@ -52,7 +52,7 @@ function hasExpandedNonDefaultChangeList(
 }
 
 /**
- * 参考上游 `shouldExpandDefaultChangeList()` 的核心语义。
+ * 参考实现 `shouldExpandDefaultChangeList()` 的核心语义。
  */
 export function shouldExpandDefaultChangeList(args: {
   previousGroups: ChangeEntryGroup[];
@@ -190,7 +190,7 @@ function findFirstFileNodeKey(nodes: CommitTreeNode[]): string {
 }
 
 /**
- * 按当前 inclusion 状态判断指定 changelist 是否处于“全集已纳入”状态，对齐 IDEA `setSelection()` 的 fully included 分支。
+ * 按当前 inclusion 状态判断指定 changelist 是否处于“全集已纳入”状态，保持与参考实现一致的 `setSelection()` fully included 分支。
  */
 function isCommitGroupFullyIncluded(
   group: CommitTreeGroup,
@@ -247,7 +247,7 @@ function resolveFirstIncludedNodeKey(
 }
 
 /**
- * 当刷新后原选择失效时，按 IDEA inclusion / merge conflict / default changelist 的顺序回落默认选中对象。
+ * 当刷新后原选择失效时，按参考实现 inclusion / merge conflict / default changelist 的顺序回落默认选中对象。
  */
 export function resolveCommitFallbackRowSelection(args: {
   groups: CommitTreeGroup[];

--- a/web/src/features/git/detail-actions.test.ts
+++ b/web/src/features/git/detail-actions.test.ts
@@ -67,7 +67,7 @@ describe("detail-actions", () => {
     });
   });
 
-  it("应按 IDEA committed changes 菜单层级输出详情右键分组", () => {
+  it("应按 committed changes 菜单层级输出详情右键分组", () => {
     const availability = {
       actions: {
         editSource: { visible: true, enabled: true },

--- a/web/src/features/git/detail-actions.ts
+++ b/web/src/features/git/detail-actions.ts
@@ -141,7 +141,7 @@ export function getCommitDetailsActionItem(
 }
 
 /**
- * 按 IDEA `Vcs.RepositoryChangesBrowserMenu` 与 Git 追加动作的层级，构建提交详情右键菜单分组。
+ * 按参考实现 `Vcs.RepositoryChangesBrowserMenu` 与 Git 追加动作的层级，构建提交详情右键菜单分组。
  */
 export function buildCommitDetailsContextMenuGroups(
   availability: GitCommitDetailsActionAvailability | null | undefined,

--- a/web/src/features/git/details-browser.test.tsx
+++ b/web/src/features/git/details-browser.test.tsx
@@ -5,7 +5,7 @@ import i18next from "i18next";
 import { initReactI18next } from "react-i18next";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { createRoot, type Root } from "react-dom/client";
-import { GitDetailsBrowser, type GitDetailsBrowserTreeNode } from "./details-browser";
+import { buildGitDetailsBrowserCopyText, GitDetailsBrowser, type GitDetailsBrowserTreeNode } from "./details-browser";
 import type { GitCommitDetailsActionAvailability, GitLogDetails } from "./types";
 import zhGit from "../../locales/zh/git.json";
 
@@ -128,6 +128,19 @@ beforeAll(async () => {
 });
 
 describe("GitDetailsBrowser", () => {
+  it("copy provider 应按当前显示顺序输出选中节点路径", () => {
+    expect(buildGitDetailsBrowserCopyText({
+      rows: [
+        { node: DETAIL_NODE, depth: 0 },
+        { node: SECOND_DETAIL_NODE, depth: 0 },
+      ],
+      selectedNodeKeys: [SECOND_DETAIL_NODE.key, DETAIL_NODE.key],
+    })).toBe([
+      "src/app.ts",
+      "src/other.ts",
+    ].join("\n"));
+  });
+
   it("应按当前产品设计隐藏重复 toolbar 动作，并在点击文件时打开 Diff", async () => {
     const mounted = createMountedRoot();
     const onOpenDiff = vi.fn();
@@ -240,7 +253,7 @@ describe("GitDetailsBrowser", () => {
     }
   });
 
-  it("提交详情右键菜单应对齐 IDEA 的历史与父项文案，并在多提交聚合时禁用历史动作", async () => {
+  it("提交详情右键菜单应保持与参考实现一致的历史与父项文案，并在多提交聚合时禁用历史动作", async () => {
     const mounted = createMountedRoot();
     try {
       await act(async () => {

--- a/web/src/features/git/details-browser.tsx
+++ b/web/src/features/git/details-browser.tsx
@@ -94,6 +94,22 @@ type GitDetailsBrowserMenuState = GitContextMenuState & {
 };
 
 /**
+ * 按详情树当前显示顺序构造复制文本，目录节点输出完整路径，文件节点输出文件路径。
+ */
+export function buildGitDetailsBrowserCopyText(args: {
+  rows: Array<{ node: GitDetailsBrowserTreeNode; depth: number }>;
+  selectedNodeKeys: string[];
+}): string {
+  const selected = new Set((args.selectedNodeKeys || []).map((key) => String(key || "").trim()).filter(Boolean));
+  if (selected.size <= 0) return "";
+  return (args.rows || [])
+    .filter((row) => selected.has(row.node.key))
+    .map((row) => String(row.node.fullPath || row.node.name || "").trim())
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
  * 独立渲染 committed changes details browser，统一承接选择、Diff 同步、toolbar 与 popup。
  */
 export function GitDetailsBrowser(props: GitDetailsBrowserProps): JSX.Element {
@@ -207,7 +223,7 @@ export function GitDetailsBrowser(props: GitDetailsBrowserProps): JSX.Element {
   }, [detailSpeedSearchOpen]);
 
   /**
-   * 根据右键命中的节点与当前树选区推导动作目标文件；若命中节点已在选区内，则复用整个选区，对齐 IDEA 基于 `getSelectedChanges()` 的批量执行语义。
+   * 根据右键命中的节点与当前树选区推导动作目标文件；若命中节点已在选区内，则复用整个选区，保持批量动作目标一致。
    */
   const resolveTargetFiles = (targetPath: string): string[] => {
     const normalizedTargetPath = String(targetPath || "").trim();
@@ -349,7 +365,7 @@ export function GitDetailsBrowser(props: GitDetailsBrowserProps): JSX.Element {
         {details ? (
           <div className="flex min-h-0 flex-1 flex-col">
             {/* 当前产品设计要求把“提交详情”面板顶部工具栏内的重复动作统一收敛到右键菜单，顶部不再重复渲染同名按钮；
-                原因是右键已提供等价功能，继续平铺会造成重复操作入口。设计如此，此处在“提交详情顶部工具栏”范围内继续不对齐 IDEA。 */}
+                原因是右键已提供等价功能，继续平铺会造成重复操作入口。设计如此，此处在“提交详情顶部工具栏”范围内保留当前产品取舍。 */}
             <div ref={speedSearchRootRef} className="relative min-h-0 flex-[1.1] border-b border-[var(--cf-border)]">
               {detailSpeedSearchOpen ? (
                 <div

--- a/web/src/features/git/git-workbench-utils.ts
+++ b/web/src/features/git/git-workbench-utils.ts
@@ -93,7 +93,7 @@ function sanitizePatchFileNameSegment(value: string): string {
 }
 
 /**
- * 按 IDEA `GitCheckoutActionGroup` 规则构建日志右键“签出”菜单模型：
+ * 按参考实现 `GitCheckoutActionGroup` 规则构建日志右键“签出”菜单模型：
  * 仅纳入本地分支引用，排除当前分支；只要存在分支签出入口，顶层就升级为子菜单。
  */
 export function buildGitLogCheckoutMenuModel(args: {
@@ -114,7 +114,7 @@ export function buildGitLogCheckoutMenuModel(args: {
 
 /**
  * 按动作语义规整日志多选提交的执行顺序。
- * IDEA 的 Cherry-pick 会把 UI 中“新到旧”的选区反转为“旧到新”后再执行，避免多提交应用顺序颠倒。
+ * 参考实现的 Cherry-pick 会把 UI 中“新到旧”的选区反转为“旧到新”后再执行，避免多提交应用顺序颠倒。
  */
 export function resolveLogActionExecutionHashes(args: {
   action: string;
@@ -411,7 +411,7 @@ export function resolvePartialCommitValidationDiffMode(args: {
 }
 
 /**
- * 判断当前状态是否应按 IDEA apply-changes 语义进入“提交更改完成 Cherry-pick”阶段。
+ * 判断当前状态是否应按参考实现 apply-changes 语义进入“提交更改完成 Cherry-pick”阶段。
  * 只要仓库仍处于 grafting、没有未解决冲突，且 Git 已提供建议提交消息，就应切到提交收尾；
  * 不要求当前状态列表里仍显式保留“已解决冲突文件”条目。
  */

--- a/web/src/features/git/git-workbench.tsx
+++ b/web/src/features/git/git-workbench.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
-// Git 工作台交互模型参考 IntelliJ IDEA Community Edition / IntelliJ Platform 的 Apache-2.0 源码语义，并按本项目 React/TypeScript 架构重写。
+// Git 工作台交互模型借鉴参考实现的 Apache-2.0 源码语义，并按本项目 React/TypeScript 架构重写。
 
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import i18next from "i18next";
@@ -135,6 +135,7 @@ import {
 } from "./api";
 import {
   buildGitLogColumnStyle,
+  buildGitLogCopyText,
   estimateGitLogColumnWidth,
   GIT_LOG_COLUMN_DEFINITIONS,
   type GitLogColumnId,
@@ -164,6 +165,7 @@ import {
 } from "./branch-sync/presentation";
 import { shouldAutoRefreshBranchSyncAfterActivity } from "./branch-sync/activity";
 import {
+  buildBranchPanelCopyText,
   buildBranchPanelRows,
   buildBranchPopupRows,
   createDefaultBranchPopupGroupOpen,
@@ -249,7 +251,7 @@ import {
   type GitRollbackBrowserEntry,
   type GitRollbackBrowserGroupingKey,
 } from "./rollback-browser-model";
-import { GitDetailsBrowser } from "./details-browser";
+import { buildGitDetailsBrowserCopyText, GitDetailsBrowser } from "./details-browser";
 import { ContextMenu, ContextMenuItem, ContextMenuSubmenu, renderContextMenuSections } from "./context-menu";
 import { resolveGitStageGlobalActionAvailability } from "./stage-action-model";
 import { resolveCommitToolbarIntent, resolveGitToolbarState } from "./toolbar-state";
@@ -416,6 +418,7 @@ import {
   resolveCommitPreviewDiffMode,
 } from "./commit-panel/interaction-model";
 import {
+  buildCommitTreeCopyText,
   findCommitSpeedSearchMatch,
   findCommitSpeedSearchRanges,
 } from "./commit-panel/tree-interactions";
@@ -708,7 +711,7 @@ function gitWorkbenchErrorText(raw: unknown, key: string, fallback: string, valu
 }
 
 /**
- * 把后端结构化 interactive rebase 不可用原因转换为更接近 IDEA gating 的用户提示。
+ * 把后端结构化 interactive rebase 不可用原因转换为更接近参考实现可用性门控的用户提示。
  */
 function resolveInteractiveRebasePlanErrorText(error: string | undefined, data: any): string {
   const reasonCode = String(data?.reasonCode || "").trim();
@@ -2660,7 +2663,7 @@ function buildLogDecorationPills(
 }
 
 /**
- * 根据日志 decorations 推断新建分支默认名称（与 IDEA 建议逻辑保持接近）。
+ * 根据日志 decorations 推断新建分支默认名称（与参考实现建议逻辑保持接近）。
  */
 function suggestBranchNameFromDecorations(decorationsRaw: string): string {
   const rows = String(decorationsRaw || "")
@@ -2994,7 +2997,7 @@ function ToolbarDropdownSubmenu(props: ToolbarDropdownSubmenuProps): JSX.Element
 }
 
 /**
- * Git 工作台，按 Rider/IntelliJ 风格组织提交、Diff、日志与分支交互。
+ * Git 工作台，按 现代 IDE 风格组织提交、Diff、日志与分支交互。
  */
 export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   const { t } = useTranslation(["git", "common"]);
@@ -3408,6 +3411,8 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     remote: true,
   });
   const [branchPopupGroupOpen, setBranchPopupGroupOpen] = useState<BranchPopupGroupOpen>(initialBranchPopupState.groupOpen || createDefaultBranchPopupGroupOpen());
+  const [branchPanelGroupByDirectory, setBranchPanelGroupByDirectory] = useState<boolean>(initialBranchPopupState.panelGroupByDirectory === true);
+  const [branchDirectoryOpen, setBranchDirectoryOpen] = useState<Record<string, boolean>>({});
 
   const selectedBranchRepository = useMemo(() => {
     return resolveSelectedBranchPopupRepository(branchPopup, branchSelectedRepoRoot);
@@ -3450,16 +3455,17 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   );
 
   const branchPanelRows = useMemo<BranchPanelRow[]>(
-    () => buildBranchPanelRows(branchPopup, branchSelectedRepoRoot, branchGroupOpen, gt),
-    [branchGroupOpen, branchPopup, branchSelectedRepoRoot, gt],
+    () => buildBranchPanelRows(branchPopup, branchSelectedRepoRoot, branchGroupOpen, branchPanelGroupByDirectory, branchDirectoryOpen, gt),
+    [branchDirectoryOpen, branchGroupOpen, branchPanelGroupByDirectory, branchPopup, branchSelectedRepoRoot, gt],
   );
   useEffect(() => {
     saveGitBranchPopupState({
       selectedRepoRoot: branchSelectedRepoRoot,
       step: branchPopupStep,
       groupOpen: branchPopupGroupOpen,
+      panelGroupByDirectory: branchPanelGroupByDirectory,
     });
-  }, [branchPopupGroupOpen, branchPopupStep, branchSelectedRepoRoot]);
+  }, [branchPanelGroupByDirectory, branchPopupGroupOpen, branchPopupStep, branchSelectedRepoRoot]);
   const branchPanelPresentationByKey = useMemo<Map<string, GitBranchRowPresentation>>(() => {
     const map = new Map<string, GitBranchRowPresentation>();
     for (const row of branchPanelRows) {
@@ -3617,7 +3623,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     if (!branchPanelSpeedSearchOpen) return;
 
     /**
-     * 点击分支面板外部时按 IDEA `focusLost -> manageSearchPopup(null)` 语义关闭并清空当前搜索。
+     * 点击分支面板外部时按参考实现 `focusLost -> manageSearchPopup(null)` 语义关闭并清空当前搜索。
      */
     const handleBranchPanelSpeedSearchOutsideMouseDown = (event: MouseEvent): void => {
       const root = branchPanelSpeedSearchRootRef.current;
@@ -4090,7 +4096,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, []);
 
   /**
-   * 当前仓按规则豁免 IDE Local History 宿主能力，因此统一映射到 Git 文件历史；仍支持携带目标修订号，对齐 IDEA “Show History / Show History for Revision” 的入口语义。
+   * 当前仓按规则豁免 IDE Local History 宿主能力，因此统一映射到 Git 文件历史；仍支持携带目标修订号，保持与参考实现一致的 “Show History / Show History for Revision” 的入口语义。
    */
   const showPathHistory = useCallback((relPath: string, options?: { revision?: string; followRenames?: boolean }): void => {
     const clean = String(relPath || "").trim().replace(/\\/g, "/");
@@ -4112,7 +4118,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [closeUpdateInfoLogView]);
 
   /**
-   * 显式显示 Worktrees 页签；对齐 IDEA openedByUser 语义，并消耗 NEW badge。
+   * 显式显示 Worktrees 页签；保持与参考实现一致的 openedByUser 语义，并消耗 NEW badge。
    */
   const showWorktreesTabByUser = useCallback((options?: { select?: boolean }): void => {
     updateWorktreeTabPreferences((prev) => markWorktreeTabOpenedByUser(prev));
@@ -4129,7 +4135,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [updateWorktreeTabPreferences]);
 
   /**
-   * 显式显示冲突面板；会重置当前关闭记忆，并在需要时重新开启自动面板 gate。
+   * 显式显示冲突面板；会重置当前关闭记忆，并在需要时重新开启自动面板门控。
    */
   const showConflictsPanelByUser = useCallback((options?: { select?: boolean }): void => {
     updateConflictsPanelPreferences((prev) => revealConflictsPanel(prev));
@@ -4139,7 +4145,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [updateConflictsPanelPreferences]);
 
   /**
-   * 完全停用冲突自动面板 gate；用于替代 IDEA registry 开关的当前仓等价实现。
+   * 完全停用冲突自动面板门控；用于替代参考实现 registry 开关的当前仓等价实现。
    */
   const disableConflictsPanelGate = useCallback((): void => {
     updateConflictsPanelPreferences((prev) => setConflictsPanelGateEnabled(prev, false));
@@ -4898,7 +4904,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [commitNodeByKey, commitRenderRowByKey, selectedCommitTreeKeys]);
   /**
    * 为当前右键菜单冻结提交树选择快照。
-   * - 对齐 IDEA DataContext：菜单项执行时应使用打开菜单那一刻的树选择，而不是依赖后续可能变化的全局状态。
+   * - 保持与参考实现一致的 DataContext：菜单项执行时应使用打开菜单那一刻的树选择，而不是依赖后续可能变化的全局状态。
    */
   const menuCommitSelectionSnapshot = useMemo(() => {
     const selectedRowKeys = menu?.type === "changes"
@@ -5004,7 +5010,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     };
   }, [displayChangeLists, localChangesConfig.changeListsEnabled, localChangesConfig.stagingAreaEnabled, selectedChangeListIds, status?.changeLists?.activeListId]);
   /**
-   * 按 IDEA selectedDiffableNode 语义维护当前 diffable 节点；group/目录选中时优先保留仍在子树中的旧 diffable。
+   * 按参考实现 selectedDiffableNode 语义维护当前 diffable 节点；group/目录选中时优先保留仍在子树中的旧 diffable。
    */
   useEffect(() => {
     setSelectedDiffableCommitNodeKey((prev) => {
@@ -5169,7 +5175,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [activeSelectionScope, leftTab, selectedActionableEntries, selectedChangeListIds, status?.changeLists?.activeListId]);
 
   /**
-   * 对齐 IDEA `setCommitState(initialChangeList, included, ...)` 语义；显式进入提交流程时，需同步重建 included changes 与树选区。
+   * 保持与参考实现一致的 `setCommitState(initialChangeList, included, ...)` 语义；显式进入提交流程时，需同步重建 included changes 与树选区。
    */
   const applyCommitWorkflowActivationReset = useCallback((request: CommitWorkflowActivationResetRequest): boolean => {
     if (commitTreeBusy || !status) return false;
@@ -5421,7 +5427,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     return pushPreview.commits.find((one) => one.hash === selected) || null;
   }, [pushPreview, pushSelectedCommitHash]);
   /**
-   * 提取 Push 对话框中的仓库显示名，对齐 IDEA 顶层仓库节点的简短命名。
+   * 提取 Push 对话框中的仓库显示名，保持与参考实现一致的顶层仓库节点简短命名。
    */
   const pushRepoDisplayName = useMemo<string>(() => {
     const clean = String(repoRoot || "").trim().replace(/\\/g, "/").replace(/\/+$/, "");
@@ -5683,6 +5689,63 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     return hashes.join(" ").trim();
   }, [logItems, selectedCommitHashes]);
 
+  /**
+   * 按当前焦点所在 Git 子视图构造 Ctrl+C 文本，复用各控件自身的复制语义。
+   */
+  const buildActiveGitCopyText = useCallback((target: HTMLElement | null): string => {
+    if (target && commitTreeContainerRef.current?.contains(target)) {
+      return buildCommitTreeCopyText({
+        rows: commitRenderRows,
+        selectedRowKeys: selectedCommitTreeKeys,
+      });
+    }
+    if (target && branchPanelContainerRef.current?.contains(target)) {
+      return buildBranchPanelCopyText({
+        rows: branchPanelRows,
+        focusedRowKey: branchPanelFocusedRowKey,
+      });
+    }
+    if (target && logVirtual.containerRef.current?.contains(target)) {
+      return buildGitLogCopyText({
+        items: logItems,
+        selectedHashes: selectedCommitHashes,
+        layout: logColumnLayout,
+        formatDate: toCompactDateText,
+      });
+    }
+    if (target && detailTreeContainerRef.current?.contains(target)) {
+      return buildGitDetailsBrowserCopyText({
+        rows: detailFileRows,
+        selectedNodeKeys: selectedDetailNodeKeys,
+      });
+    }
+    if (activeSelectionScope === "detail") {
+      return buildGitDetailsBrowserCopyText({
+        rows: detailFileRows,
+        selectedNodeKeys: selectedDetailNodeKeys,
+      });
+    }
+    if (activeSelectionScope === "commit") {
+      return buildCommitTreeCopyText({
+        rows: commitRenderRows,
+        selectedRowKeys: selectedCommitTreeKeys,
+      });
+    }
+    return "";
+  }, [
+    activeSelectionScope,
+    branchPanelFocusedRowKey,
+    branchPanelRows,
+    commitRenderRows,
+    detailFileRows,
+    logColumnLayout,
+    logItems,
+    logVirtual.containerRef,
+    selectedCommitHashes,
+    selectedCommitTreeKeys,
+    selectedDetailNodeKeys,
+  ]);
+
   const logDecorationPillsByHash = useMemo<Map<string, GitDecorationPill[]>>(() => {
     const map = new Map<string, GitDecorationPill[]>();
     for (const item of logItems) {
@@ -5733,7 +5796,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [logColumnLayout, logColumnPreferredWidthMap]);
 
   /**
-   * 渲染日志表某一列的内容；`subject` 列会把图谱嵌入提交文本前，对齐 IDEA 在同一单元格内绘制 graph 的方式。
+   * 渲染日志表某一列的内容；`subject` 列会把图谱嵌入提交文本前，保持与参考实现一致，在同一单元格内绘制 graph 的方式。
    */
   const renderLogColumnContent = useCallback((
     item: GitLogItem,
@@ -5784,7 +5847,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [logDecorationPillsByHash]);
 
   /**
-   * 读取日志动作默认消息草稿，对齐 IDEA 的 reword/squash 初始编辑体验。
+   * 读取日志动作默认消息草稿，保持与参考实现一致的 reword/squash 初始编辑体验。
    */
   const loadLogMessageDraftValueAsync = useCallback(
     async (action: "editMessage" | "squashCommits", hashes: string[]): Promise<string> => {
@@ -5950,7 +6013,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [repoRoot]);
 
   /**
-   * 独立刷新 worktree 列表；对齐 IDEA `worktreesChanged` 只更新 worktree 视图的语义，
+   * 独立刷新 worktree 列表；保持与参考实现一致的 `worktreesChanged` 只更新 worktree 视图的语义，
    * 避免把 `.git/worktrees/*` 变化错误放大成整仓刷新。
    */
   const refreshWorktreeItemsAsync = useCallback(async (nextRepoRoot?: string): Promise<void> => {
@@ -6389,7 +6452,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [commitAmendDetails?.hash, commitAmendEnabled, loadCommitAmendDetailsAsync, repoRoot, status?.headSha]);
 
   /**
-   * 切换“修改上一提交”模式；开启时读取 HEAD 详情并回填 message/author，关闭时按 IDEA 语义恢复旧草稿。
+   * 切换“修改上一提交”模式；开启时读取 HEAD 详情并回填 message/author，关闭时按参考实现语义恢复旧草稿。
    */
   const handleCommitAmendToggleAsync = useCallback(async (enabled: boolean): Promise<void> => {
     if (!enabled) {
@@ -6988,7 +7051,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, []);
 
   /**
-   * 把当前选中的提交直接移动到顶部或底部，补齐接近 IDEA 上下文动作的快速重排体验。
+   * 把当前选中的提交直接移动到顶部或底部，补齐接近参考实现上下文动作的快速重排体验。
    */
   const moveInteractiveRebaseDialogEntryToEdge = useCallback((hash: string, edge: "top" | "bottom"): void => {
     setInteractiveRebaseDialogState((prev) => {
@@ -7275,7 +7338,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
 
   /**
    * 为回滚弹窗临时 Diff 浮层保存打开前的工作台 Diff 状态。
-   * 这是对齐 IDEA“在当前流程里临时查看差异”的变通设计：当前产品没有独立的 Diff 窗口宿主，因此改为前置浮层并在关闭后恢复原状态。
+   * 这是保持与参考实现一致“在当前流程里临时查看差异”的变通设计：当前产品没有独立的 Diff 窗口宿主，因此改为前置浮层并在关闭后恢复原状态。
    */
   const captureRollbackDiffOverlayRestoreSnapshot = useCallback((): void => {
     if (rollbackDiffOverlayRestoreRef.current) return;
@@ -7963,8 +8026,8 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [refreshAllAsync, repoRoot, shelfViewState]);
 
   /**
-   * 按 AGENTS.md 的 Git 面板对齐规则，Shelf 的“显示差异 / 在新标签页中显示差异 / 与本地比较”
-   * 统一映射到现有 GitWorkbench + Monaco Diff 宿主；其中“新标签页”用 pinned/fullscreen 作为 IDEA 标签页的等价变通实现。
+   * 按 AGENTS.md 的 Git 面板兼容规则，Shelf 的“显示差异 / 在新标签页中显示差异 / 与本地比较”
+   * 统一映射到现有 GitWorkbench + Monaco Diff 宿主；其中“新标签页”用 pinned/fullscreen 作为 参考实现标签页的等价变通实现。
    */
   const runShelfDiffActionAsync = useCallback(async (
     shelf: GitShelfItem,
@@ -7997,8 +8060,8 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [openDiffRequestAsync, openPinnedDiffRequestAsync, repoRoot]);
 
   /**
-   * 按 AGENTS.md 的 Git 面板对齐规则，Shelf 的 Create Patch / Copy Patch 复用现有补丁导出链路；
-   * 多文件选择会逐文件读取 shelf patch 后再聚合导出，而不是新增 IDEA 原生 patch 对话框宿主。
+   * 按 AGENTS.md 的 Git 面板兼容规则，Shelf 的 Create Patch / Copy Patch 复用现有补丁导出链路；
+   * 多文件选择会逐文件读取 shelf patch 后再聚合导出，而不是新增 独立 patch 对话框宿主。
    */
   const exportShelfPatchSelectionAsync = useCallback(async (
     shelf: GitShelfItem,
@@ -8277,7 +8340,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, []);
 
   /**
-   * 把 resolver 焦点切到下一个未解决文件，形成 closer to IDEA 的 resolver 回跳闭环。
+   * 把 resolver 焦点切到下一个未解决文件，形成更接近参考实现的 resolver 回跳闭环。
    */
   const selectNextConflictResolverPath = useCallback((): void => {
     setConflictResolverDialogState((prev) => {
@@ -8534,7 +8597,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [activateCommitWorkflow, closeConflictResolverDialog]);
 
   /**
-   * 在应用内 merge 已把文件写回并 `git add` 之后，按 IDEA `GitConflictResolver#proceedAfterAllMerged`
+   * 在应用内 merge 已把文件写回并 `git add` 之后，按参考实现 `GitConflictResolver#proceedAfterAllMerged`
    * 的收尾语义直接继续当前 Git 操作；后续是否还能继续、是否再次冲突、是否已自动结束，统一以后端真实仓库状态为准。
    */
   const continueResolvedOperationAsync = useCallback(async (
@@ -8644,7 +8707,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [closeConflictMergeDialog, conflictMergeDialogState, continueResolvedOperationAsync]);
 
   /**
-   * 按 IDEA 底部“接受左侧/接受右侧”语义直接采用整侧内容并完成写回。
+   * 按参考实现底部“接受左侧/接受右侧”语义直接采用整侧内容并完成写回。
    */
   const resolveConflictMergeWithSourceAsync = useCallback(async (source: "ours" | "theirs"): Promise<void> => {
     const snapshot = conflictMergeDialogState?.snapshot;
@@ -9187,7 +9250,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [openRollbackViewerDialog, operationProblem, repoRoot, status?.entries]);
 
   /**
-   * 在 Cherry-pick 冲突全部解决后切换到提交工作流，并预填 Git 建议的提交消息，对齐 IDEA 的收尾方式。
+   * 在 Cherry-pick 冲突全部解决后切换到提交工作流，并预填 Git 建议的提交消息，保持与参考实现一致的收尾方式。
    */
   const enterCherryPickCommitCompletionMode = useCallback((options?: {
     closeResolver?: boolean;
@@ -10357,7 +10420,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [pushSelectedCommitHash]);
 
   /**
-   * 处理 Push 左侧树的键盘导航，行为尽量对齐 IDEA 的树选择体验。
+   * 处理 Push 左侧树的键盘导航，行为尽量保持与参考实现一致的树选择体验。
    */
   const handlePushTreeKeyboardNavigation = useCallback((event: KeyboardEvent): void => {
     if (!pushDialogOpen || pushDialogLoading) return;
@@ -11391,7 +11454,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     if (!detailSpeedSearchOpen) return;
 
     /**
-     * 点击详情树外部时按 IDEA `focusLost -> manageSearchPopup(null)` 语义关闭并清空当前搜索。
+     * 点击详情树外部时按参考实现 `focusLost -> manageSearchPopup(null)` 语义关闭并清空当前搜索。
      */
     const handleDetailSpeedSearchOutsideMouseDown = (event: MouseEvent): void => {
       const root = detailTreeSpeedSearchRootRef.current;
@@ -11786,7 +11849,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
       });
       const availableChangeListIds = new Set((status?.changeLists?.lists || []).map((one) => String(one.id || "").trim()).filter(Boolean));
       /**
-       * 生成与 IDEA `VirtualFileDeleteProvider` 一致的删除确认文案。
+       * 生成与参考实现 `VirtualFileDeleteProvider` 一致的删除确认文案。
        */
       const confirmDeleteSelectionAsync = async (): Promise<boolean> => {
         const effectiveTargets = Array.from(new Set((actionSelectedDeleteTargets.length > 0 ? actionSelectedDeleteTargets : files).filter(Boolean)));
@@ -12696,7 +12759,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [buildBranchCompareDialogConfig, openActionDialogAsync, openBranchCompareCommits, openBranchCompareFilesDialogAsync, repoRoot, resolveBranchCompareRepository]);
 
   /**
-   * 为“删除分支成功”提示构造补救动作，对齐 IDEA 的 Restore / View commits / Delete tracked branch 语义。
+   * 为“删除分支成功”提示构造补救动作，保持与参考实现一致的 Restore / View commits / Delete tracked branch 语义。
    */
   const buildDeletedBranchRecoveryNoticeActions = useCallback((recoveryInfo: GitDeletedBranchRecoveryInfo, repoRootOverride?: string): GitNoticeActionItem[] => {
     const actionRepoRoot = String(repoRootOverride || repoRoot || "").trim();
@@ -13215,7 +13278,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   );
 
   /**
-   * 执行日志菜单中的“提交 refs 分支/标签操作”（对齐 IDEA Git.BranchOperationGroup 主链路）。
+   * 执行日志菜单中的“提交 refs 分支/标签操作”（保持与参考实现一致的 Git.BranchOperationGroup 主链路）。
    */
   const runLogRefMenuActionAsync = useCallback(
     async (
@@ -13356,7 +13419,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
    * 执行日志分支 dashboard 的“选择分支”动作。
    * 在 Git 面板“分支”侧栏的双击交互范围内，当前产品设计要求双击分支优先切换当前日志筛选，不再因仓库上下文不一致而中断；
    * 若所选分支并非当前日志仓，或路径只在大小写/分隔符层面不同，则直接按分支名切换筛选。
-   * 设计如此，此处在“分支侧栏双击筛选”范围内继续不对齐 IDEA，以保证交互稳定可用。
+   * 设计如此，此处在“分支侧栏双击筛选”范围内继续不保持与参考实现一致，以保证交互稳定可用。
    */
   const applyLogBranchSelection = useCallback((args: {
     branchName: string;
@@ -13708,7 +13771,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [activeLogFilters.path, isFileHistoryMode, logHasMore, logItems, logLoading, pendingLogSelectionHash]);
 
   /**
-   * 文件历史模式下，单击提交记录后自动打开该文件在该提交上的 Diff，对齐 IDEA 文件历史联动行为。
+   * 文件历史模式下，单击提交记录后自动打开该文件在该提交上的 Diff，保持与参考实现一致的文件历史联动行为。
    */
   useEffect(() => {
     if (!active || !repoRoot || !isFileHistoryMode) return;
@@ -13908,7 +13971,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [commitTreeBusy, commitTreeGroups]);
 
   /**
-   * 确保当前主树选中行始终滚动到可视区域内，对齐 IDEA `selectNode/selectPath -> makeVisible()` 的语义。
+   * 确保当前主树选中行始终滚动到可视区域内，保持与参考实现一致的 `selectNode/selectPath -> makeVisible()` 的语义。
    */
   useEffect(() => {
     if (commitTreeBusy) return;
@@ -14198,6 +14261,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   useEffect(() => {
     if (!active) return;
     const onKey = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
       const ctrl = event.ctrlKey || event.metaKey;
       const key = event.key.toLowerCase();
       const target = event.target as HTMLElement | null;
@@ -14221,6 +14285,14 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
           event.preventDefault();
           applyCommitNodeSelection(commitVisibleRowKeys);
         }
+        return;
+      }
+      if (ctrl && !event.altKey && !event.shiftKey && key === "c") {
+        if (isTextEditable) return;
+        const text = buildActiveGitCopyText(target);
+        if (!text) return;
+        event.preventDefault();
+        void window.host?.utils?.copyText?.(text);
         return;
       }
       if (ctrl && event.shiftKey && !event.altKey && event.key.toLowerCase() === "k") {
@@ -14251,6 +14323,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     active,
     activeSelectionScope,
     applyCommitNodeSelection,
+    buildActiveGitCopyText,
     commitVisibleRowKeys,
     detailVisibleNodeKeys,
     runBranchTreeActionAsync,
@@ -14324,7 +14397,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [handlePushTreeKeyboardNavigation, pushDialogOpen]);
 
   /**
-   * 处理日志列宽拖拽，行为对齐 IDEA 的可调列表头。
+   * 处理日志列宽拖拽，行为保持与参考实现一致的可调列表头。
    */
   useEffect(() => {
     const onMove = (event: MouseEvent) => {
@@ -14847,7 +14920,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
                   cacheKey: group.kind,
                   kind: group.kind === "ignored" ? "ignored" : group.kind === "conflict" ? "conflict" : "unversioned",
                   title: group.label,
-                  description: gt("workbench.misc.changeListManyFilesDescription", "该节点包含 {{count}} 个文件，按 IDEA 的 many files 语义改为通过浏览对话框查看。", { count: group.entries.length }),
+                  description: gt("workbench.misc.changeListManyFilesDescription", "该节点包含 {{count}} 个文件，按大量文件节点语义改为通过浏览对话框查看。", { count: group.entries.length }),
                   entries: group.entries,
                 });
               }}
@@ -15212,7 +15285,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
                 {worktreeTabVisible ? (
                   <div className="flex items-center gap-1">
                     {/* 当前产品设计要求 Git 面板底部页签区里的 Worktrees 页签常驻且不可关闭，因此这里不再暴露关闭按钮。
-                        设计如此，此处在“底部页签显隐与关闭入口”范围内继续不对齐 IDEA。 */}
+                        设计如此，此处在“底部页签显隐与关闭入口”范围内继续不保持与参考实现一致。 */}
                     <TabsTrigger value="worktrees" className={cn(GIT_BOTTOM_TABS_TRIGGER_CLASS, "min-w-[92px] pr-2")}>
                       <span className="flex items-center gap-1">
                         <span>{gt("workbench.misc.worktrees.title", "工作树")}</span>
@@ -15396,7 +15469,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
                     ) : null}
                     <div className="ml-auto flex items-center gap-1">
                       {/* 当前产品设计把 Git 面板“分支”侧栏头部的低频控制统一收敛到一个下拉菜单，避免头部横向拥挤并减少多按钮并排造成的误触。
-                          设计如此，此处在“分支侧栏头部操作入口”范围内继续不对齐 IDEA。 */}
+                          设计如此，此处在“分支侧栏头部操作入口”范围内继续不保持与参考实现一致。 */}
                       <DropdownMenu>
                         <DropdownMenuTrigger>
                           <Button size="icon-sm" variant="ghost" title={gt("workbench.branches.panel.actionsTitle", "分支面板操作")}>
@@ -15412,6 +15485,16 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
                           <DropdownMenuItem className={TOOLBAR_MENU_ITEM_CLASS} onClick={() => void setBranchShowOnlyMyAsync(branchPopup?.showOnlyMy !== true)}>
                             <Check className={`mr-2 h-3.5 w-3.5 ${branchPopup?.showOnlyMy === true ? "opacity-100 text-[var(--cf-accent)]" : "opacity-0"}`} />
                             {gt("workbench.branches.panel.menu.myBranches", "我的分支")}
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            className={TOOLBAR_MENU_ITEM_CLASS}
+                            onClick={() => {
+                              setBranchPanelGroupByDirectory((prev) => !prev);
+                              setBranchDirectoryOpen({});
+                            }}
+                          >
+                            <Check className={`mr-2 h-3.5 w-3.5 ${branchPanelGroupByDirectory ? "opacity-100 text-[var(--cf-accent)]" : "opacity-0"}`} />
+                            {gt("workbench.branches.panel.menu.groupByDirectory", "分组依据 目录")}
                           </DropdownMenuItem>
                           {branchPanelRepositories.length > 1 ? (
                             <>
@@ -15464,16 +15547,32 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
                     </div>
                     {branchPanelRows.map((row, index) => {
                       if (row.kind === "group") {
-                        const expanded = row.key === "group:favorites"
-                          ? branchGroupOpen.favorites
-                          : row.key === "group:local"
-                            ? branchGroupOpen.local
-                            : branchGroupOpen.remote;
+                        const isDirectoryGroup = !!row.directoryPath;
+                        const expanded = isDirectoryGroup
+                          ? branchDirectoryOpen[row.key] !== false
+                          : row.key === "group:favorites"
+                            ? branchGroupOpen.favorites
+                            : row.key === "group:local"
+                              ? branchGroupOpen.local
+                              : branchGroupOpen.remote;
                         return (
                           <button
                             key={row.key}
-                            className={cn("cf-git-section-toggle flex w-full items-center gap-0.5 px-1 py-0.5 text-left text-[11px]", index > 0 ? "mt-0.5" : "")}
+                            className={cn(
+                              "cf-git-section-toggle flex w-full items-center gap-0.5 px-1 py-0.5 text-left text-[11px]",
+                              index > 0 && !isDirectoryGroup ? "mt-0.5" : "",
+                              isDirectoryGroup ? "ml-3 text-[var(--cf-text-secondary)]" : "",
+                            )}
+                            style={isDirectoryGroup ? { paddingLeft: 8 + Math.max(0, Number(row.depth) || 0) * 14 } : undefined}
+                            onMouseDown={() => {
+                              setBranchPanelFocusedRowKey(row.key);
+                              branchPanelContainerRef.current?.focus();
+                            }}
                             onClick={() => {
+                              if (isDirectoryGroup) {
+                                setBranchDirectoryOpen((prev) => ({ ...prev, [row.key]: prev[row.key] === false }));
+                                return;
+                              }
                               setBranchGroupOpen((prev) => ({
                                 ...prev,
                                 favorites: row.key === "group:favorites" ? !prev.favorites : prev.favorites,
@@ -15482,7 +15581,9 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
                               }));
                             }}
                           >
-                            {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />} {row.label}
+                            {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+                            {isDirectoryGroup ? <Folder className="h-3.5 w-3.5 shrink-0" /> : null}
+                            <span className="min-w-0 truncate">{row.label}</span>
                           </button>
                         );
                       }
@@ -15506,6 +15607,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
                             row.section === "remote" && isFilteredBranch ? "cf-git-row-selected text-[var(--cf-text-primary)]" : "",
                             isSpeedSearchFocused ? "cf-git-row-selected text-[var(--cf-text-primary)]" : "",
                           )}
+                          style={branchPanelGroupByDirectory ? { marginLeft: 12 + Math.max(0, Number(row.depth) || 0) * 14 } : undefined}
                           title={presentation.tooltip}
                           onMouseDown={() => {
                             setBranchPanelFocusedRowKey(row.key);
@@ -15526,7 +15628,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
                         >
                           <span className="min-w-0 flex-1" title={row.name}>
                             <span className="block truncate text-[11px] leading-5">
-                              {branchPanelSpeedSearchQuery ? renderGitSpeedSearchText(row.name, branchPanelSpeedSearchQuery) : row.name}
+                              {branchPanelSpeedSearchQuery ? renderGitSpeedSearchText(row.displayName, branchPanelSpeedSearchQuery) : row.displayName}
                             </span>
                           </span>
                           <div className="ml-1 flex shrink-0 items-center gap-1">
@@ -15916,7 +16018,11 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
                 </div>
                 <div
                   ref={logVirtual.containerRef}
-                  className="min-h-0 flex-1 overflow-auto cf-scroll-area"
+                  className="min-h-0 flex-1 overflow-auto cf-scroll-area outline-none"
+                  tabIndex={0}
+                  onMouseDown={() => {
+                    logVirtual.containerRef.current?.focus();
+                  }}
                   onContextMenu={(event) => {
                     event.preventDefault();
                     event.stopPropagation();
@@ -17143,7 +17249,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
         showEditSource: selectionContext.navigatablePaths.length > 0,
       });
       /**
-       * 把提交树共享菜单模型渲染成具体菜单项，统一承接 IDEA 提交工具窗口层级与当前产品豁免映射。
+       * 把提交树共享菜单模型渲染成具体菜单项，统一承接 参考实现提交工具窗口层级与当前产品豁免映射。
        */
       const renderSharedMenuNode = (node: CommitTreeSharedMenuNode): JSX.Element | null => {
         if (node.kind === "submenu") {
@@ -17752,7 +17858,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
       const allPathsHaveSingleHash = detailHashResolution.allPathsHaveSingleHash;
       const canShowRevisionHistory = targetIsFile && canSingleFileAction && singleHashContext && !!targetHash;
       /**
-       * 渲染单个提交详情菜单动作，保持 committed changes 菜单顺序和危险动作语义与 IDEA 一致。
+       * 渲染单个提交详情菜单动作，保持 committed changes 菜单顺序和危险动作语义与参考实现一致。
        */
       const renderDetailContextMenuAction = (actionKey: ReturnType<typeof buildCommitDetailsContextMenuGroups>[number][number]): JSX.Element | null => {
         if (actionKey === "showDiff") {
@@ -18837,7 +18943,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
 
   /**
    * 渲染 rollback viewer 之上的临时 Diff 浮层。
-   * 这是对齐 IDEA“当前流程内查看差异”的变通设计：现有产品没有单独的 Diff 窗口宿主，因此复用工作台 Diff 面板并临时前置显示。
+   * 这是保持与参考实现一致“当前流程内查看差异”的变通设计：现有产品没有单独的 Diff 窗口宿主，因此复用工作台 Diff 面板并临时前置显示。
    */
   const renderRollbackDiffOverlay = (): JSX.Element | null => {
     if (!rollbackDiffOverlayOpen || !diff) return null;

--- a/web/src/features/git/interactive-rebase-dialog.tsx
+++ b/web/src/features/git/interactive-rebase-dialog.tsx
@@ -200,7 +200,7 @@ function renderSelectedDetails(
 }
 
 /**
- * 渲染应用内 interactive rebase editor，对齐 IDEA 的提交列表 + 行级动作编辑主流程。
+ * 渲染应用内 interactive rebase editor，保持与参考实现一致的提交列表 + 行级动作编辑主流程。
  */
 export function InteractiveRebaseDialog({
   open,

--- a/web/src/features/git/interactive-rebase-model.ts
+++ b/web/src/features/git/interactive-rebase-model.ts
@@ -52,7 +52,7 @@ function getCommitMessageSubject(message: string): string {
 }
 
 /**
- * 判断消息是否为 autosquash 前缀，便于生成更接近 IDEA 的 squash 初始文案。
+ * 判断消息是否为 autosquash 前缀，便于生成更接近参考实现的 squash 初始文案。
  */
 function isAutosquashCommitMessage(message: string): boolean {
   return /^(fixup|squash|amend)! /i.test(getCommitMessageSubject(message));
@@ -67,7 +67,7 @@ function trimAutosquashCommitMessage(message: string): string {
 }
 
 /**
- * 按 IDEA `pretty squash` 的思路生成消息建议，用于 squash 文本区提示。
+ * 按参考实现 `pretty squash` 的思路生成消息建议，用于 squash 文本区提示。
  */
 function buildPrettySquashMessage(messagesInput: string[]): string {
   const messages = messagesInput.map((one) => String(one || "")).filter((one) => one.length > 0);
@@ -230,7 +230,7 @@ function canAttachInteractiveRebaseEntry(entries: GitInteractiveRebaseEntry[], h
 }
 
 /**
- * 计算某条 entry 上下文动作当前是否可用，对齐前序可附着目标这一类 IDEA gating。
+ * 计算某条 entry 上下文动作当前是否可用，复用参考实现中“前序可附着目标”这一类可用性门控。
  */
 export function getInteractiveRebaseActionAvailability(
   entries: GitInteractiveRebaseEntry[],

--- a/web/src/features/git/log-columns.test.ts
+++ b/web/src/features/git/log-columns.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   createDefaultGitLogColumnLayout,
+  buildGitLogCopyText,
   estimateGitLogColumnWidth,
   loadGitLogColumnLayout,
   normalizeGitLogColumnLayout,
@@ -124,5 +125,59 @@ describe("log-columns", () => {
     const resized = resizeGitLogColumn(layout, "author", 166);
     expect(resized.autoFit.author).toBe(false);
     expect(resolveGitLogColumnWidth(resized, "author", 72)).toBe(166);
+  });
+
+  /**
+   * 验证日志复制文本按当前列顺序输出，且只包含被选中的提交行。
+   */
+  it("copy provider 应按当前列顺序输出选中提交", () => {
+    const text = buildGitLogCopyText({
+      items: [
+        {
+          hash: "a1b2c3d4",
+          shortHash: "a1b2c3d",
+          parents: [],
+          authorName: "Alice",
+          authorEmail: "alice@example.com",
+          authorDate: "2025-06-01T00:00:00.000Z",
+          subject: "feat: one",
+          decorations: "main",
+        },
+        {
+          hash: "b2c3d4e5",
+          shortHash: "b2c3d4e",
+          parents: [],
+          authorName: "Bob",
+          authorEmail: "bob@example.com",
+          authorDate: "2025-06-02T00:00:00.000Z",
+          subject: "fix: two",
+          decorations: "origin/main",
+        },
+      ],
+      selectedHashes: ["b2c3d4e5", "a1b2c3d4"],
+      layout: {
+        order: ["author", "hash", "subject", "date", "refs"],
+        widths: {
+          subject: 368,
+          author: 104,
+          date: 96,
+          hash: 82,
+          refs: 128,
+        },
+        autoFit: {
+          subject: false,
+          author: true,
+          date: true,
+          hash: true,
+          refs: true,
+        },
+      },
+      formatDate: (iso) => iso.slice(0, 10),
+    });
+
+    expect(text).toBe([
+      "Alice a1b2c3d feat: one 2025-06-01 main",
+      "Bob b2c3d4e fix: two 2025-06-02 origin/main",
+    ].join("\n"));
   });
 });

--- a/web/src/features/git/log-columns.ts
+++ b/web/src/features/git/log-columns.ts
@@ -2,6 +2,7 @@
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
 import type { CSSProperties } from "react";
+import type { GitLogItem } from "./types";
 import { resolveGitText } from "./git-i18n";
 
 export type GitLogColumnId = "subject" | "author" | "date" | "hash" | "refs";
@@ -18,6 +19,13 @@ export type GitLogColumnLayout = {
   order: GitLogColumnId[];
   widths: Record<GitLogColumnId, number>;
   autoFit: Record<GitLogColumnId, boolean>;
+};
+
+export type GitLogCopyTextOptions = {
+  items: GitLogItem[];
+  selectedHashes: string[];
+  layout: GitLogColumnLayout;
+  formatDate?: (iso: string) => string;
 };
 
 const GIT_LOG_COLUMN_LAYOUT_STORAGE_KEY = "cf.gitWorkbench.logColumns.v3";
@@ -195,7 +203,7 @@ export function saveGitLogColumnLayout(layout: GitLogColumnLayout): void {
 }
 
 /**
- * 返回某一列在当前布局下的弹性样式，模拟 IDEA 日志表格的“主列自适应、其余列可收缩”。
+ * 返回某一列在当前布局下的弹性样式，保留“主列自适应、其余列可收缩”的日志表格布局。
  */
 export function buildGitLogColumnStyle(layout: GitLogColumnLayout, columnId: GitLogColumnId, preferredWidth?: number): CSSProperties {
   const definition = GIT_LOG_COLUMN_DEFINITIONS.find((one) => one.id === columnId) || GIT_LOG_COLUMN_DEFINITIONS[0];
@@ -237,6 +245,33 @@ export function estimateGitLogColumnWidth(columnId: GitLogColumnId, samples: str
 }
 
 /**
+ * 按日志表当前可见列顺序构造复制文本，保持和表格显示字段一致。
+ */
+export function buildGitLogCopyText(options: GitLogCopyTextOptions): string {
+  const selected = new Set((options.selectedHashes || []).map((hash) => String(hash || "").trim()).filter(Boolean));
+  if (selected.size <= 0) return "";
+  const normalizedLayout = normalizeGitLogColumnLayout(options.layout);
+  const formatDate = options.formatDate || ((value: string) => String(value || "").trim());
+  return (options.items || [])
+    .filter((item) => selected.has(item.hash))
+    .map((item) => normalizedLayout.order.map((columnId) => resolveGitLogCopyCellText(item, columnId, formatDate)).filter(Boolean).join(" "))
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
+ * 将日志项转换为单列文本；与渲染列保持同一字段来源，避免复制内容与屏幕显示明显分叉。
+ */
+function resolveGitLogCopyCellText(item: GitLogItem, columnId: GitLogColumnId, formatDate: (iso: string) => string): string {
+  if (columnId === "subject") return String(item.subject || "").trim();
+  if (columnId === "author") return String(item.authorName || "").trim();
+  if (columnId === "date") return String(formatDate(item.authorDate) || "").trim();
+  if (columnId === "hash") return String(item.shortHash || item.hash || "").trim();
+  if (columnId === "refs") return String(item.decorations || "").trim();
+  return "";
+}
+
+/**
  * 解析日志列最终生效宽度；自动列优先取内容估算值，手动列保持用户拖拽结果。
  */
 export function resolveGitLogColumnWidth(layout: GitLogColumnLayout, columnId: GitLogColumnId, preferredWidth?: number): number {
@@ -269,7 +304,7 @@ export function resizeGitLogColumn(layout: GitLogColumnLayout, columnId: GitLogC
 }
 
 /**
- * 按拖拽结果重新排列日志列顺序，行为对齐 IDEA 的表头拖拽交换。
+ * 按拖拽结果重新排列日志列顺序，保持表头拖拽交换行为稳定。
  */
 export function moveGitLogColumn(layout: GitLogColumnLayout, sourceId: GitLogColumnId, targetId: GitLogColumnId): GitLogColumnLayout {
   if (sourceId === targetId) return normalizeGitLogColumnLayout(layout);

--- a/web/src/features/git/log-commit-editing-prefs.ts
+++ b/web/src/features/git/log-commit-editing-prefs.ts
@@ -27,7 +27,7 @@ function getLocalStorageSafe(): Storage | null {
 }
 
 /**
- * 把偏好对象收敛为稳定结构；缺省场景默认开启删除提交提醒，对齐 IDEA。
+ * 把偏好对象收敛为稳定结构；缺省场景默认开启删除提交提醒，保持与参考实现一致。
  */
 function normalizeGitLogCommitEditingPrefs(input: unknown): GitLogCommitEditingPrefs {
   const obj = (input && typeof input === "object") ? (input as Partial<GitLogCommitEditingPrefs>) : {};

--- a/web/src/features/git/log-filter-popups.tsx
+++ b/web/src/features/git/log-filter-popups.tsx
@@ -98,7 +98,7 @@ export function formatGitLogDateFilterLabel(label: string, dateFrom: string, dat
 }
 
 /**
- * 顶部多值筛选按钮，按 IDEA popup 语义提供搜索、多选与清空入口。
+ * 顶部多值筛选按钮，按参考实现 popup 语义提供搜索、多选与清空入口。
  */
 export function GitLogMultiSelectFilterButton(props: GitLogMultiSelectFilterButtonProps): JSX.Element {
   const {
@@ -186,7 +186,7 @@ export function GitLogMultiSelectFilterButton(props: GitLogMultiSelectFilterButt
 }
 
 /**
- * 顶部日期筛选按钮，提供 IDEA 风格的快捷时间范围与自定义入口。
+ * 顶部日期筛选按钮，提供参考实现风格的快捷时间范围与自定义入口。
  */
 export function GitLogDateFilterButton(props: GitLogDateFilterButtonProps): JSX.Element {
   const {

--- a/web/src/features/git/log-graph/cell.test.tsx
+++ b/web/src/features/git/log-graph/cell.test.tsx
@@ -370,7 +370,7 @@ describe("GitLogGraphCell", () => {
     }
   });
 
-  it("普通节点默认应无 outline，选中 HEAD 节点应退化为 IDEA 的单个放大实心圆", async () => {
+  it("普通节点默认应无 outline，选中 HEAD 节点应退化为参考实现的单个放大实心圆", async () => {
     const rendered = await renderGraphCell({
       lane: 0,
       color: "#b28b33",

--- a/web/src/features/git/log-graph/cell.tsx
+++ b/web/src/features/git/log-graph/cell.tsx
@@ -111,7 +111,7 @@ function resolveGraphElementScopeKey(cell: GitGraphCell, scopeId: string): strin
 
 /**
  * 渲染不带节点的背景 track；若上一行通过斜线接入，则在本行补齐上半段对接，再继续向下延伸竖线。
- * 对齐 IDEA 后，track 还需要支持上/下两个方向各自独立的 terminal arrow。
+ * 保持与参考实现一致后，track 还需要支持上/下两个方向各自独立的 terminal arrow。
  */
 function renderGraphTrack(args: {
   track: GitGraphCell["tracks"][number];
@@ -206,7 +206,7 @@ function resolveGraphIncomingSegments(
 
 /**
  * 计算斜线在当前行边界处的中点横坐标。
- * 终止箭头仍锚在边界中点，以对齐 IDEA 对非垂直线段的箭头落点语义。
+ * 终止箭头仍锚在边界中点，以保留参考实现对非垂直线段的箭头落点语义。
  */
 function resolveGraphBoundaryX(fromX: number, toX: number): number {
   return (fromX + toX) / 2;
@@ -215,7 +215,7 @@ function resolveGraphBoundaryX(fromX: number, toX: number): number {
 /**
  * 渲染从上一行进入当前行中心的入射连线。
  * - 垂直线仍按 Web 分片绘制到当前行上边界，避免与相邻行背景互相覆盖；
- * - 斜线改为按 IDEA 的完整几何（上一行中心 -> 当前行中心）绘制，再裁切出当前行可见部分，
+ * - 斜线改为按参考实现的完整几何（上一行中心 -> 当前行中心）绘制，再裁切出当前行可见部分，
  *   这样不会在行接缝处叠出两个圆角端帽，避免截图里的折痕。
  */
 function renderGraphIncomingEdge(args: {
@@ -303,7 +303,7 @@ function renderGraphIncomingEdge(args: {
 /**
  * 渲染从当前行中心发往下一行的出射连线。
  * - 垂直线仍只画到当前行下边界，保持 Web 分片渲染稳定；
- * - 斜线改为按 IDEA 的完整几何（当前行中心 -> 下一行中心）绘制，再裁切出当前行可见部分，
+ * - 斜线改为按参考实现的完整几何（当前行中心 -> 下一行中心）绘制，再裁切出当前行可见部分，
  *   保证跨行视觉上仍是一条直线，而不是两段各自带圆角端帽的半线。
  */
 function renderGraphOutgoingEdge(args: {
@@ -385,7 +385,7 @@ function renderGraphOutgoingEdge(args: {
 
 /**
  * 计算 terminal edge 在当前行内的收口位置。
- * 对齐 IDEA `SimpleGraphCellPainter` 的 `circleRadius / 2 + 1`，让箭头贴近边界但不压到节点圆心。
+ * 保持与参考实现一致的 `SimpleGraphCellPainter` 的 `circleRadius / 2 + 1`，让箭头贴近边界但不压到节点圆心。
  */
 function resolveGraphTerminalBoundaryY(rowHeight: number, direction: "up" | "down"): number {
   const gap = resolveLogGraphTerminalGap(rowHeight);
@@ -531,7 +531,7 @@ function renderGraphArrow(args: {
 }
 
 /**
- * 按 IDEA `rotate(...)` 的几何把箭头两条边从终点反向旋出。
+ * 按参考实现 `rotate(...)` 的几何把箭头两条边从终点反向旋出。
  */
 function rotateGraphPoint(
   x: number,
@@ -555,7 +555,7 @@ function rotateGraphPoint(
 }
 
 /**
- * 计算 terminal arrow 的臂长，对齐 IDEA `ARROW_LENGTH * rowHeight`。
+ * 计算 terminal arrow 的臂长，保持与参考实现一致的 `ARROW_LENGTH * rowHeight`。
  */
 function resolveGraphArrowLength(rowHeight: number): number {
   return LOG_GRAPH_ARROW_LENGTH_FACTOR * rowHeight;
@@ -569,7 +569,7 @@ function formatGraphCoordinate(value: number): string {
 }
 
 /**
- * 渲染普通节点与 HEAD 节点，整体语义对齐 IDEA `SimpleGraphCellPainter` / `HeadNodePainter`。
+ * 渲染普通节点与 HEAD 节点，整体语义保持与参考实现一致的 `SimpleGraphCellPainter` / `HeadNodePainter`。
  * 默认节点直接填充圆；HEAD 节点未选中时绘制三层圆，选中时退化为单个放大的实心圆。
  */
 function renderGraphNode(args: {
@@ -635,7 +635,7 @@ function renderGraphNode(args: {
 }
 
 /**
- * 按接近 IDEA painter 的规则推导虚线节距。
+ * 按接近参考实现 painter 的规则推导虚线节距。
  * 由于 Web 端把跨行边拆成半段绘制，这里需要先还原对应的“逻辑整段长度”，避免 terminal edge 或半段斜线出现负 dash / 过密短线。
  */
 function resolveGraphDashArray(x1: number, y1: number, x2: number, y2: number, rowHeight: number): string {

--- a/web/src/features/git/log-graph/metrics.ts
+++ b/web/src/features/git/log-graph/metrics.ts
@@ -18,14 +18,14 @@ type LogGraphRoundingMode = "floor" | "ceil" | "round";
 type LogGraphParityMode = "odd" | "even";
 
 /**
- * 按 IDEA `PaintParameters.scaleWithRowHeight` 的语义，把图谱尺寸随着实际行高同比缩放。
+ * 按参考实现 `PaintParameters.scaleWithRowHeight` 的语义，把图谱尺寸随着实际行高同比缩放。
  */
 export function scaleLogGraphMetric(value: number, rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return (value * rowHeight) / LOG_GRAPH_ROW_HEIGHT_BASE;
 }
 
 /**
- * 按指定舍入策略把值对齐到整数像素，语义贴近 IDEA `PaintUtil.alignToInt`。
+ * 按指定舍入策略把值对齐到整数像素，语义贴近参考实现 `PaintUtil.alignToInt`。
  */
 function alignLogGraphToPixel(value: number, roundingMode: LogGraphRoundingMode, parityMode?: LogGraphParityMode): number {
   let rounded = roundLogGraphPixel(value, parityMode && roundingMode === "round" ? "floor" : roundingMode);
@@ -46,7 +46,7 @@ function roundLogGraphPixel(value: number, roundingMode: LogGraphRoundingMode): 
 }
 
 /**
- * 返回整数像素值的奇偶性，供 IDEA 风格的奇/偶对齐使用。
+ * 返回整数像素值的奇偶性，供参考实现风格的奇/偶对齐使用。
  */
 function resolveLogGraphParity(value: number): LogGraphParityMode {
   return Math.abs(value % 2) === 0 ? "even" : "odd";
@@ -54,7 +54,7 @@ function resolveLogGraphParity(value: number): LogGraphParityMode {
 
 /**
  * 获取当前行高下的行中心。
- * Web 端这里必须与日志列表行盒的真实几何中心保持一致；若继续照搬 IDEA Swing 里的奇数像素对齐，
+ * Web 端这里必须与日志列表行盒的真实几何中心保持一致；若继续照搬参考实现 Swing 里的奇数像素对齐，
  * 在当前 `32px` 偶数行高下会把整张图谱统一上移 `1px`，导致节点与文本行心整体错位。
  */
 export function resolveLogGraphRowCenter(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
@@ -62,35 +62,35 @@ export function resolveLogGraphRowCenter(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT
 }
 
 /**
- * 获取当前行高下的 lane 宽度，对齐 IDEA `elementWidth = alignToInt(getElementWidth(rowHeight), FLOOR, ODD)`。
+ * 获取当前行高下的 lane 宽度，保持与参考实现一致 `elementWidth = alignToInt(getElementWidth(rowHeight), FLOOR, ODD)`。
  */
 export function resolveLogGraphLaneWidth(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return alignLogGraphToPixel(scaleLogGraphMetric(LOG_GRAPH_LANE_WIDTH, rowHeight), "floor", "odd");
 }
 
 /**
- * 获取当前行高下的单个 lane 的水平中心，保证列中心与 IDEA 的布局一致。
+ * 获取当前行高下的单个 lane 的水平中心，保证列中心与参考实现的布局一致。
  */
 export function resolveLogGraphLaneCenter(lane: number, rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return lane * resolveLogGraphLaneWidth(rowHeight) + resolveLogGraphXOffset(rowHeight);
 }
 
 /**
- * 获取当前行高下的图谱列中心偏移，对齐 IDEA `elementCenter = alignToInt(getElementWidth(rowHeight) / 2, FLOOR, null)`。
+ * 获取当前行高下的图谱列中心偏移，保持与参考实现一致 `elementCenter = alignToInt(getElementWidth(rowHeight) / 2, FLOOR, null)`。
  */
 export function resolveLogGraphXOffset(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return alignLogGraphToPixel(scaleLogGraphMetric(LOG_GRAPH_LANE_WIDTH, rowHeight) / 2, "floor");
 }
 
 /**
- * 获取当前行高下的普通线宽，对齐 IDEA `lineThickness = alignToInt(getLineThickness(rowHeight), FLOOR, ODD)`。
+ * 获取当前行高下的普通线宽，保持与参考实现一致 `lineThickness = alignToInt(getLineThickness(rowHeight), FLOOR, ODD)`。
  */
 export function resolveLogGraphLineWidth(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return Math.max(1, alignLogGraphToPixel(scaleLogGraphMetric(LOG_GRAPH_LINE_WIDTH, rowHeight), "floor", "odd"));
 }
 
 /**
- * 获取当前行高下的选中线宽，对齐 IDEA `selectedLineThickness` 的对齐与最小差值规则。
+ * 获取当前行高下的选中线宽，保持与参考实现一致 `selectedLineThickness` 的对齐与最小差值规则。
  */
 export function resolveLogGraphSelectedLineWidth(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return Math.max(
@@ -100,49 +100,49 @@ export function resolveLogGraphSelectedLineWidth(rowHeight = LOG_GRAPH_RENDER_RO
 }
 
 /**
- * 获取当前行高下的节点圆直径，对齐 IDEA `circleDiameter = alignToInt(2 * getCircleRadius(rowHeight), FLOOR, ODD)`。
+ * 获取当前行高下的节点圆直径，保持与参考实现一致 `circleDiameter = alignToInt(2 * getCircleRadius(rowHeight), FLOOR, ODD)`。
  */
 export function resolveLogGraphCircleDiameter(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return alignLogGraphToPixel(scaleLogGraphMetric(LOG_GRAPH_CIRCLE_RADIUS * 2, rowHeight), "floor", "odd");
 }
 
 /**
- * 获取当前行高下的节点圆半径，对齐 IDEA `circleRadius = alignToInt(circleDiameter / 2, FLOOR, null)`。
+ * 获取当前行高下的节点圆半径，保持与参考实现一致 `circleRadius = alignToInt(circleDiameter / 2, FLOOR, null)`。
  */
 export function resolveLogGraphCircleRadius(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return alignLogGraphToPixel(resolveLogGraphCircleDiameter(rowHeight) / 2, "floor");
 }
 
 /**
- * 获取当前行高下的选中节点圆直径，对齐 IDEA `selectedCircleDiameter = circleDiameter + selectedLineThickness - lineThickness`。
+ * 获取当前行高下的选中节点圆直径，保持与参考实现一致 `selectedCircleDiameter = circleDiameter + selectedLineThickness - lineThickness`。
  */
 export function resolveLogGraphSelectedCircleDiameter(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return resolveLogGraphCircleDiameter(rowHeight) + resolveLogGraphSelectedLineWidth(rowHeight) - resolveLogGraphLineWidth(rowHeight);
 }
 
 /**
- * 获取当前行高下的选中节点圆半径，对齐 IDEA `selectedCircleRadius = alignToInt(selectedCircleDiameter / 2, FLOOR, null)`。
+ * 获取当前行高下的选中节点圆半径，保持与参考实现一致 `selectedCircleRadius = alignToInt(selectedCircleDiameter / 2, FLOOR, null)`。
  */
 export function resolveLogGraphSelectedCircleRadius(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return alignLogGraphToPixel(resolveLogGraphSelectedCircleDiameter(rowHeight) / 2, "floor");
 }
 
 /**
- * 获取当前行高下的图谱与文本间距，对齐 IDEA `PaintParameters.getGraphTextGap`。
+ * 获取当前行高下的图谱与文本间距，保持与参考实现一致 `PaintParameters.getGraphTextGap`。
  */
 export function resolveLogGraphTextGap(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return scaleLogGraphMetric(LOG_GRAPH_TEXT_GAP, rowHeight);
 }
 
 /**
- * 获取当前行高下的 HEAD 节点外圈半径增量，对齐 IDEA `HeadNodePainter` 中的 `delta`。
+ * 获取当前行高下的 HEAD 节点外圈半径增量，保持与参考实现一致 `HeadNodePainter` 中的 `delta`。
  */
 export function resolveLogGraphHeadRadiusDelta(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return alignLogGraphToPixel(scaleLogGraphMetric(LOG_GRAPH_HEAD_RADIUS_DELTA, rowHeight), "floor");
 }
 
 /**
- * 获取当前行高下的 HEAD 节点外圈直径，对齐 IDEA `outerCircleDiameter` 的计算方式。
+ * 获取当前行高下的 HEAD 节点外圈直径，保持与参考实现一致 `outerCircleDiameter` 的计算方式。
  */
 export function resolveLogGraphHeadOuterCircleDiameter(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return alignLogGraphToPixel(
@@ -153,28 +153,28 @@ export function resolveLogGraphHeadOuterCircleDiameter(rowHeight = LOG_GRAPH_REN
 }
 
 /**
- * 获取当前行高下的 HEAD 节点外圈半径，对齐 IDEA `outerCircleRadius`。
+ * 获取当前行高下的 HEAD 节点外圈半径，保持与参考实现一致 `outerCircleRadius`。
  */
 export function resolveLogGraphHeadOuterCircleRadius(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return alignLogGraphToPixel(resolveLogGraphHeadOuterCircleDiameter(rowHeight) / 2, "floor");
 }
 
 /**
- * 获取当前行高下的选中 HEAD 节点外圈直径，对齐 IDEA `selectedOuterCircleDiameter`。
+ * 获取当前行高下的选中 HEAD 节点外圈直径，保持与参考实现一致 `selectedOuterCircleDiameter`。
  */
 export function resolveLogGraphHeadSelectedOuterCircleDiameter(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return resolveLogGraphHeadOuterCircleDiameter(rowHeight) + resolveLogGraphSelectedLineWidth(rowHeight) - resolveLogGraphLineWidth(rowHeight);
 }
 
 /**
- * 获取当前行高下的选中 HEAD 节点外圈半径，对齐 IDEA `selectedOuterCircleRadius`。
+ * 获取当前行高下的选中 HEAD 节点外圈半径，保持与参考实现一致 `selectedOuterCircleRadius`。
  */
 export function resolveLogGraphHeadSelectedOuterCircleRadius(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return alignLogGraphToPixel(resolveLogGraphHeadSelectedOuterCircleDiameter(rowHeight) / 2, "floor");
 }
 
 /**
- * 计算 Web 端单行 SVG 中，上/下半段跨行边的拼接边界，等价于 IDEA 完整边在相邻两行中心之间的中点。
+ * 计算 Web 端单行 SVG 中，上/下半段跨行边的拼接边界，等价于参考实现完整边在相邻两行中心之间的中点。
  * 由于 Web 端每一行外层还带有 `border-b` 分隔线，若边界刚好卡在 `0 / rowHeight`，斜线会在接缝处显得断半截。
  * 这里额外向上下各延伸 `1px`，让相邻两行的半段在分隔线区域有稳定重叠。
  */
@@ -197,14 +197,14 @@ function resolveLogGraphHalfEdgeOverlap(rowHeight: number): number {
 }
 
 /**
- * 计算 terminal edge 在当前行内的收口间距，对齐 IDEA `circleRadius / 2 + 1`。
+ * 计算 terminal edge 在当前行内的收口间距，保持与参考实现一致 `circleRadius / 2 + 1`。
  */
 export function resolveLogGraphTerminalGap(rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   return resolveLogGraphCircleRadius(rowHeight) / 2 + 1;
 }
 
 /**
- * 仅按当前行实际可见的节点、轨道和边计算最右侧 lane，语义对齐 IDEA `GraphCommitCellUtil`
+ * 仅按当前行实际可见的节点、轨道和边计算最右侧 lane，语义保持与参考实现一致的 `GraphCommitCellUtil`
  * “只消费本行 print elements，不预留未来行空白”的宽度判定方式。
  * 由于 Web 端把跨行斜线拆成上下半段，这里要按“当前行真实画出的半段”估算右边界，而不是直接吃下一行的完整目标列。
  */
@@ -272,7 +272,7 @@ function resolveLogGraphBoundaryVisibleLane(fromLane: number, toLane: number): n
 }
 
 /**
- * 把 lane 上界换算成图谱宽度，保持与 IDEA `PaintParameters` 相同的元素宽和文本间隔口径。
+ * 把 lane 上界换算成图谱宽度，保持与参考实现 `PaintParameters` 相同的元素宽和文本间隔口径。
  */
 export function resolveLogGraphWidth(maxLane: number, rowHeight = LOG_GRAPH_RENDER_ROW_HEIGHT): number {
   const laneWidth = resolveLogGraphLaneWidth(rowHeight);

--- a/web/src/features/git/log-graph/model.test.ts
+++ b/web/src/features/git/log-graph/model.test.ts
@@ -237,7 +237,7 @@ describe("git log graph model", () => {
     expect(cells[4]?.color).not.toBe(trackAtDf30?.color);
   });
 
-  it("长边应像 IDEA 一样只保留两端可见段，并在截断点绘制箭头", () => {
+  it("长边应像 参考实现一样只保留两端可见段，并在截断点绘制箭头", () => {
     const items: GitLogItem[] = [
       createLogItem({ hash: "feature-head", parents: ["feature-base"], decorations: "feature/demo" }),
       createLogItem({ hash: "main-0", parents: ["main-1"], decorations: "HEAD -> master, origin/master" }),
@@ -717,7 +717,7 @@ describe("git log graph model", () => {
   it("脱敏拓扑复现：merge 首父缺失时，不应把可见次父误并入当前 fragment", () => {
     /**
      * 该夹具直接取自脱敏截图的顶部序列。
-     * 对齐 IDEA `GraphLayoutBuilder.build + walk(first child without layoutIndex)` 的完整图语义：
+     * 保持与参考实现一致 `GraphLayoutBuilder.build + walk(first child without layoutIndex)` 的完整图语义：
      * - `a0000420` 的首父 `a00002c0` 虽然当前页不可见，但仍属于当前 `feature/audio-demo` fragment；
      * - 因此可见次父 `a0000760` 必须落到独立 lane，而不是被误当成当前 fragment 的继续直线；
      * - 后续 `a0000150` 也不能再把 `a0000260` 主链挤到右侧。
@@ -766,7 +766,7 @@ describe("git log graph model", () => {
     /**
      * 该夹具直接取自脱敏提交序列中的对应时间段。
      * 当前截图里的剩余问题是 `a0000640/a0000820 -> a0000280` 两条长边在中段互换左右顺序，
-     * 导致 `a00004c0/a00002e0` 一带出现 IDEA 中不存在的 X 形折返。
+     * 导致 `a00004c0/a00002e0` 一带出现 参考实现中不存在的 X 形折返。
      * 这里要求两条兄弟长边在到达 `a0000280` 前，左右顺序必须持续稳定。
      */
     const items = [
@@ -815,7 +815,7 @@ describe("git log graph model", () => {
 
     /**
      * 兄弟长边重排后，track 自身的上半段入射列也必须同步到上一行真实列位。
-     * 否则即使左右顺序没换位，`bc76/38989/36484` 这些行仍会沿用重排前旧列位，形成 IDEA 不存在的折返尖角。
+     * 否则即使左右顺序没换位，`bc76/38989/36484` 这些行仍会沿用重排前旧列位，形成参考实现不存在的折返尖角。
      */
     const assertTrackContinuity = (previousRowIndex: number, currentRowIndex: number, sourceHashPrefix: string): void => {
       const previousTrack = (cells[previousRowIndex]?.tracks || []).find((track) =>
@@ -895,8 +895,8 @@ describe("git log graph model", () => {
   it("脱敏拓扑复现：a00003d / a000008 / a000012 这一段不应把右侧长边提前左挪", () => {
     /**
      * 该夹具直接取自脱敏仓库的对应区间。
-     * 对齐 IDEA 后：
-     * - `a000012 -> a00003d` 在 `a000008` 这一行仍应保持在节点右侧，但目标行要回到 IDEA 当前行排序后的列位；
+     * 保持与参考实现一致后：
+     * - `a000012 -> a00003d` 在 `a000008` 这一行仍应保持在节点右侧，但目标行要回到 参考实现当前行排序后的列位；
      * - `a00003d` 节点在下一行应从上一行同一条 track 的列位接入，而不是再额外右偏一列；
      * - 这段修复只影响 `a000012 -> a00003d` 这条右侧长边，不应误伤 `a000008 -> a00009e` 这一条左侧链路。
      */
@@ -947,7 +947,7 @@ describe("git log graph model", () => {
 
   it("脱敏拓扑复现：a00005c0 这一行应已经切到 a0000a70 所属颜色，而不是继续沿用右侧说明分支颜色", () => {
     /**
-     * 对齐 IDEA `PrintElementPresentationManagerImpl#getColorId`。
+     * 保持与参考实现一致的 `PrintElementPresentationManagerImpl#getColorId`。
      * `a00006c0 -> a0000a70` 这条 normal edge 在 a00005c0 行对应的可见 track，
      * 颜色必须与目标 fragment `a0000a70` 保持一致，并且不能再沿用 `a00005c0` 自身链路的颜色。
      */
@@ -1025,7 +1025,7 @@ describe("git log graph model", () => {
 
   it("脱敏拓扑复现：a0000440 与 a0000500 指向 a00007b0 的折线应从 a0000a70 行开始，而不是拖到 a00007b0 行", () => {
     /**
-     * 对齐 IDEA `GraphElementComparatorByLayoutIndex` 驱动的可见位置排序。
+     * 保持与参考实现一致的 `GraphElementComparatorByLayoutIndex` 驱动的可见位置排序。
      * 到了 `a0000a70` 这一行，指向 `a00007b0` 的两条长边已经进入“下一压缩行的目标列”。
      * 因此当前行就必须产出指向目标节点列的 `outgoingToLane`，而不是等到下一行节点处再弯折。
      */
@@ -1085,7 +1085,7 @@ describe("git log graph model", () => {
 
   it("长边 terminal 可见段在目标前一行应直接对接目标节点列", () => {
     /**
-     * 对齐 IDEA `PrintElementGeneratorImpl#createEndPositionFunction`。
+     * 保持与参考实现一致的 `PrintElementGeneratorImpl#createEndPositionFunction`。
      * 当一条长边在目标前一行首次作为 terminal 可见段出现时，
      * 当前行下半段就应直接指向下一行目标节点列，而不是额外保留一行竖线。
      */
@@ -1117,7 +1117,7 @@ describe("git log graph model", () => {
   it("脱敏拓扑复现：a0000650 -> a00004b0 -> a00006d0 为相邻 direct edge 链时，应保持同列直下", () => {
     /**
      * 该夹具直接覆盖脱敏拓扑里 `a0000270/a00008c0/a0000650/a00004b0/a00006d0` 这一段。
-     * 对齐 IDEA `PrintElementGeneratorImpl#getSortedVisibleElementsInRow` + `EdgesInRowGenerator#getEdgesInRow`：
+     * 保持与参考实现一致的 `PrintElementGeneratorImpl#getSortedVisibleElementsInRow` + `EdgesInRowGenerator#getEdgesInRow`：
      * - 相邻 normal direct edge 不会在当前行留下独立 `GraphEdge` 位置；
      * - 因而 `a0000650 -> a00004b0 -> a00006d0` 这一条短链应继续共用同一局部列位；
      * - 不能把 direct edge 误当成额外泳道，再人为压出一次折线。
@@ -1156,7 +1156,7 @@ describe("git log graph model", () => {
     expect(edge65To9f?.to).toBe(cells[8]?.lane);
   });
 
-  it("脱敏拓扑复现：wt7 截图整段可见序列应保留 IDEA 的独立轨道与双入射关系", () => {
+  it("脱敏拓扑复现：wt7 截图整段可见序列应保留参考实现的独立轨道与双入射关系", () => {
     /**
      * 该夹具直接取自脱敏截图里的同一组可见提交顺序。
      * 这里锁定三类问题：

--- a/web/src/features/git/log-graph/model.ts
+++ b/web/src/features/git/log-graph/model.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
-// Git 日志图布局参考 IntelliJ IDEA Community Edition / IntelliJ Platform 的 Apache-2.0 源码语义，并按本项目 React/TypeScript 架构重写。
+// Git 日志图布局借鉴参考实现的 Apache-2.0 源码语义，并按本项目 React/TypeScript 架构重写。
 
 import type { GitLogItem } from "../types";
 import { resolveLogGraphVisibleMaxLane } from "./metrics";
@@ -150,9 +150,9 @@ const LOG_GRAPH_VISIBLE_PART_SIZE = 1;
 export { LOG_GRAPH_BASE_WIDTH, LOG_GRAPH_LANE_WIDTH, LOG_GRAPH_TEXT_GAP, LOG_GRAPH_X_OFFSET } from "./metrics";
 
 /**
- * 按接近 IDEA `DefaultColorGenerator` 的规则，把稳定颜色种子映射成图谱颜色。
+ * 按接近参考实现 `DefaultColorGenerator` 的规则，把稳定颜色种子映射成图谱颜色。
  * - 颜色 ID 仍由上层 head-ref / fragment 语义提供；
- * - 实际 RGB/HSB 转换改成和 IDEA 同构，避免当前仓库固定调色盘与 IDEA 视觉方向明显偏离。
+ * - 实际 RGB/HSB 转换改成和参考实现同构，避免当前仓库固定调色盘与参考实现视觉方向明显偏离。
  */
 export function resolveLogGraphColor(seed: string): string {
   const normalized = String(seed || "").trim() || "default";
@@ -166,9 +166,9 @@ export function resolveLogGraphColor(seed: string): string {
 }
 
 /**
- * 把颜色种子解析成接近 IDEA `GraphColorManagerImpl` 的 color id。
+ * 把颜色种子解析成接近参考实现 `GraphColorManagerImpl` 的 color id。
  * - head fragment 仍按 ref 名字做稳定哈希；
- * - 普通 fragment 则直接复用 `fragmentIndex` 整数，避免把 `fragment:${index}` 再二次哈希后偏离 IDEA 配色。
+ * - 普通 fragment 则直接复用 `fragmentIndex` 整数，避免把 `fragment:${index}` 再二次哈希后偏离 参考实现配色。
  */
 function resolveLogGraphColorId(seed: string): number {
   const fragmentMatch = /^fragment:(-?\d+)$/.exec(seed);
@@ -178,7 +178,7 @@ function resolveLogGraphColorId(seed: string): number {
 }
 
 /**
- * 把任意整数拉回到接近 IDEA 的可用 RGB 区间，避免颜色过暗或过亮。
+ * 把任意整数拉回到接近参考实现的可用 RGB 区间，避免颜色过暗或过亮。
  */
 function rangeFix(value: number): number {
   return Math.abs(value % 100) + 70;
@@ -258,9 +258,9 @@ function hsbToHex(h: number, s: number, v: number): string {
 }
 
 /**
- * 对齐 IDEA visible graph 语义构建图谱单元。
+ * 保持与参考实现一致的 visible graph 语义构建图谱单元。
  * - `items` 是最终显示在列表里的可见提交；
- * - `graphItems` 是构建图谱时可用的完整行序列，允许保留被文本筛掉的隐藏提交，从而压缩出更接近 IDEA 的长边与 lane 延续。
+ * - `graphItems` 是构建图谱时可用的完整行序列，允许保留被文本筛掉的隐藏提交，从而压缩出更接近参考实现的长边与 lane 延续。
  */
 export function buildLogGraphCells(items: GitLogItem[], graphItems?: GitLogItem[]): GitGraphCell[] {
   const visibleItems = Array.isArray(items) ? items : [];
@@ -569,8 +569,8 @@ function createEmptyLogGraphCell(): GitGraphCell {
 
 /**
  * 把内部稳定 lane 压缩成当前行真正可见的局部位置。
- * - 保留稳定 lane 的相对顺序，用于参考上游 `GraphLayoutBuilder` 决定的左右关系；
- * - 去掉当前行并不存在的空槽，靠近 IDEA `PrintElementGenerator` 的按行位置分配语义；
+ * - 保留稳定 lane 的相对顺序，用于参考实现 `GraphLayoutBuilder` 决定的左右关系；
+ * - 去掉当前行并不存在的空槽，靠近参考实现 `PrintElementGenerator` 的按行位置分配语义；
  * - 上下半段连线的“另一行位置”分别映射到相邻可见行，避免继续使用全局 lane 导致宽度和斜线都被拉大。
  */
 function compressLogGraphCells(cells: GitGraphCell[]): GitGraphCell[] {
@@ -588,7 +588,7 @@ function compressLogGraphCells(cells: GitGraphCell[]): GitGraphCell[] {
 
 /**
  * 为单个可见行建立“图元 -> 当前行局部位置”的映射。
- * - 对齐 IDEA `PrintElementGeneratorImpl + GraphElementComparatorByLayoutIndex`，位置顺序按 node/edge 图元排序决定，而不是简单按唯一 lane 去重；
+ * - 保持与参考实现一致的 `PrintElementGeneratorImpl + GraphElementComparatorByLayoutIndex`，位置顺序按 node/edge 图元排序决定，而不是简单按唯一 lane 去重；
  * - 这样同一行里“节点 + 经过的边”即使共享稳定 lane，也仍能分配到不同的局部位置，避免被提前压成一列。
  */
 function buildLogGraphPositionMap(cell: GitGraphCell, rowIndex: number): GitGraphPositionMap {
@@ -632,11 +632,11 @@ function buildLogGraphPositionMap(cell: GitGraphCell, rowIndex: number): GitGrap
 
 /**
  * 把当前节点与所有过路线投影成一组可排序图元。
- * 对齐 IDEA `PrintElementGeneratorImpl#getSortedVisibleElementsInRow`：
+ * 保持与参考实现一致的 `PrintElementGeneratorImpl#getSortedVisibleElementsInRow`：
  * - 当前行包含节点本身；
  * - 包含从当前行向下穿过本行的 normal edge / track；
  * - 不包含“从上一行结束在当前节点”的 normal incoming edge；
- * - IDEA 的相邻 normal direct edge 不会作为独立 `GraphEdge` 留在 `visible elements` 里；
+ * - 参考实现的相邻 normal direct edge 不会作为独立 `GraphEdge` 留在 `visible elements` 里；
  *   因此这里只在当前行几乎没有别的可见图元时，补一个最小 `reserved-edge` 占位，
  *   用来保住下一行目标列，避免过滤隐藏提交后把弯折错误提前到上一行。
  */
@@ -685,7 +685,7 @@ function createLogGraphTrackPositionElement(
 
 /**
  * 把当前节点发出的非垂直边转成“仅占位”的排序图元。
- * 该图元不是 IDEA 原始 `visible elements` 的一部分，只在当前行缺少可见图元时作为压缩补偿使用，
+ * 该图元不是 参考实现原始 `visible elements` 的一部分，只在当前行缺少可见图元时作为压缩补偿使用，
  * 不参与相邻可见行的精确对接，避免把相邻 direct edge 错当成一条独立泳道。
  */
 function createLogGraphReservedEdgePositionElement(
@@ -715,7 +715,7 @@ function createLogGraphReservedEdgePositionElement(
 }
 
 /**
- * 按 IDEA `GraphElementComparatorByLayoutIndex` 的思路比较当前行两个图元的先后位置。
+ * 按参考实现 `GraphElementComparatorByLayoutIndex` 的思路比较当前行两个图元的先后位置。
  */
 function compareLogGraphPositionElements(left: GitGraphPositionElement, right: GitGraphPositionElement): number {
   if (left.kind !== "node" && right.kind !== "node")
@@ -729,7 +729,7 @@ function compareLogGraphPositionElements(left: GitGraphPositionElement, right: G
 
 /**
  * 比较一条过路线与一个节点的左右先后。
- * 规则直接对齐 IDEA `compare2(edge, node)`：
+ * 规则直接保持与参考实现一致 `compare2(edge, node)`：
  * 先看 edge 两端更靠右的 layout index；若相同，再用 edge 的 sourceRow 与节点行号断平。
  */
 function compareLogGraphTrackWithNode(
@@ -743,7 +743,7 @@ function compareLogGraphTrackWithNode(
 
 /**
  * 比较两条过路线的左右先后。
- * 规则对应 IDEA `GraphElementComparatorByLayoutIndex.compare(edge1, edge2)` 的 normal edge 分支。
+ * 规则对应参考实现 `GraphElementComparatorByLayoutIndex.compare(edge1, edge2)` 的 normal edge 分支。
  */
 function compareLogGraphTrackElements(
   left: Extract<GitGraphPositionElement, { kind: "track" | "reserved-edge" }>,
@@ -1033,10 +1033,10 @@ function synchronizeCompressedLogGraphNeighborGeometry(cells: GitGraphCell[]): v
       }
       if (String(nextCell.commitHash || "").trim() !== targetHash) continue;
       /**
-       * 对齐 IDEA `PrintElementGeneratorImpl#createEndPositionFunction`，
+       * 保持与参考实现一致的 `PrintElementGeneratorImpl#createEndPositionFunction`，
        * 当当前可见 track 的下一行就是目标节点时，本行下半段应直接对接目标节点列。
        * 即便这是长边靠近目标端的 terminal 可见段，也不能再额外保留一行竖线，
-       * 否则会把 IDEA 里的单段斜线错误拖成“先直后斜”。
+       * 否则会把 参考实现里的单段斜线错误拖成“先直后斜”。
        */
       track.outgoingToLane = nextCell.lane;
       nextCell.incomingEdges = appendLogGraphIncomingEdges(nextCell.incomingEdges, {
@@ -1067,7 +1067,7 @@ function resetCompressedLogGraphIncomingGeometry(cells: GitGraphCell[]): void {
 /**
  * 当同一条长边在上一行与当前行保持同列，而下一行已确定要向左收一列时，
  * 若当前行左侧目标列为空，则允许当前行提前完成这一步左收。
- * 这样可对齐 IDEA 里“连续长边在真正空出来的那一行就开始折”的形态，
+ * 这样可保持与参考实现一致的“连续长边在真正空出来的那一行就开始折”的形态，
  * 避免把折角拖迟一行后表现成你截图里 `9d7d9d3d` 一带的直线。
  */
 function advanceCompressedLogGraphLongTrackCorners(cells: GitGraphCell[]): void {
@@ -1215,7 +1215,7 @@ function compactCompressedLogGraphTrackGroupLeft(currentGroup: GitGraphTrack[], 
 
 /**
  * 压缩当前行时，先按当前行位置图里的局部顺序处理 track。
- * 这样长边会先占住 IDEA 对齐后的可见位置，再基于上一行做最小让位，
+ * 这样长边会先占住与参考实现一致的可见位置，再基于上一行做最小让位，
  * 避免仅因原始数组顺序不同而在当前行中途换位。
  */
 function compareCompressedLogGraphTrackProcessingOrder(
@@ -1245,7 +1245,7 @@ function compareCompressedLogGraphTrackProcessingOrder(
 
 /**
  * 比较同一目标 track 的稳定来源顺序。
- * 优先使用来源节点的稳定列位 `sourceLane`，再用来源提交哈希兜底，尽量贴近 IDEA 的稳定布局排序。
+ * 优先使用来源节点的稳定列位 `sourceLane`，再用来源提交哈希兜底，尽量贴近参考实现的稳定布局排序。
  */
 function compareCompressedLogGraphTrackStableOrder(left: GitGraphTrack, right: GitGraphTrack): number {
   const leftSourceLaneValue = left.sourceLane;
@@ -1322,7 +1322,7 @@ function resolveLogGraphIncomingLanesFromEdges(
 
 /**
  * 解析多行 track 在当前行的精确列位。
- * 对齐 IDEA 后，这里优先保留当前行已计算出的 edge 位置，仅在目标列已被占用时才做最小让位。
+ * 保持与参考实现一致后，这里优先保留当前行已计算出的 edge 位置，仅在目标列已被占用时才做最小让位。
  */
 function resolveCompressedLogGraphTrackCurrentLane(
   track: GitGraphTrack,
@@ -1423,7 +1423,7 @@ function resolveCompressedLogGraphTrackFreeLane(
 
 /**
  * 计算当前节点在上一可见行里的所有对接位置。
- * 若上一行里存在指向当前提交的 track，则优先复用这些 track 的局部位置；这样能对齐 IDEA 的 `positionInOtherRow`。
+ * 若上一行里存在指向当前提交的 track，则优先复用这些 track 的局部位置；这样能保持与参考实现一致的 `positionInOtherRow`。
  */
 function resolveCompressedLogGraphNodeIncomingLanes(
   hash: string,
@@ -1459,7 +1459,7 @@ function resolveCompressedLogGraphNodeIncomingLanes(
 
 /**
  * 当上一可见行为当前节点保留了 outgoing reserved-edge 位置时，优先把节点对齐到该停靠列。
- * 这样可以保住 IDEA 里“分支先竖直延续，再在真正需要的行发生弯折”的拓扑形态。
+ * 这样可以保住 参考实现里“分支先竖直延续，再在真正需要的行发生弯折”的拓扑形态。
  * 若上一行并未给当前节点保留 reserved-edge 停靠位，则当入射列与当前行排序列冲突时，优先采用当前行排序列。
  * 这样可以避免把“应在当前行发生的弯折”错误拖到下一行。
  */
@@ -1658,7 +1658,7 @@ function resolveCompressedLogGraphMaxOtherPosition(
 }
 
 /**
- * 按输入行序列构建稳定 lane 布局，参考上游 `GraphLayoutBuilder` 的“先排序 head，再沿 down 节点 DFS 分配 layoutIndex”语义。
+ * 按输入行序列构建稳定 lane 布局，参考实现 `GraphLayoutBuilder` 的“先排序 head，再沿 down 节点 DFS 分配 layoutIndex”语义。
  */
 function buildVisibleGraphLayout(items: GitLogItem[]): VisibleGraphLayout {
   const topology = buildVisibleGraphTopology(items);
@@ -1711,7 +1711,7 @@ function buildVisibleGraphTopology(items: GitLogItem[]): VisibleGraphTopology {
 }
 
 /**
- * 对可见图执行稳定 `layoutIndex` 分配；head 顺序优先对齐 IDEA 的 Git 分支布局比较器，再回退到可见行顺序保持稳定。
+ * 对可见图执行稳定 `layoutIndex` 分配；head 顺序优先保持与参考实现一致的 Git 分支布局比较器，再回退到可见行顺序保持稳定。
  */
 function assignVisibleGraphLayoutIndices(items: GitLogItem[], topology: VisibleGraphTopology): number[] {
   const layoutIndexByRow = Array(topology.hashByRow.length).fill(0);
@@ -1733,7 +1733,7 @@ function assignVisibleGraphLayoutIndices(items: GitLogItem[], topology: VisibleG
 
 /**
  * 收集参与稳定 layout 遍历的起点集合。
- * 对齐 IDEA `GraphLayoutBuilder.build(graph, branches, comparator)`：
+ * 保持与参考实现一致 `GraphLayoutBuilder.build(graph, branches, comparator)`：
  * - 既包含真正没有上游边的 graph heads；
  * - 也包含所有带 branch ref 的节点，避免仅按图头遍历时把重要分支压回主干。
  */
@@ -1747,7 +1747,7 @@ function resolveVisibleGraphLayoutStartRows(items: GitLogItem[], topology: Visib
 }
 
 /**
- * 按接近 IDEA `HeadCommitsComparator` 的规则为布局起点排序。
+ * 按接近参考实现 `HeadCommitsComparator` 的规则为布局起点排序。
  * 真正的 graph head 才按 branch ref 比较；非 head 的 branch 起点仍参与遍历，但排序时回退到行号。
  */
 function sortVisibleGraphHeadRows(items: GitLogItem[], topology: VisibleGraphTopology, headRows: number[]): number[] {
@@ -1757,7 +1757,7 @@ function sortVisibleGraphHeadRows(items: GitLogItem[], topology: VisibleGraphTop
 /**
  * 比较两个布局起点的优先级。
  * - 若两边都是真正的 graph head，则按代表 ref 的优先级与名称比较；
- * - 只要其中一边拿不到 `refForHeadCommit`，就按 IDEA 语义回退，使其排在真实 head 之后；
+ * - 只要其中一边拿不到 `refForHeadCommit`，就按参考实现语义回退，使其排在真实 head 之后；
  * - 双方都拿不到 ref 时回退到行号，保持排序稳定。
  */
 function compareVisibleGraphHeadRows(items: GitLogItem[], topology: VisibleGraphTopology, leftRow: number, rightRow: number): number {
@@ -1776,7 +1776,7 @@ function compareVisibleGraphHeadRows(items: GitLogItem[], topology: VisibleGraph
 }
 
 /**
- * 解析某个布局起点在 IDEA `HeadCommitsComparator` 语义下的排序引用。
+ * 解析某个布局起点在参考实现 `HeadCommitsComparator` 语义下的排序引用。
  * 只有真正没有上游边的 graph head 才能拿到 `refForHeadCommit`；非 head branch 起点统一回退为 `null`。
  */
 function resolveVisibleGraphStartRowHeadRefToken(
@@ -1795,7 +1795,7 @@ function resolveVisibleGraphStartRowHeadRefToken(
 }
 
 /**
- * 判断某行是否带有会参与 IDEA branch layout 排序的分支引用。
+ * 判断某行是否带有会参与参考实现 branch layout 排序的分支引用。
  * 这里只保留本地/远端 branch 类 ref；`tag`、`HEAD` 本身不作为 `branchesCommitId` 起点。
  */
 function hasVisibleGraphBranchLayoutRef(item?: GitLogItem | null): boolean {
@@ -1803,7 +1803,7 @@ function hasVisibleGraphBranchLayoutRef(item?: GitLogItem | null): boolean {
 }
 
 /**
- * 为单个 head 选择参与布局排序的代表引用，语义上对齐 IDEA 的“同一 head 取 branchLayoutComparator 最小 ref”。
+ * 为单个 head 选择参与布局排序的代表引用，语义上保持与参考实现一致的“同一 head 取 branchLayoutComparator 最小 ref”。
  */
 function resolveLogGraphHeadRefToken(item?: GitLogItem | null): GitLogGraphHeadRefToken {
   const candidates = extractLogGraphHeadRefTokens(String(item?.decorations || ""));
@@ -1816,7 +1816,7 @@ function resolveLogGraphHeadRefToken(item?: GitLogItem | null): GitLogGraphHeadR
 }
 
 /**
- * 按 IDEA `RefsModel.getRefForHeadCommit + branchLayoutComparator` 的语义，
+ * 按参考实现 `RefsModel.getRefForHeadCommit + branchLayoutComparator` 的语义，
  * 从 decorations 中挑出当前提交的最佳 ref 原始名字，供颜色种子直接复用。
  */
 function resolveLogGraphBestRefName(decorationsRaw: string): string {
@@ -1830,7 +1830,7 @@ function resolveLogGraphBestRefName(decorationsRaw: string): string {
 }
 
 /**
- * 按接近 IDEA `GitReference.REFS_NAMES_COMPARATOR` 的自然排序比较引用名。
+ * 按接近参考实现 `GitReference.REFS_NAMES_COMPARATOR` 的自然排序比较引用名。
  * 这里保留现有的 `numeric` 自然排序，但先补一层“ASCII 领先字符优先”。
  * 否则中文分支名在部分宿主环境里会被排到 `cf-wt/...` 这类 ASCII 工作分支之前，
  * 进而把整条支线错误挤到左侧泳道。
@@ -1868,7 +1868,7 @@ function extractLogGraphHeadRefTokens(decorationsRaw: string): GitLogGraphHeadRe
 
 /**
  * 把 decorations 展开成同时保留“排序语义”和“原始名字”的 ref 候选。
- * 排序仍走归一化后的名字，颜色种子则复用原始名字，避免大小写与 decoration 语法破坏 IDEA 的颜色归属。
+ * 排序仍走归一化后的名字，颜色种子则复用原始名字，避免大小写与 decoration 语法破坏参考实现的颜色归属。
  */
 function extractLogGraphRawRefCandidates(decorationsRaw: string): GitLogGraphRawRefCandidate[] {
   const tokens: GitLogGraphRawRefCandidate[] = [];
@@ -1898,7 +1898,7 @@ function extractLogGraphRawRefCandidates(decorationsRaw: string): GitLogGraphRaw
 }
 
 /**
- * 把普通引用名映射到接近 IDEA Git 分支布局比较器的优先级，优先级越小越靠左。
+ * 把普通引用名映射到接近参考实现 Git 分支布局比较器的优先级，优先级越小越靠左。
  */
 function resolveLogGraphNamedRefToken(refNameRaw: string): GitLogGraphRawRefCandidate {
   const refName = String(refNameRaw || "").trim();
@@ -1911,7 +1911,7 @@ function resolveLogGraphNamedRefToken(refNameRaw: string): GitLogGraphRawRefCand
 }
 
 /**
- * 按远端名提示判断引用是否更像远端分支；这里优先兼容 `origin/*`、`upstream/*` 等 IDEA 常见场景，避免把主干远端误排到本地分支之后。
+ * 按远端名提示判断引用是否更像远端分支；这里优先兼容 `origin/*`、`upstream/*` 等参考实现常见场景，避免把主干远端误排到本地分支之后。
  */
 function isLogGraphRemoteRef(refName: string): boolean {
   const prefix = refName.split("/")[0] || "";
@@ -1919,7 +1919,7 @@ function isLogGraphRemoteRef(refName: string): boolean {
 }
 
 /**
- * 按 IDEA `walk + first child without layoutIndex` 规则遍历可见图，确保公共祖先不会被后续分支改写到新的 lane。
+ * 按参考实现 `walk + first child without layoutIndex` 规则遍历可见图，确保公共祖先不会被后续分支改写到新的 lane。
  */
 function walkVisibleGraphLayout(
   downRows: number[][],
@@ -1984,7 +1984,7 @@ function normalizeVisibleGraphLayout(topology: VisibleGraphTopology, layoutIndex
 
 /**
  * 提取提交自身直接携带的颜色种子。
- * 对齐 IDEA `GraphColorManagerImpl`，head fragment 的颜色 ID 直接来自“最佳 ref 原始名字”的哈希，
+ * 保持与参考实现一致的 `GraphColorManagerImpl`，head fragment 的颜色 ID 直接来自“最佳 ref 原始名字”的哈希，
  * 这里不再附加 `local:` / `ref:` 之类的前缀，避免同名分支仅因 decoration 语法不同而取到不同颜色。
  * 另外，主干远端 `origin/master|main` / `upstream/master|main` 会归一到本地等价名字，
  * 避免远端前缀把主干颜色推到与旁侧远端支线过于接近的碰撞色。
@@ -1995,7 +1995,7 @@ function resolveLogGraphDirectColorSeed(item?: GitLogItem | null): string {
 
 /**
  * 归一化直接 ref 的颜色种子。
- * - 普通 ref 继续保留原始名字，对齐 IDEA 以 ref 名决定颜色 ID 的语义；
+ * - 普通 ref 继续保留原始名字，保持与参考实现一致，以 ref 名决定颜色 ID 的语义；
  * - 仅对主干远端分支做“远端名 -> 本地主干名”的收敛，让 `origin/master` 与 `master`
  *   保持同色，同时避免它与其它 `origin/*` 远端支线更容易撞到同一颜色。
  */
@@ -2009,7 +2009,7 @@ function normalizeLogGraphDirectColorSeed(seed: string): string {
 }
 
 /**
- * 按 IDEA `GraphColorManagerImpl + GraphColorGetterByHead` 的语义生成 fragment 颜色种子。
+ * 按参考实现 `GraphColorManagerImpl + GraphColorGetterByHead` 的语义生成 fragment 颜色种子。
  * - 头 fragment 使用 head ref 名字；
  * - 其余 fragment 主要由 fragment lane 决定；
  * - 若上下文还不足，则回退到调用方传入的稳定种子。
@@ -2034,7 +2034,7 @@ function resolveLogGraphColorSeed(item: GitLogItem, fallbackSeed: string): strin
 
 /**
  * 从所有可见来源里选出当前共享段应继承的支配 head。
- * 优先选择布局更靠左的 head；若相同，则优先较新的来源，尽量贴近 IDEA “更重要 branch 支配共享子图颜色”的语义。
+ * 优先选择布局更靠左的 head；若相同，则优先较新的来源，尽量贴近参考实现 “更重要 branch 支配共享子图颜色”的语义。
  */
 function resolveLogGraphDominantSourceHead(
   sources: GitGraphActiveSource[],
@@ -2076,7 +2076,7 @@ function resolveLogGraphActiveLaneColorSeed(entry: ActiveGraphLane, lane: number
 
 /**
  * 从活跃 lane 中提取当前行真正需要显示的过路线。
- * - 对齐 IDEA `PrintElementGeneratorImpl`，超过阈值的长边只显示两端可见段，中间隐藏；
+ * - 保持与参考实现一致的 `PrintElementGeneratorImpl`，超过阈值的长边只显示两端可见段，中间隐藏；
  * - 截断点通过 track 的 `incoming/outgoing + terminal + arrow` 状态传给渲染层，避免把整条长边一直画到屏幕下方。
  */
 function buildLogGraphTracks(
@@ -2149,9 +2149,9 @@ function buildLogGraphTracks(
 
 /**
  * 为过路线选择当前行的显示位置。
- * - 对齐 IDEA `GraphElementComparatorByLayoutIndex` 的核心规则：边在排序时优先锚定到“两端更靠右的 layout index”；
+ * - 保持与参考实现一致的 `GraphElementComparatorByLayoutIndex` 核心规则：边在排序时优先锚定到“两端更靠右的 layout index”；
  * - 因此回并到左侧主干时，中间几行的过路线要继续停留在右侧列，直到真正接入目标节点那一行再斜向落回主干；
- * - IDEA 的 `PrintElement` 允许边和节点处于同一列，边会在节点下方绘制，因此这里不再把冲突边强行右移到新列。
+ * - 参考实现的 `PrintElement` 允许边和节点处于同一列，边会在节点下方绘制，因此这里不再把冲突边强行右移到新列。
  */
 function resolveLogGraphTrackLane(
   entry: ActiveGraphLane,
@@ -2388,7 +2388,7 @@ function isLogGraphLongEdge(sourceRow: number, targetRow: number): boolean {
 
 /**
  * 判断指定行是否应该显示这条边。
- * 语义对齐 IDEA `isEdgeVisibleInRow`：短边全程可见，长边只显示靠近两端的 `visiblePartSize` 行。
+ * 语义保持与参考实现一致 `isEdgeVisibleInRow`：短边全程可见，长边只显示靠近两端的 `visiblePartSize` 行。
  */
 function isLogGraphEdgeVisibleInRow(sourceRow: number, targetRow: number, currentRow: number): boolean {
   if (currentRow <= sourceRow || currentRow >= targetRow) return false;

--- a/web/src/features/git/log-style/log-row-style.ts
+++ b/web/src/features/git/log-style/log-row-style.ts
@@ -9,7 +9,7 @@ export type GitLogRowStyle = {
 };
 
 /**
- * 判断当前日志视图是否应启用 current branch 高亮，语义对齐 IDEA `CurrentBranchHighlighter.update()`。
+ * 判断当前日志视图是否应启用 current branch 高亮，语义保持与参考实现一致 `CurrentBranchHighlighter.update()`。
  */
 export function shouldHighlightCurrentBranch(args: {
   currentBranch: string;

--- a/web/src/features/git/monaco-git-diff.tsx
+++ b/web/src/features/git/monaco-git-diff.tsx
@@ -206,7 +206,7 @@ function resolveEditorLineHeight(
 }
 
 /**
- * 把复选框定位到行号前侧 gutter，优先居中落在 glyph margin 内，和 IDEA 的左侧勾选列保持一致。
+ * 把复选框定位到行号前侧 gutter，优先居中落在 glyph margin 内，和参考实现的左侧勾选列保持一致。
  */
 function resolveEditorCheckboxLeft(args: {
   rootNode: HTMLDivElement;

--- a/web/src/features/git/pull-dialog.tsx
+++ b/web/src/features/git/pull-dialog.tsx
@@ -112,7 +112,7 @@ function buildPullOptionMeta(gt: GitTranslate): Record<GitPullDialogOptionKey, {
 }
 
 /**
- * 判断候选 Pull 选项是否与当前模式及已选项兼容，规则对齐 IDEA `GitPullOption.isOptionSuitable()`。
+ * 判断候选 Pull 选项是否与当前模式及已选项兼容，规则保持与参考实现一致的 `GitPullOption.isOptionSuitable()`。
  */
 function resolvePullOptionAvailability(
   mode: GitPullDialogValue["mode"],
@@ -182,7 +182,7 @@ function getPullModeMeta(mode: GitPullDialogValue["mode"], gt: GitTranslate): { 
 }
 
 /**
- * 生成 Pull 对话框标题；有当前分支时对齐 IDEA 的“拉取到 <branch>”语义。
+ * 生成 Pull 对话框标题；有当前分支时保持与参考实现一致的“拉取到 <branch>”语义。
  */
 function buildPullDialogTitle(currentBranchName: string | undefined, gt: GitTranslate): string {
   const branchName = String(currentBranchName || "").trim();
@@ -192,7 +192,7 @@ function buildPullDialogTitle(currentBranchName: string | undefined, gt: GitTran
 }
 
 /**
- * 渲染独立 Pull 对话框，采用更接近 IDEA 的命令式布局与层级。
+ * 渲染独立 Pull 对话框，采用更接近参考实现的命令式布局与层级。
  */
 export function PullDialog(props: GitPullDialogProps): JSX.Element | null {
   const { t } = useTranslation(["git", "common"]);

--- a/web/src/features/git/rollback-browser-model.test.ts
+++ b/web/src/features/git/rollback-browser-model.test.ts
@@ -77,7 +77,7 @@ describe("rollback-browser-model", () => {
     });
   });
 
-  it("扁平模式应按 IDEA 风格优先使用文件名排序", () => {
+  it("扁平模式应按文件名优先规则排序", () => {
     const entries = buildRollbackBrowserEntriesFromStatusEntries([
       {
         path: "web/src/zeta.ts",

--- a/web/src/features/git/rollback-browser-model.ts
+++ b/web/src/features/git/rollback-browser-model.ts
@@ -79,7 +79,7 @@ function resolveRollbackDirectory(filePath: string, translate?: GitTranslate): s
 }
 
 /**
- * 按 IDEA flattened comparator 语义比较路径；先比文件名，再回落到完整层级路径。
+ * 按参考实现 flattened comparator 语义比较路径；先比文件名，再回落到完整层级路径。
  */
 function compareRollbackPaths(leftPath: string, rightPath: string, flattened: boolean): number {
   if (flattened) {
@@ -97,7 +97,7 @@ function compareRollbackPaths(leftPath: string, rightPath: string, flattened: bo
 }
 
 /**
- * 按 IDEA rollback browser 的扁平/树形比较器统一排序条目，避免组件层散落重复排序规则。
+ * 按参考实现 rollback browser 的扁平/树形比较器统一排序条目，避免组件层散落重复排序规则。
  */
 export function sortRollbackBrowserEntries(
   entries: GitRollbackBrowserEntry[],
@@ -177,7 +177,7 @@ function createPathOnlyRollbackEntry(filePath: string, translate?: GitTranslate)
 }
 
 /**
- * 规范化 rollback viewer 允许的 grouping key 集；当前仅开放 IDEA 同源的目录分组。
+ * 规范化 rollback viewer 允许的 grouping key 集；当前仅开放与参考实现同源的目录分组。
  */
 export function normalizeRollbackBrowserGroupingKeys(
   groupingKeysInput: ReadonlyArray<GitRollbackBrowserGroupingKey> | null | undefined,
@@ -242,7 +242,7 @@ export function buildOperationProblemRollbackEntries(
 }
 
 /**
- * 构建 rollback viewer 的线性渲染行；目录分组开启时复用提交树目录折叠逻辑，否则走 IDEA 风格扁平列表。
+ * 构建 rollback viewer 的线性渲染行；目录分组开启时复用提交树目录折叠逻辑，否则走 参考实现风格扁平列表。
  */
 export function buildRollbackBrowserRows(
   entries: GitRollbackBrowserEntry[],

--- a/web/src/features/git/saved-changes-actions.ts
+++ b/web/src/features/git/saved-changes-actions.ts
@@ -181,7 +181,7 @@ export function consumePendingSavedChangesOpenRequest(currentRepoRoot: string): 
 }
 
 /**
- * 按当前选择、当前更改列表与当前可见受影响变更构建手动搁置载荷，对齐 IDEA 的手动 shelf 入口语义。
+ * 按当前选择、当前更改列表与当前可见受影响变更构建手动搁置载荷，保持与参考实现一致的手动 shelf 入口语义。
  */
 export function buildManualShelveSelection(args: {
   selectedEntries: GitStatusEntry[];

--- a/web/src/features/git/shelf-browser-model.test.ts
+++ b/web/src/features/git/shelf-browser-model.test.ts
@@ -63,7 +63,7 @@ describe("shelf-browser-model", () => {
     expect(rows.find((row) => row.kind === "shelf" && row.shelf.ref === "shelf@{deleted}")?.depth).toBe(1);
   });
 
-  it("扁平模式应按 IDEA 风格优先按文件名排序", () => {
+  it("扁平模式应按参考实现风格优先按文件名排序", () => {
     const rows = buildShelfBrowserRows({
       items: [
         createShelfItem({

--- a/web/src/features/git/shelf-browser-model.ts
+++ b/web/src/features/git/shelf-browser-model.ts
@@ -92,7 +92,7 @@ export function resolveShelfBrowserDirectory(pathText: string, translate?: GitTr
 }
 
 /**
- * 规范化 shelf browser 的 grouping key；当前仅开放 IDEA 同源的目录分组。
+ * 规范化 shelf browser 的 grouping key；当前仅开放与参考实现同源的目录分组。
  */
 export function normalizeShelfBrowserGroupingKeys(
   groupingKeysInput: ReadonlyArray<GitShelfBrowserGroupingKey> | null | undefined,
@@ -116,7 +116,7 @@ function toShelfBrowserCommitGroupingKeys(
 }
 
 /**
- * 按 IDEA shelf tree 的扁平比较器比较路径；无目录分组时先按文件名，再回落完整路径。
+ * 按参考实现 shelf tree 的扁平比较器比较路径；无目录分组时先按文件名，再回落完整路径。
  */
 function compareShelfPaths(leftPath: string, rightPath: string, flattened: boolean): number {
   if (flattened) {
@@ -284,7 +284,7 @@ function isVisibleActiveShelf(shelf: GitShelfItem, showRecycled: boolean): boole
 }
 
 /**
- * 构建 shelf browser 的线性渲染行，对齐 IDEA 的活动列表 + 最近删除标签结构。
+ * 构建 shelf browser 的线性渲染行，保持与参考实现一致的活动列表 + 最近删除标签结构。
  */
 export function buildShelfBrowserRows(args: {
   items: GitShelfItem[];

--- a/web/src/features/git/shelf-browser-pane.test.tsx
+++ b/web/src/features/git/shelf-browser-pane.test.tsx
@@ -183,7 +183,7 @@ describe("ShelfBrowserPane", () => {
     }
   });
 
-  it("活动 shelf 删除语义应统一显示为 IDEA 对齐的删除文案", async () => {
+  it("活动 shelf 删除语义应统一显示为 与参考实现一致的删除文案", async () => {
     const mounted = createMountedRoot();
     const onRecycleShelf = vi.fn();
     try {
@@ -213,7 +213,7 @@ describe("ShelfBrowserPane", () => {
     }
   });
 
-  it("shelf 右键菜单应补齐 IDEA 对齐的差异与补丁动作", async () => {
+  it("shelf 右键菜单应补齐与参考实现一致的差异与补丁动作", async () => {
     const mounted = createMountedRoot();
     const onRunDiffAction = vi.fn();
     const onCreatePatch = vi.fn();

--- a/web/src/features/git/shelf-browser-pane.tsx
+++ b/web/src/features/git/shelf-browser-pane.tsx
@@ -159,7 +159,7 @@ function resolveShelfStateBadgeLabel(state: GitShelfItem["state"], gt?: GitTrans
 }
 
 /**
- * 渲染 shelf 树浏览器，对齐 IDEA 的树形 shelf / recently deleted / directory grouping 交互。
+ * 渲染 shelf 树浏览器，保持与参考实现一致的树形 shelf / recently deleted / directory grouping 交互。
  */
 export function ShelfBrowserPane(props: ShelfBrowserPaneProps): JSX.Element {
   const { t } = useTranslation(["git", "common"]);
@@ -254,7 +254,7 @@ export function ShelfBrowserPane(props: ShelfBrowserPaneProps): JSX.Element {
   }, [menu, rows]);
 
   /**
-   * 切换目录/shelf/tag 节点展开态；未显式记录的节点默认视为展开，对齐 IDEA 初始展开语义。
+   * 切换目录/shelf/tag 节点展开态；未显式记录的节点默认视为展开，保持与参考实现一致的初始展开语义。
    */
   const toggleExpanded = (rowKey: string): void => {
     setExpandedRows((prev) => ({
@@ -313,7 +313,7 @@ export function ShelfBrowserPane(props: ShelfBrowserPaneProps): JSX.Element {
   };
 
   /**
-   * 执行 shelf 的 Create Patch / Copy Patch；路径组选区统一交给上层聚合导出，保持和 IDEA 菜单语义一致。
+   * 执行 shelf 的 Create Patch / Copy Patch；路径组选区统一交给上层聚合导出，保持和参考实现菜单语义一致。
    */
   const runCreatePatchAction = (
     row: GitShelfBrowserRow | null | undefined,
@@ -340,14 +340,14 @@ export function ShelfBrowserPane(props: ShelfBrowserPaneProps): JSX.Element {
   };
 
   /**
-   * 切换是否显示回收区，对齐 IDEA 的 Show/Hide Recycled 独立开关。
+   * 切换是否显示回收区，保持与参考实现一致的 Show/Hide Recycled 独立开关。
    */
   const toggleShowRecycled = (): void => {
     onViewStateChange({ showRecycled: !viewState.showRecycled });
   };
 
   /**
-   * 切换按目录分组开关，保持与 IDEA 分组菜单里的目录维度一致。
+   * 切换按目录分组开关，保持与参考实现分组菜单里的目录维度一致。
    */
   const toggleDirectoryGrouping = (): void => {
     onViewStateChange({ groupByDirectory: !viewState.groupByDirectory });

--- a/web/src/features/git/update/conflicts-panel-state.ts
+++ b/web/src/features/git/update/conflicts-panel-state.ts
@@ -17,7 +17,7 @@ type StorageLike = Pick<Storage, "getItem" | "setItem">;
 const CONFLICTS_PANEL_STORAGE_KEY = "cf.gitWorkbench.conflicts.panel.v1";
 
 /**
- * 返回冲突面板默认偏好；gate 默认开启，贴近 IDEA 默认自动显隐的行为。
+ * 返回冲突面板默认偏好；门控默认开启，贴近参考实现默认自动显隐的行为。
  */
 export function createDefaultConflictsPanelPreferences(): ConflictsPanelPreferences {
   return {

--- a/web/src/features/git/update/fix-tracked-branch-dialog.tsx
+++ b/web/src/features/git/update/fix-tracked-branch-dialog.tsx
@@ -99,7 +99,7 @@ function getUpdateMethodLabel(
 }
 
 /**
- * 渲染 tracked branch 修复对话框，仅承载 IDEA 主路径的 upstream 修复与 Merge/Rebase 选择。
+ * 渲染 tracked branch 修复对话框，仅承载 参考实现主路径的 upstream 修复与 Merge/Rebase 选择。
  */
 export function FixTrackedBranchDialog(props: FixTrackedBranchDialogProps): JSX.Element | null {
   const { t } = useTranslation("git");

--- a/web/src/features/git/update/multiple-file-merge-dialog.tsx
+++ b/web/src/features/git/update/multiple-file-merge-dialog.tsx
@@ -204,7 +204,7 @@ function buildMergeConflictPrimaryActionDescription(args: {
 }
 
 /**
- * 把当前仓库冲突状态翻译为顶部提示文案，尽量贴近 IDEA resolver 的说明密度。
+ * 把当前仓库冲突状态翻译为顶部提示文案，尽量贴近参考实现 resolver 的说明密度。
  */
 function buildMergeConflictScopeHint(snapshot: GitConflictMergeSessionSnapshot | null, resolveLabel?: LabelResolver): string {
   if (snapshot?.reverseSides) {
@@ -228,7 +228,7 @@ function formatMergeConflictDirectorySummary(fileCount: number, resolveLabel?: L
 }
 
 /**
- * 渲染接近 IDEA MultipleFileMergeDialog 的多文件冲突总线 UI，统一承载表格、目录分组与主操作按钮。
+ * 渲染接近参考实现的 MultipleFileMergeDialog 的多文件冲突总线 UI，统一承载表格、目录分组与主操作按钮。
  */
 export function MultipleFileMergeDialog(props: MultipleFileMergeDialogProps): React.ReactElement {
   const { t } = useTranslation("git");

--- a/web/src/features/git/update/smart-operation-dialog.tsx
+++ b/web/src/features/git/update/smart-operation-dialog.tsx
@@ -49,7 +49,7 @@ function getProblemActionVariant(action: GitUpdateOperationProblem["actions"][nu
 }
 
 /**
- * 按操作语义细化“查看受影响内容”按钮文案；Cherry-pick 本地改动覆盖时对齐 IDEA，使用“显示文件”。
+ * 按操作语义细化“查看受影响内容”按钮文案；Cherry-pick 本地改动覆盖时保持与参考实现一致，使用“显示文件”。
  */
 function getViewChangesButtonLabel(
   problem: GitUpdateOperationProblem,

--- a/web/src/features/git/use-git-auto-refresh.ts
+++ b/web/src/features/git/use-git-auto-refresh.ts
@@ -137,7 +137,7 @@ export function useGitAutoRefresh(args: UseGitAutoRefreshArgs): void {
 
     /**
      * 根据 watcher 来源与原因决定刷新粒度。
-     * - `worktrees` 对齐 IDEA `workingTreeHolder.scheduleReload()` 语义，仅刷新 worktree 列表；
+     * - `worktrees` 保持与参考实现一致的 `workingTreeHolder.scheduleReload()` 语义，仅刷新 worktree 列表；
      * - 其它事件继续走整仓刷新链路。
      */
     const resolveRefreshKind = (source: "fileIndex" | "repoWatch", reason?: string): GitAutoRefreshKind => {

--- a/web/src/features/git/workbench-layout.ts
+++ b/web/src/features/git/workbench-layout.ts
@@ -53,7 +53,7 @@ export function normalizeWorkbenchProportion(value: number | null | undefined, f
 
 /**
  * 根据当前容器宽度推导主提交面板应占的像素宽度，并保留比例用于窗口缩放时自动跟随。
- * - 参考 IDEA `ChangesViewCommitPanelSplitter` 的 proportion 思路，避免固定像素宽度在窗口收窄时浪费空间。
+ * - 借鉴参考实现 `ChangesViewCommitPanelSplitter` 的 proportion 思路，避免固定像素宽度在窗口收窄时浪费空间。
  * - 右侧 Diff 区本身已经使用 `minmax(0,1fr)` + 工具栏横向滚动处理窄宽度，因此这里只保留技术最小宽度，
  *   避免用户手动拖拽时被过高的保底宽度过早锁死。
  */
@@ -87,7 +87,7 @@ export function resolveMainPanelLayout(
  * 根据底部三列容器宽度解析“分支树 / 日志 / 提交详情”的实际宽度。
  * - 分支树与提交详情按比例自动伸缩；
  * - 中央日志列始终优先保留最小阅读空间；
- * - 行为参考 IDEA 在 VCS Log / Changes 中对 splitter proportion 的持久化方式。
+ * - 行为借鉴参考实现在 VCS Log / Changes 中对 splitter proportion 的持久化方式。
  */
 export function resolveBottomPanelLayout(
   containerWidth: number,

--- a/web/src/features/git/worktree-tab-state.ts
+++ b/web/src/features/git/worktree-tab-state.ts
@@ -65,7 +65,7 @@ export function hasAdditionalWorktrees(items: GitWorktreeItem[] | null | undefin
 
 /**
  * 当前产品设计要求 Git 面板底部页签区中的 Worktrees 页签常驻，避免主入口被隐藏；
- * 因此这里始终返回显示态。设计如此，此处在“底部页签显隐策略”范围内继续不对齐 IDEA。
+ * 因此这里始终返回显示态。设计如此，此处在“底部页签显隐策略”范围内继续不保持与参考实现一致。
  */
 export function shouldShowWorktreeTab(args: {
   preferences: WorktreeTabPreferences;
@@ -77,7 +77,7 @@ export function shouldShowWorktreeTab(args: {
 
 /**
  * 当前产品设计下，Git 面板底部页签区中的 Worktrees 页签既然已经常驻，就不再额外显示 NEW badge；
- * 因此这里始终关闭 badge。设计如此，此处在“底部页签 badge 策略”范围内继续不对齐 IDEA。
+ * 因此这里始终关闭 badge。设计如此，此处在“底部页签 badge 策略”范围内继续不保持与参考实现一致。
  */
 export function shouldShowWorktreeNewBadge(args: {
   preferences: WorktreeTabPreferences;

--- a/web/src/locales/en/git.json
+++ b/web/src/locales/en/git.json
@@ -1761,6 +1761,7 @@
           "display": "Display",
           "incomingOutgoing": "Incoming / Outgoing",
           "myBranches": "My Branches",
+          "groupByDirectory": "Group by Directory",
           "repositories": "Repositories",
           "previousRepository": "Previous Repository",
           "nextRepository": "Next Repository",

--- a/web/src/locales/zh/git.json
+++ b/web/src/locales/zh/git.json
@@ -1761,6 +1761,7 @@
           "display": "显示",
           "incomingOutgoing": "传入/传出",
           "myBranches": "我的分支",
+          "groupByDirectory": "分组依据 目录",
           "repositories": "仓库",
           "previousRepository": "上一个仓库",
           "nextRepository": "下一个仓库",


### PR DESCRIPTION
从产品层面看，本次变更补齐 Git 工作台多个核心列表的复制体验：
提交树、日志列表、提交详情和分支面板现在可以按当前焦点与屏幕顺序复制可见文本；
分支侧栏新增按目录分组的显示选项，并持久化到本地偏好，便于在大量 feature/release 分支中浏览。

从技术层面看，本次变更抽出分支目录树模型、日志复制文本构造和详情树复制文本构造，
同时调整日志列宽、图谱渲染与下拉菜单定位的若干细节，保证复制内容、列顺序和界面显示保持一致。
审查中发现目录分组下分支叶子只保留短显示名会导致完整分支路径无法被 speed search 命中， 因此修复为显示短名但搜索文本保留完整分支名，并补充对应测试。

验证：
- npm run i18n:check
- npm run test