### PR TITLE
perf(codex): 修复 SQLite 清理导致的主进程卡顿

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -15,6 +15,21 @@
   - `[WC] did-fail-load ...` / `[WC] did-finish-load`
   - `[WC.console] ...`（渲染端 console 输出）
   - `[renderer:error]` / `[renderer:unhandledrejection]`
+  - `[main.eventLoop.blocked]`：主进程事件循环被阻塞，通常指向同步 I/O、CPU 密集任务或原生调用卡住
+  - `[main.ipc.slow]`：某个主进程 IPC handler 执行超过阈值，可直接看 `channel=...`
+  - `[ipc.invoke.slow]`：渲染侧等待某个 IPC 返回超过阈值，用于和 `[main.ipc.slow]` 对齐
+  - `[renderer.runtime] eventLoop.blocked` / `longTask`：渲染进程主线程卡住，通常指向 React 渲染、布局、xterm 写入或同步 JS 任务
+
+## 排查短暂停顿
+
+1. 打开 `%APPDATA%/codexflow/debug.config.jsonc`，将 `global.diagLog` 改为 `true`。
+2. 保存配置后复现“卡死几秒”的场景。
+3. 查看 `%APPDATA%/codexflow/perf.log` 中同一时间段的标签：
+   - 只有 `[renderer.runtime]`：优先排查前端同步计算、DOM/布局、终端渲染。
+   - 有 `[main.eventLoop.blocked]`：优先排查主进程同步任务。
+   - 有 `[main.ipc.slow]` 且 `channel=...` 明确：优先排查对应 IPC handler。
+   - 只有 `[ipc.invoke.slow]`：说明渲染侧等待 IPC 很久，但主进程 handler 本身未记录慢日志，需继续看主进程是否事件循环阻塞或外部进程/系统调用等待。
+4. 排查结束后将 `global.diagLog` 改回 `false`，避免持续写入普通性能诊断日志。
 
 > 生产打包默认关闭详细日志；可在 debug.config.jsonc 打开。
 

--- a/electron/codexStateCleanupWorker.ts
+++ b/electron/codexStateCleanupWorker.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import { parentPort, workerData } from "node:worker_threads";
+import { cleanupCodexStateForDeletedHistoryFiles, repairMissingCodexRolloutRows } from "./codexStateCleanup";
+
+type CleanupWorkerTask =
+  | { kind: "cleanupDeleted"; filePaths?: string[] }
+  | { kind: "repairMissing" };
+
+/**
+ * 执行 Codex sqlite 清理 worker 任务。
+ */
+async function runCleanupWorkerTask(task: CleanupWorkerTask): Promise<unknown> {
+  if (task?.kind === "cleanupDeleted") {
+    return await cleanupCodexStateForDeletedHistoryFiles(Array.isArray(task.filePaths) ? task.filePaths : [], {
+      repairMissingRollouts: false,
+    });
+  }
+  if (task?.kind === "repairMissing")
+    return await repairMissingCodexRolloutRows();
+  throw new Error(`unknown codex cleanup task: ${String((task as any)?.kind || "")}`);
+}
+
+/**
+ * 启动 worker 主流程，并把结果发送回主进程。
+ */
+async function main(): Promise<void> {
+  try {
+    const result = await runCleanupWorkerTask(workerData as CleanupWorkerTask);
+    parentPort?.postMessage({ ok: true, result });
+  } catch (error) {
+    parentPort?.postMessage({
+      ok: false,
+      error: String((error as any)?.stack || (error as any)?.message || error),
+    });
+  }
+}
+
+void main();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7,6 +7,7 @@ import { execFile, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import { promises as fsp } from 'node:fs';
 import path from 'node:path';
+import { Worker } from 'node:worker_threads';
 import { ProxyAgent, setGlobalDispatcher, Agent } from 'undici';
 import { PTYManager, setTermDebug } from "./pty";
 import opentype from 'opentype.js';
@@ -39,7 +40,7 @@ import { CodexBridge, type CodexBridgeOptions } from "./codex/bridge";
 import { applyCodexAuthBackupAsync, deleteCodexAuthBackupAsync, isSafeAuthBackupId, listCodexAuthBackupsAsync, readCodexAuthBackupMetaAsync, resolveCodexAccountSignature, resolveCodexAuthJsonPathAsync, upsertCodexAuthBackupAsync, upsertCodexAuthBackupMetaOnlyAsync } from "./codex/authBackups";
 import { ensureAllCodexNotifications } from "./codex/config";
 import { startCodexNotificationBridge, stopCodexNotificationBridge } from "./codex/notifications";
-import { cleanupCodexStateForDeletedHistoryFiles, repairMissingCodexRolloutRows, type CodexStateCleanupResult } from "./codexStateCleanup";
+import type { CodexStateCleanupResult } from "./codexStateCleanup";
 import { ensureAllClaudeNotifications, startClaudeNotificationBridge, stopClaudeNotificationBridge } from "./claude/notifications";
 import { getClaudeUsageSnapshotAsync } from "./claude/usage";
 import { ensureAllGeminiNotifications, startGeminiNotificationBridge, stopGeminiNotificationBridge } from "./gemini/notifications";
@@ -57,6 +58,7 @@ import * as repoWatch from "./git/repoWatch";
 import { initGitRepositoryAsync } from "./git/repoInit";
 import { activateWindowPreservingState } from "./windowActivation";
 import { dispatchGitFeatureAction } from "./git/featureService";
+import { installMainEventLoopDiagnostics, installMainIpcTimingDiagnostics } from "./runtimeDiagnostics";
 import { autoCommitWorktreeIfDirtyAsync, createWorktreesAsync, listLocalBranchesAsync, recycleWorktreeAsync, removeWorktreeAsync } from "./git/worktreeOps";
 import { isWorktreeAlignedToMainAsync, resetWorktreeAsync } from "./git/worktreeReset";
 import { resolveWorktreeForkPointAsync, searchForkPointCommitsAsync, validateForkPointRefAsync } from "./git/worktreeForkPoint";
@@ -78,6 +80,9 @@ import {
 // 使用 CommonJS 编译输出时，运行时环境会提供 `__dirname`，直接使用即可
 
 let codexStateRepairStarted = false;
+let codexStateCleanupWorkerChain: Promise<void> = Promise.resolve();
+
+try { installMainIpcTimingDiagnostics(); } catch {}
 
 /**
  * 汇总 Codex sqlite 清理结果，便于主进程日志快速定位问题。
@@ -108,15 +113,88 @@ function logCodexStateCleanupResult(reason: string, result: CodexStateCleanupRes
 }
 
 /**
+ * 使用 worker thread 执行 Codex sqlite 清理，避免 better-sqlite3 同步调用阻塞 Electron 主事件循环。
+ */
+function runCodexStateCleanupWorker(
+  task: { kind: "cleanupDeleted"; filePaths: string[] } | { kind: "repairMissing" },
+  timeoutMs = 60_000,
+): Promise<CodexStateCleanupResult> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let worker: Worker | null = null;
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      try { clearTimeout(timer); } catch {}
+      fn();
+    };
+    const timer = setTimeout(() => {
+      finish(() => {
+        try { worker?.terminate().catch(() => {}); } catch {}
+        reject(new Error(`Codex sqlite cleanup worker timeout after ${timeoutMs}ms`));
+      });
+    }, Math.max(5000, timeoutMs));
+    try { (timer as any).unref?.(); } catch {}
+
+    try {
+      worker = new Worker(path.join(__dirname, "codexStateCleanupWorker.js"), {
+        workerData: task,
+      });
+      worker.on("message", (message: any) => {
+        finish(() => {
+          if (message?.ok && message.result) {
+            resolve(message.result as CodexStateCleanupResult);
+            return;
+          }
+          reject(new Error(String(message?.error || "Codex sqlite cleanup worker failed")));
+        });
+      });
+      worker.on("error", (error) => {
+        finish(() => reject(error));
+      });
+      worker.on("exit", (code) => {
+        if (settled) return;
+        finish(() => reject(new Error(`Codex sqlite cleanup worker exited with code ${code}`)));
+      });
+    } catch (error) {
+      finish(() => reject(error as Error));
+    }
+  });
+}
+
+/**
+ * 串行执行 Codex sqlite 清理 worker，避免多个 worker 同时争用同一批 sqlite DB。
+ */
+async function enqueueCodexStateCleanupWorker(
+  task: { kind: "cleanupDeleted"; filePaths: string[] } | { kind: "repairMissing" },
+): Promise<CodexStateCleanupResult> {
+  let resolveTask: (value: CodexStateCleanupResult) => void;
+  let rejectTask: (reason?: unknown) => void;
+  const promise = new Promise<CodexStateCleanupResult>((resolve, reject) => {
+    resolveTask = resolve;
+    rejectTask = reject;
+  });
+  codexStateCleanupWorkerChain = codexStateCleanupWorkerChain
+    .catch(() => {})
+    .then(async () => {
+      try {
+        const result = await runCodexStateCleanupWorker(task);
+        resolveTask(result);
+      } catch (error) {
+        rejectTask(error);
+      }
+    });
+  return promise;
+}
+
+/**
  * 安全清理本次已删除历史路径对应的 Codex sqlite 状态。
  */
 async function cleanupCodexStateForDeletedPathsSafely(filePaths: string[], reason: string): Promise<void> {
   const paths = Array.from(new Set(filePaths.filter((item) => typeof item === "string" && item.trim())));
   if (paths.length === 0) return;
   try {
-    const result = await cleanupCodexStateForDeletedHistoryFiles(paths, {
-      repairMissingRollouts: false,
-    });
+    const result = await enqueueCodexStateCleanupWorker({ kind: "cleanupDeleted", filePaths: paths });
     logCodexStateCleanupResult(reason, result);
   } catch (error) {
     try { console.warn(`codex state cleanup ${reason} failed`, error); } catch {}
@@ -130,7 +208,7 @@ function startCodexStateRepairOnce(reason: string): void {
   if (codexStateRepairStarted) return;
   codexStateRepairStarted = true;
   const timer = setTimeout(() => {
-    void repairMissingCodexRolloutRows()
+    void enqueueCodexStateCleanupWorker({ kind: "repairMissing" })
       .then((result) => logCodexStateCleanupResult(reason, result))
       .catch((error) => {
         try { console.warn(`codex state repair ${reason} failed`, error); } catch {}
@@ -2226,6 +2304,7 @@ if (!gotLock) {
   app.whenReady().then(async () => {
     // 加载统一调试配置并建立监听
     try { readDebugConfig(); applyDebugGlobalsFromConfig(); watchDebugConfig(); } catch {}
+    try { installMainEventLoopDiagnostics(); } catch {}
     // Windows：尽早设置 AUMID（建议在创建窗口前完成）
     try {
       if (process.platform === 'win32') {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -10,6 +10,55 @@ type OpenArgs = { terminal?: TerminalMode; distro?: string; wslPath?: string; wi
 type PtyDataPayload = { id: string; data: string };
 type PtyExitPayload = { id: string; exitCode?: number };
 
+const PRELOAD_SLOW_INVOKE_WARN_MS = 700;
+
+/**
+ * 读取单调时间，用于计算渲染侧 IPC 等待耗时。
+ */
+function nowMs(): number {
+  try { return typeof performance !== 'undefined' ? performance.now() : Date.now(); } catch { return Date.now(); }
+}
+
+/**
+ * 判断普通诊断日志是否开启，避免默认写入低优先级性能日志。
+ */
+function isDiagLogEnabled(): boolean {
+  try { return !!(globalThis as any).__cf_diag_log__; } catch { return false; }
+}
+
+/**
+ * 安装渲染侧 IPC invoke 耗时探针。
+ */
+function installInvokeTimingDiagnostics(): void {
+  try {
+    const key = Symbol.for("codexflow:ipcInvokeTimingInstalled");
+    const g: any = process as any;
+    if (g[key]) return;
+    g[key] = true;
+    const originalInvoke = ipcRenderer.invoke.bind(ipcRenderer);
+    (ipcRenderer as any).invoke = async (channel: string, ...args: any[]) => {
+      const startedAt = nowMs();
+      try {
+        const result = await originalInvoke(channel, ...args);
+        const durationMs = nowMs() - startedAt;
+        if (durationMs >= PRELOAD_SLOW_INVOKE_WARN_MS && isDiagLogEnabled() && channel !== 'utils.perfLog' && channel !== 'utils.perfLogCritical') {
+          try { void originalInvoke('utils.perfLog', { text: `[ipc.invoke.slow] channel=${String(channel)} ok=1 durationMs=${Math.round(durationMs)} args=${args.length}` }); } catch {}
+        }
+        return result;
+      } catch (error) {
+        const durationMs = nowMs() - startedAt;
+        if (durationMs >= PRELOAD_SLOW_INVOKE_WARN_MS && isDiagLogEnabled() && channel !== 'utils.perfLog' && channel !== 'utils.perfLogCritical') {
+          const message = String((error as any)?.message || error || "");
+          try { void originalInvoke('utils.perfLog', { text: `[ipc.invoke.slow] channel=${String(channel)} ok=0 durationMs=${Math.round(durationMs)} args=${args.length} error=${message.slice(0, 160)}` }); } catch {}
+        }
+        throw error;
+      }
+    };
+  } catch {}
+}
+
+installInvokeTimingDiagnostics();
+
 // ---- PTY 事件分发（关键性能修复）----
 //
 // - 旧实现：每次 `window.host.pty.onData(id, cb)` 都会 `ipcRenderer.on('pty:data', ...)` 注册一个监听器；
@@ -872,6 +921,7 @@ module.exports = {};
 // ---- 统一调试配置：同步关键项到全局只读缓存（供渲染层直接读取，避免多次 IPC）----
 function __applyDebugGlobals(cfg: any) {
   try {
+    (globalThis as any).__cf_diag_log__ = !!(cfg?.global?.diagLog);
     (globalThis as any).__cf_ui_debug_cache__ = !!(cfg?.renderer?.uiDebug);
     (globalThis as any).__cf_notif_debug_cache__ = !!(cfg?.renderer?.notifications?.debug);
     (globalThis as any).__cf_notif_menu_mode__ = String(cfg?.renderer?.notifications?.menu || 'auto');

--- a/electron/runtimeDiagnostics.ts
+++ b/electron/runtimeDiagnostics.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import { ipcMain } from "electron";
+import { performance } from "node:perf_hooks";
+import { getDebugConfig } from "./debugConfig";
+import { perfLogger } from "./log";
+
+type IpcHandler = (event: Electron.IpcMainInvokeEvent, ...args: any[]) => any;
+
+const MAIN_EVENT_LOOP_INTERVAL_MS = 1000;
+const MAIN_EVENT_LOOP_WARN_DRIFT_MS = 700;
+const MAIN_EVENT_LOOP_MIN_LOG_GAP_MS = 3000;
+const MAIN_SLOW_IPC_WARN_MS = 700;
+const MAIN_IPC_PAYLOAD_PREVIEW_LIMIT = 220;
+
+let eventLoopProbeInstalled = false;
+let ipcTimingInstalled = false;
+
+/**
+ * 判断普通诊断日志是否启用，关闭时跳过低优先级诊断组装。
+ */
+function isDiagLogEnabled(): boolean {
+  try { return !!getDebugConfig()?.global?.diagLog; } catch { return false; }
+}
+
+/**
+ * 返回当前单调时间，避免系统时间变化影响耗时计算。
+ */
+function nowMs(): number {
+  try { return performance.now(); } catch { return Date.now(); }
+}
+
+/**
+ * 将日志字段裁剪为稳定长度，避免大型 payload 放大 perf.log。
+ */
+function clampLogValue(value: unknown, maxLen = MAIN_IPC_PAYLOAD_PREVIEW_LIMIT): string {
+  const text = (() => {
+    try {
+      if (typeof value === "string") return value;
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  })();
+  const safe = String(text ?? "").replace(/\s+/g, " ").trim();
+  return safe.length > maxLen ? `${safe.slice(0, maxLen)}...` : safe;
+}
+
+/**
+ * 生成 IPC 参数预览，只保留数量、类型和长度，避免记录用户正文内容。
+ */
+function summarizeIpcArgs(args: any[]): string {
+  try {
+    if (!Array.isArray(args) || args.length === 0) return "args=0";
+    const preview = args.slice(0, 3).map((arg) => {
+      if (arg == null) return String(arg);
+      if (typeof arg === "string") return `string:${arg.length}`;
+      if (typeof arg === "number" || typeof arg === "boolean") return `${typeof arg}:${String(arg)}`;
+      if (Array.isArray(arg)) return `array:${arg.length}`;
+      if (typeof arg === "object") {
+        const keys = Object.keys(arg).slice(0, 8).join(",");
+        return `object:${keys}`;
+      }
+      return typeof arg;
+    }).join("|");
+    const more = args.length > 3 ? ` more=${args.length - 3}` : "";
+    return `args=${args.length} preview=${clampLogValue(preview)}${more}`;
+  } catch {
+    return `args=${Array.isArray(args) ? args.length : 0}`;
+  }
+}
+
+/**
+ * 记录慢 IPC handler，帮助区分主进程任务耗时和渲染进程等待。
+ */
+function logSlowIpc(channel: string, durationMs: number, ok: boolean, args: any[], error?: unknown): void {
+  if (!isDiagLogEnabled()) return;
+  const errorText = error ? ` error="${clampLogValue((error as any)?.message || error, 180)}"` : "";
+  try {
+    perfLogger.log(`[main.ipc.slow] channel=${channel} ok=${ok ? 1 : 0} durationMs=${Math.round(durationMs)} ${summarizeIpcArgs(args)}${errorText}`);
+  } catch {}
+}
+
+/**
+ * 安装主进程 IPC handler 耗时拦截。
+ */
+export function installMainIpcTimingDiagnostics(): void {
+  if (ipcTimingInstalled) return;
+  ipcTimingInstalled = true;
+  const originalHandle = ipcMain.handle.bind(ipcMain);
+  (ipcMain as any).handle = (channel: string, listener: IpcHandler) => {
+    if (typeof listener !== "function") return originalHandle(channel, listener);
+    const wrapped: IpcHandler = async (event, ...args) => {
+      const startedAt = nowMs();
+      try {
+        const result = await listener(event, ...args);
+        const durationMs = nowMs() - startedAt;
+        if (durationMs >= MAIN_SLOW_IPC_WARN_MS && channel !== "utils.perfLog" && channel !== "utils.perfLogCritical")
+          logSlowIpc(channel, durationMs, true, args);
+        return result;
+      } catch (error) {
+        const durationMs = nowMs() - startedAt;
+        if (durationMs >= MAIN_SLOW_IPC_WARN_MS)
+          logSlowIpc(channel, durationMs, false, args, error);
+        throw error;
+      }
+    };
+    return originalHandle(channel, wrapped);
+  };
+}
+
+/**
+ * 安装主进程事件循环漂移探针，用于定位主进程被同步任务阻塞的时间段。
+ */
+export function installMainEventLoopDiagnostics(): void {
+  if (eventLoopProbeInstalled) return;
+  eventLoopProbeInstalled = true;
+
+  let expectedAt = nowMs() + MAIN_EVENT_LOOP_INTERVAL_MS;
+  let lastLoggedAt = 0;
+  const timer = setInterval(() => {
+    try {
+      const now = nowMs();
+      const driftMs = now - expectedAt;
+      expectedAt = now + MAIN_EVENT_LOOP_INTERVAL_MS;
+      if (driftMs < MAIN_EVENT_LOOP_WARN_DRIFT_MS) return;
+      if (!isDiagLogEnabled()) return;
+      if (now - lastLoggedAt < MAIN_EVENT_LOOP_MIN_LOG_GAP_MS) return;
+      lastLoggedAt = now;
+      perfLogger.log(`[main.eventLoop.blocked] driftMs=${Math.round(driftMs)} intervalMs=${MAIN_EVENT_LOOP_INTERVAL_MS}`);
+    } catch {}
+  }, MAIN_EVENT_LOOP_INTERVAL_MS);
+  try { (timer as any).unref?.(); } catch {}
+}

--- a/web/src/lib/runtime-diagnostics.ts
+++ b/web/src/lib/runtime-diagnostics.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+const RENDERER_DIAGNOSTICS_INSTALLED_KEY = "__cf_renderer_runtime_diagnostics_installed__";
+const RENDERER_HEARTBEAT_INTERVAL_MS = 1000;
+const RENDERER_HEARTBEAT_WARN_DRIFT_MS = 700;
+const RENDERER_HEARTBEAT_MIN_LOG_GAP_MS = 3000;
+const RENDERER_LONG_TASK_WARN_MS = 200;
+const RENDERER_LONG_TASK_MIN_LOG_GAP_MS = 1500;
+
+let rendererDiagnosticsEnabled = false;
+
+/**
+ * 返回当前单调时间，用于避免系统时间变化影响耗时计算。
+ */
+function nowMs(): number {
+  try { return typeof performance !== "undefined" ? performance.now() : Date.now(); } catch { return Date.now(); }
+}
+
+/**
+ * 裁剪日志字段，避免异常对象或 URL 放大 perf.log。
+ */
+function clampLogValue(value: unknown, maxLength = 180): string {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
+}
+
+/**
+ * 写入普通渲染诊断日志；仅在 `global.diagLog` 开启后落盘。
+ */
+function logRendererDiagnostic(message: string): void {
+  if (!rendererDiagnosticsEnabled) return;
+  try { void window.host?.utils?.perfLog?.(`[renderer.runtime] ${message}`); } catch {}
+}
+
+/**
+ * 从主进程调试配置同步诊断开关。
+ */
+async function refreshRendererDiagnosticsEnabled(): Promise<void> {
+  try {
+    const cfg = await window.host?.debug?.get?.();
+    rendererDiagnosticsEnabled = !!cfg?.global?.diagLog;
+  } catch {
+    rendererDiagnosticsEnabled = false;
+  }
+}
+
+/**
+ * 安装渲染线程心跳漂移探针，用于定位 UI 主线程被同步任务阻塞的时间段。
+ */
+function installHeartbeatProbe(): void {
+  let expectedAt = nowMs() + RENDERER_HEARTBEAT_INTERVAL_MS;
+  let lastLoggedAt = 0;
+  const timer = window.setInterval(() => {
+    try {
+      const now = nowMs();
+      const driftMs = now - expectedAt;
+      expectedAt = now + RENDERER_HEARTBEAT_INTERVAL_MS;
+      if (driftMs < RENDERER_HEARTBEAT_WARN_DRIFT_MS) return;
+      if (now - lastLoggedAt < RENDERER_HEARTBEAT_MIN_LOG_GAP_MS) return;
+      lastLoggedAt = now;
+      logRendererDiagnostic(`eventLoop.blocked driftMs=${Math.round(driftMs)} intervalMs=${RENDERER_HEARTBEAT_INTERVAL_MS} visibility=${document.visibilityState}`);
+    } catch {}
+  }, RENDERER_HEARTBEAT_INTERVAL_MS);
+  try { (timer as any).unref?.(); } catch {}
+}
+
+/**
+ * 安装 Long Task 观察器，用于记录浏览器主线程长任务。
+ */
+function installLongTaskProbe(): void {
+  try {
+    const PerformanceObserverCtor = window.PerformanceObserver;
+    if (!PerformanceObserverCtor) return;
+    const supported = (PerformanceObserverCtor as any).supportedEntryTypes;
+    if (Array.isArray(supported) && !supported.includes("longtask")) return;
+    let lastLoggedAt = 0;
+    const observer = new PerformanceObserverCtor((list) => {
+      try {
+        for (const entry of list.getEntries()) {
+          const durationMs = Number(entry.duration || 0);
+          if (durationMs < RENDERER_LONG_TASK_WARN_MS) continue;
+          const now = nowMs();
+          if (now - lastLoggedAt < RENDERER_LONG_TASK_MIN_LOG_GAP_MS) continue;
+          lastLoggedAt = now;
+          logRendererDiagnostic(
+            `longTask durationMs=${Math.round(durationMs)} startMs=${Math.round(Number(entry.startTime || 0))} name=${clampLogValue(entry.name)} visibility=${document.visibilityState}`,
+          );
+        }
+      } catch {}
+    });
+    observer.observe({ entryTypes: ["longtask"] });
+  } catch {}
+}
+
+/**
+ * 安装渲染进程运行时诊断探针。
+ */
+export function installRendererRuntimeDiagnostics(): void {
+  if (typeof window === "undefined") return;
+  const globalWindow = window as typeof window & { [RENDERER_DIAGNOSTICS_INSTALLED_KEY]?: boolean };
+  if (globalWindow[RENDERER_DIAGNOSTICS_INSTALLED_KEY]) return;
+  globalWindow[RENDERER_DIAGNOSTICS_INSTALLED_KEY] = true;
+
+  void refreshRendererDiagnosticsEnabled().then(() => {
+    logRendererDiagnostic(`installed href=${clampLogValue(window.location.href, 260)}`);
+  });
+  try {
+    window.host?.debug?.onChanged?.(() => {
+      void refreshRendererDiagnosticsEnabled();
+    });
+  } catch {}
+
+  installHeartbeatProbe();
+  installLongTaskProbe();
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -11,12 +11,14 @@ import ErrorBoundary from '@/components/ErrorBoundary';
 import { applyTheme, getCachedThemeSetting } from '@/lib/theme';
 import { installPreventReloadShortcuts } from '@/lib/preventReloadShortcuts';
 import { installRendererLifecycleLogging } from '@/lib/renderer-lifecycle-log';
+import { installRendererRuntimeDiagnostics } from '@/lib/runtime-diagnostics';
 
 const cachedThemeSetting = getCachedThemeSetting();
 applyTheme(cachedThemeSetting ?? 'system');
 // 关键：阻止 Ctrl/Cmd+R、F5 导致的渲染进程 reload（不影响 xterm 接收按键）
 installPreventReloadShortcuts();
 installRendererLifecycleLogging();
+installRendererRuntimeDiagnostics();
 
 const root = createRoot(document.getElementById('root')!);
 


### PR DESCRIPTION
将 Codex sqlite 状态清理迁移到 worker thread 串行执行，避免 better-sqlite3 同步访问阻塞 Electron 主事件循环；启动修复与历史删除后的清理复用同一 worker 队列，并保留超时保护，降低删除历史或启动后台修复时界面短暂停顿的风险。

新增主进程和渲染进程运行时诊断，在 debug.config.jsonc 的 global.diagLog 开启后记录事件循环阻塞、Long Task、慢 IPC handler 与渲染侧 IPC 等待耗时，便于继续定位短暂停顿发生在 UI、主进程还是跨进程调用链路。

补充诊断文档说明 perf.log 中的新标签及排查顺序；慢 IPC 参数预览仅记录类型、数量和长度，避免把用户输入或路径正文写入普通诊断日志。