### PR TITLE
fix(runtime): 优化修复运行环境回退与 CLI 检测

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -23,9 +23,10 @@ import { parseGeminiSessionFile, extractGeminiProjectHashFromPath, deriveGeminiP
 import { hasNonEmptyIOFromMessages } from "./agentSessions/shared/empty";
 import { historyItemBelongsToScope } from "./historyScope";
 import { perfLogger } from "./log";
-import settings, { ensureSettingsAutodetect, ensureFirstRunTerminalSelection, type ThemeSetting as SettingsThemeSetting, type AppSettings, type IdeOpenSettings } from "./settings";
+import settings, { ensureSettingsAutodetect, ensureFirstRunTerminalSelection, hasSavedRuntimeEnvSelection, type ThemeSetting as SettingsThemeSetting, type AppSettings, type IdeOpenSettings } from "./settings";
 import { getOnboardingState, updateOnboardingState } from "./onboarding";
 import { normalizeTerminal, resolveWindowsShell, detectPwshExecutable, type TerminalMode } from "./shells";
+import { checkRuntimeCli, resolveVisibleRuntimeEnv, type ResolvedRuntimeEnv } from "./runtimeEnv";
 import { resolveActiveProviderId, resolveProviderRuntimeEnvFromSettings, resolveProviderStartupCmdFromSettings } from "./providers/runtime";
 import i18n from "./i18n";
 import wsl from "./wsl";
@@ -640,6 +641,14 @@ function logIdeOpenTrace(message: string): void {
 type CursorOpenStrategy = "auto" | "protocol" | "command";
 let cursorPreferredStrategy: CursorOpenStrategy = "auto";
 
+type RuntimeEnvRepairEntry = {
+  providerId?: string;
+  scope: "legacy" | "provider";
+  from: { terminal: TerminalMode; distro: string };
+  to: { terminal: TerminalMode; distro: string };
+  reason?: string;
+};
+
 /**
  * 中文说明：更新 Cursor 当前优先策略，用于加速后续文件定位打开。
  */
@@ -653,6 +662,131 @@ const APP_USER_MODEL_ID = 'com.codexflow.app';
 const DEV_APP_USER_MODEL_ID = 'com.codexflow.app.dev';
 const PROTOCOL_SCHEME = 'codexflow';
 const ptyManager = new PTYManager(() => BrowserWindow.getAllWindows().filter((win) => !win.isDestroyed()));
+
+/**
+ * 解析请求环境，确保返回一个当前机器可见的终端环境。
+ * @param input 请求使用的终端环境
+ */
+async function resolveVisibleRuntimeEnvForMain(input: { terminal?: TerminalMode; distro?: string }): Promise<ResolvedRuntimeEnv> {
+  return await resolveVisibleRuntimeEnv({
+    terminal: normalizeTerminal(input?.terminal),
+    distro: String(input?.distro || "").trim(),
+  });
+}
+
+/**
+ * 判断两个运行环境是否一致。
+ * @param left 左侧环境
+ * @param right 右侧环境
+ */
+function isSameRuntimeEnv(left: { terminal?: TerminalMode; distro?: string }, right: { terminal?: TerminalMode; distro?: string }): boolean {
+  return normalizeTerminal(left?.terminal) === normalizeTerminal(right?.terminal)
+    && String(left?.distro || "").trim().toLowerCase() === String(right?.distro || "").trim().toLowerCase();
+}
+
+/**
+ * 将可见环境修正写回设置，避免下次启动重复修复同一个不可用环境。
+ * @param cfg 已完成修正的设置快照
+ */
+function persistVisibleRuntimeEnvRepairs(cfg: any): void {
+  const patch: any = {
+    terminal: normalizeTerminal(cfg?.terminal),
+    distro: String(cfg?.distro || ""),
+  };
+  if (cfg?.providers && typeof cfg.providers === "object")
+    patch.providers = cfg.providers;
+  const saved = settings.updateSettings(patch) as any;
+  cfg.terminal = normalizeTerminal(saved?.terminal);
+  cfg.distro = String(saved?.distro || cfg.distro || "");
+  if (saved?.providers && typeof saved.providers === "object")
+    cfg.providers = saved.providers;
+}
+
+/**
+ * 修正设置中的 legacy/provider 环境，避免 UI 显示或启动到不可用环境。
+ * @param cfg 当前设置快照
+ * @param options 是否需要把修正信息暴露给渲染进程
+ */
+async function resolveVisibleSettingsRuntimeEnvs(cfg: any, options?: { notifyWhenChanged?: boolean }): Promise<any> {
+  const next = { ...(cfg || {}) };
+  const repairs: RuntimeEnvRepairEntry[] = [];
+  const legacy = await resolveVisibleRuntimeEnvForMain({
+    terminal: next.terminal,
+    distro: next.distro,
+  });
+  const legacyFrom = {
+    terminal: normalizeTerminal(next.terminal),
+    distro: String(next.distro || ""),
+  };
+  const legacyTo = {
+    terminal: legacy.terminal,
+    distro: legacy.distro || String(next.distro || ""),
+  };
+  if (!isSameRuntimeEnv(legacyFrom, legacyTo)) {
+    repairs.push({
+      scope: "legacy",
+      from: legacyFrom,
+      to: legacyTo,
+      reason: legacy.reason,
+    });
+  }
+  next.terminal = legacy.terminal;
+  next.distro = legacy.distro || String(next.distro || "");
+
+  const providers = next.providers && typeof next.providers === "object" ? { ...next.providers } : undefined;
+  if (providers) {
+    const envInput = providers.env && typeof providers.env === "object" ? providers.env : {};
+    const envNext: Record<string, any> = {};
+    const entries = Object.entries(envInput);
+    for (const [id, value] of entries) {
+      const raw = value && typeof value === "object" ? value as any : {};
+      const from = {
+        terminal: normalizeTerminal(raw.terminal),
+        distro: String(raw.distro || next.distro || ""),
+      };
+      const resolved = await resolveVisibleRuntimeEnvForMain({
+        terminal: raw.terminal,
+        distro: raw.distro || next.distro,
+      });
+      const to = {
+        terminal: resolved.terminal,
+        distro: resolved.distro || raw.distro || next.distro || "",
+      };
+      if (!isSameRuntimeEnv(from, to)) {
+        repairs.push({
+          scope: "provider",
+          providerId: String(id || ""),
+          from,
+          to,
+          reason: resolved.reason,
+        });
+      }
+      envNext[id] = {
+        ...raw,
+        terminal: resolved.terminal,
+        distro: resolved.distro || raw.distro || next.distro || "",
+      };
+    }
+    providers.env = envNext;
+    next.providers = providers;
+  }
+  if (repairs.length > 0) {
+    try {
+      persistVisibleRuntimeEnvRepairs(next);
+    } catch (e: any) {
+      try { perfLogger.log(`[runtime-env] settings repair persist failed error=${String(e?.message || e)}`); } catch {}
+    }
+    next._runtimeEnvRepair = {
+      changed: true,
+      notify: options?.notifyWhenChanged === true,
+      entries: repairs,
+    };
+    try {
+      perfLogger.log(`[runtime-env] settings repaired notify=${options?.notifyWhenChanged ? "1" : "0"} entries=${JSON.stringify(repairs)}`);
+    } catch {}
+  }
+  return next;
+}
 // worktree 创建后台任务：用于“创建中”进度 UI（可关闭/可重新打开查看输出）
 const worktreeCreateTasks = new WorktreeCreateTaskManager();
 // worktree 回收后台任务：用于“回收中”进度 UI（可查看实时日志）
@@ -2508,9 +2642,12 @@ function setupAppMenu() {
 ipcMain.handle('pty:open', async (_event, args: {
   terminal?: TerminalMode; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string>;
 }) => {
-  const id = ptyManager.openWSLConsole({
-    terminal: args?.terminal as any,
-    distro: args?.distro,
+  // 中文说明：打开 PTY 是标签页点击热路径；这里不做 WSL 枚举/CLI 检测，直接按请求环境启动。
+  const requestedTerminal = args?.terminal ? normalizeTerminal(args.terminal) : undefined;
+  const requestedDistro = String(args?.distro || "").trim();
+  const opened = ptyManager.openWSLConsole({
+    terminal: requestedTerminal,
+    distro: requestedDistro,
     wslPath: args?.wslPath,
     winPath: args?.winPath,
     cols: args?.cols ?? 80,
@@ -2518,7 +2655,12 @@ ipcMain.handle('pty:open', async (_event, args: {
     startupCmd: args?.startupCmd ?? '',
     env: args?.env,
   });
-  return { id };
+  return {
+    id: opened.id,
+    terminal: opened.terminal || requestedTerminal,
+    distro: opened.distro || requestedDistro,
+    fallbackReason: opened.fallbackReason,
+  };
 });
 
 /**
@@ -6233,6 +6375,8 @@ ipcMain.handle("gemini.usage", async () => {
 
 // Settings
 ipcMain.handle('settings.get', async () => {
+  const notifyRuntimeRepair = hasSavedRuntimeEnvSelection();
+  try { await ensureFirstRunTerminalSelection(); } catch {}
   try { await ensureSettingsAutodetect(); } catch {}
   try { await ensureAllCodexNotifications(); } catch {}
   try { await ensureAllClaudeNotifications(); } catch {}
@@ -6240,12 +6384,49 @@ ipcMain.handle('settings.get', async () => {
   try { await startCodexNotificationBridge(() => mainWindow); } catch {}
   try { await startClaudeNotificationBridge(() => mainWindow); } catch {}
   try { await startGeminiNotificationBridge(() => mainWindow); } catch {}
-  const cfg = settings.getSettings() as any;
+  let cfg = settings.getSettings() as any;
   try {
     const flags = getFeatureFlags();
     cfg.experimental = { ...(cfg.experimental || {}), multiInstanceEnabled: !!flags.multiInstanceEnabled };
   } catch {}
+  try { cfg = await resolveVisibleSettingsRuntimeEnvs(cfg, { notifyWhenChanged: notifyRuntimeRepair }); } catch {}
   return cfg;
+});
+
+ipcMain.handle('settings.resolveRuntimeEnv', async (_e, input: { terminal?: TerminalMode; distro?: string } = {}) => {
+  try {
+    const resolved = await resolveVisibleRuntimeEnvForMain(input || {});
+    return {
+      ok: true,
+      terminal: resolved.terminal,
+      distro: resolved.distro,
+      changed: resolved.changed,
+      reason: resolved.reason,
+      availableDistros: resolved.availableDistros,
+    };
+  } catch (e: any) {
+    return { ok: false, error: String(e) };
+  }
+});
+
+ipcMain.handle('settings.checkRuntimeCli', async (_e, input: { terminal?: TerminalMode; distro?: string; startupCmd?: string } = {}) => {
+  try {
+    const result = await checkRuntimeCli(input || {});
+    try {
+      if (!result.ok)
+        perfLogger.log(`[runtime-env] cli missing terminal=${result.terminal} distro=${result.distro || ""} cli=${result.cli || ""} reason=${result.reason || ""}`);
+    } catch {}
+    return {
+      ok: result.ok,
+      cli: result.cli,
+      terminal: result.terminal,
+      distro: result.distro,
+      reason: result.reason,
+      error: result.error,
+    };
+  } catch (e: any) {
+    return { ok: false, error: String(e) };
+  }
 });
 
 ipcMain.handle("onboarding.get", async () => {
@@ -6333,7 +6514,10 @@ ipcMain.handle('settings.update', async (_e, partial: any) => {
       try { mainWindow?.webContents.send('history:index:invalidate', { reason: 'settings' }); } catch {}
     }
   } catch {}
-  const merged = next as any;
+  let merged = next as any;
+  try {
+    merged = await resolveVisibleSettingsRuntimeEnvs(merged);
+  } catch {}
   try {
     const flags = getFeatureFlags();
     const enabled = updatedMultiInstance == null ? !!flags.multiInstanceEnabled : !!updatedMultiInstance;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -6,6 +6,7 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 type TerminalMode = 'wsl' | 'windows' | 'pwsh' | 'cmd';
 type OpenArgs = { terminal?: TerminalMode; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string> };
+type OpenResult = { id: string; terminal?: TerminalMode; distro?: string; fallbackReason?: string };
 
 type PtyDataPayload = { id: string; data: string };
 type PtyExitPayload = { id: string; exitCode?: number };
@@ -304,7 +305,7 @@ contextBridge.exposeInMainWorld('host', {
     }
   },
   pty: {
-    openWSLConsole: async (args: OpenArgs): Promise<{ id: string }> => {
+    openWSLConsole: async (args: OpenArgs): Promise<OpenResult> => {
       return await ipcRenderer.invoke('pty:open', args);
     },
     /**
@@ -619,6 +620,12 @@ contextBridge.exposeInMainWorld('host', {
     },
     update: async (partial: any) => {
       return await ipcRenderer.invoke('settings.update', partial);
+    },
+    resolveRuntimeEnv: async (args: { terminal?: TerminalMode; distro?: string }) => {
+      return await ipcRenderer.invoke('settings.resolveRuntimeEnv', args || {});
+    },
+    checkRuntimeCli: async (args: { terminal?: TerminalMode; distro?: string; startupCmd?: string }) => {
+      return await ipcRenderer.invoke('settings.checkRuntimeCli', args || {});
     },
     codexRoots: async () => {
       const res = await ipcRenderer.invoke('settings.codexRoots');

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -2,7 +2,6 @@
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
 import os from 'node:os';
-import wsl from './wsl.js';
 import settings from './settings.js';
 import { resolveWindowsShell, type TerminalMode } from './shells.js';
 import type { IPty } from '@lydell/node-pty';
@@ -175,6 +174,13 @@ type PtyIpcPendingState = {
   droppedChars: number;
 };
 
+export type PtyOpenResult = {
+  id: string;
+  terminal: TerminalMode;
+  distro?: string;
+  fallbackReason?: string;
+};
+
 export class PTYManager {
   private sessions = new Map<string, IPty>();
   private backlogs = new Map<string, PtyBacklogBuffer>();
@@ -330,13 +336,15 @@ export class PTYManager {
    * 打开一个 PTY 会话。
    * - 允许通过 opts.terminal 覆盖全局 settings.terminal，用于实现 Provider 级别环境隔离。
    */
-  openWSLConsole(opts: { terminal?: TerminalMode; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string> }): string {
+  openWSLConsole(opts: { terminal?: TerminalMode; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string> }): PtyOpenResult {
     const distro = opts.distro || 'Ubuntu-22.04';
     const wslPath = opts.wslPath || '~';
     const winPath = String(opts.winPath || '').trim();
     const cols = opts.cols || 80;
     const rows = opts.rows || 24;
     const startupCmd = opts.startupCmd || '';
+    let startupNotice = "";
+    let fallbackReason: string | undefined;
 
     const id = uid();
 
@@ -344,7 +352,7 @@ export class PTYManager {
     env = mergeExtraEnv(env, opts.env);
 
     // 根据设置选择 WSL 或 Windows 本地终端
-    const termMode = (opts.terminal || settings.getSettings().terminal || 'wsl');
+    let termMode = (opts.terminal || settings.getSettings().terminal || 'wsl');
     let proc: IPty;
     if (os.platform() !== 'win32') {
       // 在非 Windows 环境使用本地 shell 便于开发调试
@@ -375,17 +383,8 @@ export class PTYManager {
       let shell = 'wsl.exe';
       let args: string[] = [];
       if (os.platform() === 'win32') {
-        try {
-          // 如果指定了发行版且存在，则使用 -d <distro>
-          if (opts.distro && wsl.distroExists(opts.distro)) {
-            args = ['-d', distro];
-          } else {
-            // 否则回退到默认发行版（不传 -d）
-            args = [];
-          }
-        } catch {
-          args = [];
-        }
+        // 中文说明：打开标签页不预先枚举 WSL 发行版；直接尝试指定 distro，避免点击热路径阻塞。
+        args = opts.distro ? ['-d', distro] : [];
         if (opts.wslPath) {
           args.push('--cd', wslPath);
         }
@@ -394,13 +393,27 @@ export class PTYManager {
         const keys = Object.keys(opts.env).map((k) => String(k || "").trim()).filter(Boolean);
         if (keys.length > 0) env.WSLENV = appendWslEnv(env.WSLENV, keys);
       }
-      proc = pty.spawn(shell, args, {
-        name: 'xterm-256color',
-        cols,
-        rows,
-        cwd: undefined,
-        env
-      });
+      try {
+        proc = pty.spawn(shell, args, {
+          name: 'xterm-256color',
+          cols,
+          rows,
+          cwd: undefined,
+          env
+        });
+      } catch (error: any) {
+        const resolved = resolveWindowsShell('windows');
+        termMode = 'windows';
+        fallbackReason = 'wsl_spawn_failed';
+        startupNotice = `CodexFlow: WSL 环境不可用，已切换到 PowerShell。${error?.message ? ` (${String(error.message)})` : ""}\r\n`;
+        proc = pty.spawn(resolved.command, ['-NoLogo'], {
+          name: 'xterm-256color',
+          cols,
+          rows,
+          cwd: winPath || undefined,
+          env
+        });
+      }
     }
 
     this.sessions.set(id, proc);
@@ -425,13 +438,17 @@ export class PTYManager {
 
     // 关键修复：延迟执行 startupCmd，确保前端有足够时间订阅 'pty:data' 事件
     // 使用 setImmediate 让前端的 IPC 订阅先完成，避免早期输出（包括 OSC 通知）丢失
-    if (startupCmd) {
+    if (startupNotice || startupCmd) {
       const isWin = os.platform() === 'win32';
       const mode = isWin ? (termMode || 'wsl') : 'posix';
       const isWinShell = mode === 'windows' || mode === 'pwsh' || mode === 'cmd';
       setImmediate(() => {
         const p = this.sessions.get(id);
         if (!p) return; // PTY 可能已关闭
+        if (startupNotice) {
+          try { p.write(startupNotice); } catch {}
+        }
+        if (!startupCmd) return;
         if (isWinShell) {
           // Windows 本地 shell 中直接执行命令（cwd 已设置）
           p.write(`${startupCmd}\r`);
@@ -447,7 +464,7 @@ export class PTYManager {
       });
     }
 
-    return id;
+    return { id, terminal: termMode as TerminalMode, distro, fallbackReason };
   }
 
   /**

--- a/electron/runtimeEnv.test.ts
+++ b/electron/runtimeEnv.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./wsl.js", () => ({
+  default: {
+    listDistrosAsync: vi.fn(),
+  },
+}));
+
+vi.mock("./shells.js", () => ({
+  hasPwsh: vi.fn(),
+  normalizeTerminal: (raw: unknown) => {
+    const value = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+    if (value === "pwsh") return "pwsh";
+    if (value === "cmd") return "cmd";
+    if (value === "windows") return "windows";
+    return "wsl";
+  },
+  pickVisibleWindowsTerminalMode: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+import wsl from "./wsl.js";
+import { execFile } from "node:child_process";
+import { hasPwsh, pickVisibleWindowsTerminalMode } from "./shells.js";
+import { checkRuntimeCli, extractRuntimeCliName, resolveVisibleRuntimeEnv } from "./runtimeEnv";
+
+const mockedWsl = vi.mocked(wsl);
+const mockedExecFile = vi.mocked(execFile as any);
+const mockedHasPwsh = vi.mocked(hasPwsh);
+const mockedPickVisibleWindowsTerminalMode = vi.mocked(pickVisibleWindowsTerminalMode);
+const originalPlatform = process.platform;
+
+describe("resolveVisibleRuntimeEnv", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "win32" });
+    mockedPickVisibleWindowsTerminalMode.mockResolvedValue("pwsh");
+    mockedHasPwsh.mockResolvedValue(true);
+    mockedExecFile.mockImplementation((_file: string, _args: string[], _options: any, callback: (error: Error | null) => void) => {
+      callback(null);
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it("WSL 不可用时回退到可见的 Windows shell", async () => {
+    mockedWsl.listDistrosAsync.mockResolvedValue([]);
+
+    const result = await resolveVisibleRuntimeEnv({ terminal: "wsl", distro: "Ubuntu-24.04" });
+
+    expect(result.terminal).toBe("pwsh");
+    expect(result.distro).toBe("Ubuntu-24.04");
+    expect(result.changed).toBe(true);
+    expect(result.reason).toBe("wsl_unavailable");
+  });
+
+  it("请求的 WSL 发行版不存在时选择可用 Ubuntu 发行版", async () => {
+    mockedWsl.listDistrosAsync.mockResolvedValue([
+      { name: "Ubuntu-22.04" },
+      { name: "Ubuntu-24.04" },
+    ]);
+
+    const result = await resolveVisibleRuntimeEnv({ terminal: "wsl", distro: "Missing" });
+
+    expect(result.terminal).toBe("wsl");
+    expect(result.distro).toBe("Ubuntu-24.04");
+    expect(result.changed).toBe(true);
+    expect(result.reason).toBe("wsl_distro_unavailable");
+  });
+
+  it("PowerShell 7 不可用时回退到 Windows PowerShell", async () => {
+    mockedWsl.listDistrosAsync.mockResolvedValue([{ name: "Ubuntu-24.04" }]);
+    mockedHasPwsh.mockResolvedValue(false);
+
+    const result = await resolveVisibleRuntimeEnv({ terminal: "pwsh", distro: "Ubuntu-24.04" });
+
+    expect(result.terminal).toBe("windows");
+    expect(result.changed).toBe(true);
+    expect(result.reason).toBe("pwsh_unavailable");
+  });
+});
+
+describe("extractRuntimeCliName", () => {
+  it("提取普通启动命令的 CLI 名称", () => {
+    expect(extractRuntimeCliName("codex --yolo")).toBe("codex");
+  });
+
+  it("跳过 WSL 环境变量前缀", () => {
+    expect(extractRuntimeCliName("RUST_LOG=codex_tui=trace codex")).toBe("codex");
+  });
+
+  it("跳过 PowerShell 环境变量前缀", () => {
+    expect(extractRuntimeCliName("$env:RUST_LOG='codex_tui=trace'; codex")).toBe("codex");
+  });
+
+  it("跳过 cmd 环境变量前缀", () => {
+    expect(extractRuntimeCliName('set "RUST_LOG=codex_tui=trace" && codex')).toBe("codex");
+  });
+
+  it("跳过 PowerShell 调用操作符并保留 Windows 路径反斜杠", () => {
+    expect(extractRuntimeCliName('& "C:\\Program Files\\Codex\\codex.exe" --yolo')).toBe("C:\\Program Files\\Codex\\codex.exe");
+  });
+});
+
+describe("checkRuntimeCli", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedWsl.listDistrosAsync.mockResolvedValue([]);
+    mockedPickVisibleWindowsTerminalMode.mockResolvedValue("pwsh");
+    mockedHasPwsh.mockResolvedValue(true);
+    mockedExecFile.mockImplementation((_file: string, _args: string[], _options: any, callback: (error: Error | null) => void) => {
+      callback(null);
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it("非 Windows 宿主检测 CLI 时使用 POSIX command -v", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+
+    const result = await checkRuntimeCli({ terminal: "windows", startupCmd: "codex --yolo" });
+
+    expect(result.ok).toBe(true);
+    expect(result.cli).toBe("codex");
+    expect(mockedExecFile).toHaveBeenCalledWith(
+      "sh",
+      ["-lc", "command -v -- 'codex' >/dev/null 2>&1"],
+      expect.objectContaining({ timeout: 2500, windowsHide: true }),
+      expect.any(Function),
+    );
+    expect(mockedExecFile).not.toHaveBeenCalledWith(
+      "where.exe",
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+});

--- a/electron/runtimeEnv.ts
+++ b/electron/runtimeEnv.ts
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import wsl, { type DistroInfo } from "./wsl.js";
+import { hasPwsh, normalizeTerminal, pickVisibleWindowsTerminalMode, type TerminalMode } from "./shells.js";
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+
+export type RuntimeEnvInput = {
+  terminal?: TerminalMode;
+  distro?: string;
+};
+
+export type ResolvedRuntimeEnv = {
+  terminal: TerminalMode;
+  distro: string;
+  changed: boolean;
+  reason?: "wsl_unavailable" | "wsl_distro_unavailable" | "pwsh_unavailable";
+  availableDistros: string[];
+};
+
+export type RuntimeCliCheckResult = {
+  ok: boolean;
+  cli: string;
+  terminal: TerminalMode;
+  distro: string;
+  reason?: "empty_command" | "cli_missing";
+  error?: string;
+};
+
+/**
+ * 将命令行拆成轻量 argv，用于提取首个可执行命令。
+ * @param cmd 用户配置或内置生成的启动命令
+ */
+export function splitRuntimeCommandLine(cmd: string | null | undefined): string[] {
+  const raw = String(cmd || "").trim();
+  if (!raw) return [];
+
+  const out: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let i = 0;
+
+  const push = () => {
+    if (!current) return;
+    out.push(current);
+    current = "";
+  };
+
+  while (i < raw.length) {
+    const ch = raw[i];
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+        i += 1;
+        continue;
+      }
+      if (quote === '"' && ch === "\\" && i + 1 < raw.length) {
+        const next = raw[i + 1];
+        if (next === '"' || next === "\\") {
+          current += next;
+          i += 2;
+          continue;
+        }
+      }
+      current += ch;
+      i += 1;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      i += 1;
+      continue;
+    }
+
+    if (/\s/.test(ch)) {
+      push();
+      while (i < raw.length && /\s/.test(raw[i])) i += 1;
+      continue;
+    }
+
+    if (ch === "\\" && i + 1 < raw.length) {
+      const next = raw[i + 1];
+      if (/\s/.test(next) || next === "'" || next === '"' || next === "\\") {
+        current += next;
+        i += 2;
+        continue;
+      }
+    }
+
+    current += ch;
+    i += 1;
+  }
+  push();
+  return out;
+}
+
+/**
+ * 去掉命令连接符附着在 token 尾部的分号，便于识别实际命令。
+ * @param token 命令行 token
+ */
+function trimRuntimeCommandToken(token: string): string {
+  return String(token || "").trim().replace(/;$/, "");
+}
+
+/**
+ * 判断 token 是否为临时环境变量赋值。
+ * @param token 命令行 token
+ */
+function isRuntimeEnvAssignmentToken(token: string): boolean {
+  const value = trimRuntimeCommandToken(token);
+  return /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(value);
+}
+
+/**
+ * 从启动命令中提取实际需要检查的 CLI 名称。
+ * @param startupCmd Provider 基础启动命令
+ */
+export function extractRuntimeCliName(startupCmd: string | null | undefined): string {
+  const argv = splitRuntimeCommandLine(startupCmd);
+  for (const token of argv) {
+    const value = trimRuntimeCommandToken(token);
+    if (!value) continue;
+    const lower = value.toLowerCase();
+    if (lower === "set" || lower === "export" || lower === "env") continue;
+    if (isRuntimeEnvAssignmentToken(value)) continue;
+    if (/^\$env:/i.test(value)) continue;
+    if (value === ";" || value === "&&" || value === "||" || value === "&") continue;
+    return value;
+  }
+  return "";
+}
+
+/**
+ * 将字符串转换为 Bash 单引号字面量。
+ * @param value 待转义文本
+ */
+function bashSingleQuote(value: string): string {
+  const s = String(value ?? "");
+  if (s.length === 0) return "''";
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * 执行原生命令并返回是否成功。
+ * @param file 可执行文件
+ * @param args 参数列表
+ */
+async function execFileOk(file: string, args: string[]): Promise<boolean> {
+  return await new Promise((resolve) => {
+    execFile(
+      file,
+      args,
+      { encoding: "utf8", timeout: 2_500, windowsHide: true },
+      (error) => resolve(!error),
+    );
+  });
+}
+
+/**
+ * 判断给定路径是否存在并可作为命令启动。
+ * @param command CLI 路径
+ */
+function hasExecutablePath(command: string): boolean {
+  try {
+    if (process.platform === "win32")
+      return fs.existsSync(command);
+    fs.accessSync(command, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 判断宿主系统当前 PATH 中是否存在指定 CLI。
+ * @param cli CLI 名称或可执行文件路径
+ */
+async function hasHostCli(cli: string): Promise<boolean> {
+  const command = String(cli || "").trim();
+  if (!command) return false;
+  if (/[\\/]/.test(command))
+    return hasExecutablePath(command);
+  if (process.platform === "win32")
+    return await execFileOk("where.exe", [command]);
+  return await execFileOk("sh", ["-lc", `command -v -- ${bashSingleQuote(command)} >/dev/null 2>&1`]);
+}
+
+/**
+ * 判断 WSL 当前 PATH 中是否存在指定 CLI。
+ * @param distro WSL 发行版
+ * @param cli CLI 名称或可执行文件路径
+ */
+async function hasWslCli(distro: string, cli: string): Promise<boolean> {
+  const command = String(cli || "").trim();
+  if (!command) return false;
+  const quoted = bashSingleQuote(command);
+  const script = command.includes("/")
+    ? `test -x ${quoted} && echo yes || echo no`
+    : `command -v -- ${quoted} >/dev/null 2>&1 && echo yes || echo no`;
+  const out = await wsl.execInWslAsync(distro, script, { timeoutMs: 3_000 });
+  return String(out || "").trim().toLowerCase() === "yes";
+}
+
+/**
+ * 从发行版列表中选择一个可见发行版。
+ * @param preferred 用户配置中的发行版名称
+ * @param distros 当前可用发行版列表
+ */
+function pickVisibleDistro(preferred: string, distros: DistroInfo[]): string {
+  const normalized = String(preferred || "").trim();
+  if (normalized) {
+    const hit = distros.find((item) => String(item?.name || "").toLowerCase() === normalized.toLowerCase());
+    if (hit?.name) return hit.name;
+  }
+
+  const ubuntu = distros.filter((item) => /ubuntu/i.test(String(item?.name || "")));
+  const ubuntuDefault = ubuntu.find((item) => item.isDefault && item.name);
+  if (ubuntuDefault?.name) return ubuntuDefault.name;
+
+  const parseUbuntuVersion = (name: string): number => {
+    const match = String(name || "").match(/ubuntu[-_\s]?([0-9]{2})\.([0-9]{2})/i);
+    if (!match) return 0;
+    return Number(`${match[1].padStart(2, "0")}${match[2].padStart(2, "0")}`);
+  };
+  const sortedUbuntu = ubuntu
+    .map((item) => ({ item, version: parseUbuntuVersion(item.name) }))
+    .sort((a, b) => b.version - a.version);
+  if (sortedUbuntu[0]?.item?.name) return sortedUbuntu[0].item.name;
+
+  const markedDefault = distros.find((item) => item.isDefault && item.name);
+  if (markedDefault?.name) return markedDefault.name;
+  const running = distros.find((item) => String(item?.state || "").toLowerCase() === "running" && item.name);
+  if (running?.name) return running.name;
+  return distros.find((item) => !!item.name)?.name || normalized;
+}
+
+/**
+ * 将请求的终端环境解析为当前机器上可见的环境。
+ * @param input 请求使用的终端环境
+ */
+export async function resolveVisibleRuntimeEnv(input: RuntimeEnvInput): Promise<ResolvedRuntimeEnv> {
+  const requestedTerminal = normalizeTerminal(input.terminal);
+  const requestedDistro = String(input.distro || "").trim();
+
+  if (process.platform !== "win32") {
+    return {
+      terminal: requestedTerminal,
+      distro: requestedDistro,
+      changed: false,
+      availableDistros: [],
+    };
+  }
+
+  const distros = await wsl.listDistrosAsync();
+  const availableDistros = distros.map((item) => String(item?.name || "").trim()).filter(Boolean);
+
+  if (requestedTerminal === "wsl") {
+    if (distros.length <= 0) {
+      return {
+        terminal: await pickVisibleWindowsTerminalMode(),
+        distro: requestedDistro,
+        changed: true,
+        reason: "wsl_unavailable",
+        availableDistros,
+      };
+    }
+
+    const distro = pickVisibleDistro(requestedDistro, distros);
+    const changed = !!requestedDistro && distro.toLowerCase() !== requestedDistro.toLowerCase();
+    return {
+      terminal: "wsl",
+      distro,
+      changed,
+      reason: changed ? "wsl_distro_unavailable" : undefined,
+      availableDistros,
+    };
+  }
+
+  if (requestedTerminal === "pwsh" && !(await hasPwsh())) {
+    return {
+      terminal: "windows",
+      distro: requestedDistro,
+      changed: true,
+      reason: "pwsh_unavailable",
+      availableDistros,
+    };
+  }
+
+  return {
+    terminal: requestedTerminal,
+    distro: requestedDistro,
+    changed: false,
+    availableDistros,
+  };
+}
+
+/**
+ * 检查指定运行环境中是否能找到 Provider 要启动的 CLI。
+ * @param input 运行环境与启动命令
+ */
+export async function checkRuntimeCli(input: RuntimeEnvInput & { startupCmd?: string }): Promise<RuntimeCliCheckResult> {
+  const resolved = await resolveVisibleRuntimeEnv(input);
+  const cli = extractRuntimeCliName(input.startupCmd);
+  if (!cli) {
+    return {
+      ok: true,
+      cli: "",
+      terminal: resolved.terminal,
+      distro: resolved.distro,
+      reason: "empty_command",
+    };
+  }
+
+  const exists = process.platform === "win32" && resolved.terminal === "wsl"
+    ? await hasWslCli(resolved.distro, cli)
+    : await hasHostCli(cli);
+  if (exists) {
+    return {
+      ok: true,
+      cli,
+      terminal: resolved.terminal,
+      distro: resolved.distro,
+    };
+  }
+
+  return {
+    ok: false,
+    cli,
+    terminal: resolved.terminal,
+    distro: resolved.distro,
+    reason: "cli_missing",
+    error: `${cli} not found`,
+  };
+}

--- a/electron/settings.ts
+++ b/electron/settings.ts
@@ -5,8 +5,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { app } from 'electron';
 import os from 'node:os';
-import { execFileSync } from 'node:child_process';
-import { getSessionsRootsFastAsync, listDistros, execInWslAsync } from './wsl.js';
+import { getSessionsRootsFastAsync, listDistros } from './wsl.js';
 import { hasPwsh, normalizeTerminal, type TerminalMode } from './shells.js';
 import type { TerminalThemeId } from '@/types/terminal-theme';
 import type { DistroInfo } from './wsl';
@@ -166,6 +165,34 @@ export type AppSettings = {
 
 function getStorePath() {
   return path.join(app.getPath('userData'), 'settings.json');
+}
+
+/**
+ * 判断设置文件是否已经存在。
+ */
+export function hasSettingsStore(): boolean {
+  try {
+    return fs.existsSync(getStorePath());
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 判断用户是否已经保存过明确的终端环境选择。
+ */
+export function hasSavedRuntimeEnvSelection(): boolean {
+  try {
+    const storePath = getStorePath();
+    if (!fs.existsSync(storePath)) return false;
+    const raw = JSON.parse(fs.readFileSync(storePath, 'utf8') || '{}') as any;
+    if (typeof raw?.terminal === 'string' && raw.terminal.trim().length > 0) return true;
+    const env = raw?.providers?.env;
+    if (!env || typeof env !== 'object') return false;
+    return Object.values(env).some((value: any) => typeof value?.terminal === 'string' && value.terminal.trim().length > 0);
+  } catch {
+    return false;
+  }
 }
 
 const DEFAULT_WSL_DISTRO = 'Ubuntu-24.04';
@@ -676,7 +703,7 @@ export async function ensureSettingsAutodetect(): Promise<AppSettings> {
  * 首次运行时：自动选择终端环境（不提示安装）。
  * 规则：
  *  - 优先使用 WSL；在有多个发行版时优先 Ubuntu（版本高者优先）。
- *  - 若未检测到任何 WSL 发行版，但在 PowerShell 可找到 codex，则默认使用 PowerShell。
+ *  - 若未检测到任何 WSL 发行版，则优先使用 PowerShell 7，否则使用 Windows PowerShell。
  *  - 仅在“首次无设置文件或设置缺失 terminal 字段”时写入；否则保持用户选择。
  */
 export async function ensureFirstRunTerminalSelection(): Promise<AppSettings> {
@@ -690,39 +717,14 @@ export async function ensureFirstRunTerminalSelection(): Promise<AppSettings> {
     }
 
     const distros = loadDistroList();
-    // 情况 A：存在 WSL，优先 Ubuntu；若仅 PowerShell 中存在 codex 则选 Windows
+    // 情况 A：存在 WSL，首次直接选择可见 WSL，不混入 CLI 是否安装的判断。
     if (os.platform() === 'win32' && Array.isArray(distros) && distros.length > 0) {
       const distro = pickPreferredDistro('', distros);
-      const hasPsCodex = (() => {
-        try {
-          const out = execFileSync('where.exe', ['codex'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 3000 });
-          return !!String(out || '').trim();
-        } catch { return false; }
-      })();
-      const hasWslCodex = !!(await (async () => {
-        try {
-          const out = await execInWslAsync(distro, 'command -v codex >/dev/null 2>&1 && echo yes || echo no');
-          return (out || '').trim().toLowerCase() === 'yes';
-        } catch { return false; }
-      })());
-      if (hasPsCodex && !hasWslCodex) {
-        if (await hasPwsh()) {
-          return updateSettings({ terminal: 'pwsh' });
-        }
-        return updateSettings({ terminal: 'windows' });
-      }
       return updateSettings({ terminal: 'wsl', distro });
     }
 
-    // 情况 B：无 WSL，若 PowerShell 中存在 codex，则选 Windows；否则仍写 Windows 以避免 WSL 失败
-    const hasPsCodex = (() => {
-      if (os.platform() !== 'win32') return false;
-      try {
-        const out = execFileSync('where.exe', ['codex'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 3000 });
-        return !!String(out || '').trim();
-      } catch { return false; }
-    })();
-    if (hasPsCodex || os.platform() === 'win32') {
+    // 情况 B：无 WSL，优先 PowerShell 7，否则 Windows PowerShell。
+    if (os.platform() === 'win32') {
       return updateSettings({ terminal: await hasPwsh() ? 'pwsh' : 'windows' });
     }
 
@@ -733,6 +735,6 @@ export async function ensureFirstRunTerminalSelection(): Promise<AppSettings> {
   }
 }
 
-export default { getSettings, updateSettings };
+export default { getSettings, updateSettings, hasSettingsStore, hasSavedRuntimeEnvSelection };
 
 

--- a/electron/shells.ts
+++ b/electron/shells.ts
@@ -101,6 +101,15 @@ export async function hasPwsh(): Promise<boolean> {
   return !!hit;
 }
 
+/**
+ * 选择当前平台可见的 Windows 终端环境。
+ */
+export async function pickVisibleWindowsTerminalMode(): Promise<TerminalMode> {
+  if (process.platform === "win32" && await hasPwsh())
+    return "pwsh";
+  return "windows";
+}
+
 export function resolveWindowsShell(mode: "windows" | "pwsh" | "cmd"): WindowsShellResolution {
   if (mode === "cmd") {
     return { command: "cmd.exe", kind: "cmd" };

--- a/electron/wsl.ts
+++ b/electron/wsl.ts
@@ -119,6 +119,21 @@ export async function listDistrosAsync(): Promise<DistroInfo[]> {
 }
 
 /**
+ * 判断指定 WSL 发行版当前是否可用。
+ */
+export async function isDistroAvailableAsync(distro?: string): Promise<boolean> {
+  try {
+    const name = String(distro || "").trim();
+    const distros = await listDistrosAsync();
+    if (name)
+      return distros.some((item) => String(item?.name || "").toLowerCase() === name.toLowerCase());
+    return distros.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * 在 WSL 发行版中执行命令并返回 stdout（默认带超时；失败返回 null）。
  */
 export async function execInWslAsync(
@@ -431,6 +446,7 @@ export function distroExists(name: string): boolean {
 export default {
   listDistros,
   listDistrosAsync,
+  isDistroAvailableAsync,
   winToWsl,
   winToWslAsync,
   wslToUNC,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4602,6 +4602,11 @@ export default function CodexFlowManagerUI() {
     claude: { terminal: "wsl", distro: "Ubuntu-24.04" },
     gemini: { terminal: "wsl", distro: "Ubuntu-24.04" },
   }));
+  const activeProviderIdRef = useRef(activeProviderId);
+  const providerItemsRef = useRef(providerItems);
+  const providerEnvByIdRef = useRef(providerEnvById);
+  const providerSwitchSeqRef = useRef(0);
+  const providerSettingsPersistQueueRef = useRef<Promise<void>>(Promise.resolve());
   const [wslDistro, setWslDistro] = useState("Ubuntu-24.04");
   // 基础命令（默认 'codex'），不做 tmux 包装，直接在 WSL 中执行。
   const [codexCmd, setCodexCmd] = useState("codex");
@@ -4630,6 +4635,18 @@ export default function CodexFlowManagerUI() {
   const [startupChecksComplete, setStartupChecksComplete] = useState(false);
 
   const themeMode = useThemeController(themeSetting);
+
+  useEffect(() => {
+    activeProviderIdRef.current = activeProviderId;
+  }, [activeProviderId]);
+
+  useEffect(() => {
+    providerItemsRef.current = providerItems;
+  }, [providerItems]);
+
+  useEffect(() => {
+    providerEnvByIdRef.current = providerEnvById;
+  }, [providerEnvById]);
 
   useEffect(() => {
     writeThemeSettingCache(themeSetting);
@@ -4707,15 +4724,32 @@ export default function CodexFlowManagerUI() {
   }, [wslDistro]);
 
   /**
+   * 排队持久化当前 Provider 状态，避免快速切换时旧写入覆盖新选择。
+   */
+  const queueProviderSettingsPersist = useCallback((): void => {
+    providerSettingsPersistQueueRef.current = providerSettingsPersistQueueRef.current
+      .catch(() => {})
+      .then(async () => {
+        await persistProviders({
+          activeId: activeProviderIdRef.current,
+          items: providerItemsRef.current,
+          env: providerEnvByIdRef.current,
+        });
+      })
+      .catch(() => {});
+  }, [persistProviders]);
+
+  /**
    * 获取指定 Provider 的环境（缺失时回退到 codex 或当前状态）。
    */
   const getProviderEnv = useCallback((providerId: string): Required<ProviderEnv> => {
-    const hit = providerEnvById[providerId];
+    const envById = providerEnvByIdRef.current;
+    const hit = envById[providerId];
     if (hit) return hit;
-    const fallback = providerEnvById["codex"];
+    const fallback = envById["codex"];
     if (fallback) return fallback;
     return { terminal: terminalMode, distro: wslDistro };
-  }, [providerEnvById, terminalMode, wslDistro]);
+  }, [terminalMode, wslDistro]);
 
   /**
    * 中文说明：获取标签页真实执行环境。
@@ -4725,6 +4759,78 @@ export default function CodexFlowManagerUI() {
   const getTabExecEnv = useCallback((tabId: string, providerId: string): Required<ProviderEnv> => {
     return tabExecEnvByTabRef.current[tabId] || getProviderEnv(providerId);
   }, [getProviderEnv]);
+
+  /**
+   * 解析当前机器可见的 Provider 执行环境，并在必要时同步到界面状态。
+   *
+   * @param providerId Provider 唯一标识
+   * @param requestedEnv 请求使用的执行环境
+   * @param options 是否把修正后的环境写入 Provider 设置或界面状态
+   */
+  const resolveVisibleProviderEnv = useCallback(async (
+    providerId: string,
+    requestedEnv: Required<ProviderEnv>,
+    options?: { persist?: boolean; updateState?: boolean },
+  ): Promise<Required<ProviderEnv>> => {
+    const fallback: Required<ProviderEnv> = {
+      terminal: normalizeTerminalMode(requestedEnv?.terminal),
+      distro: String(requestedEnv?.distro || wslDistro || "").trim(),
+    };
+    try {
+      const result = await window.host.settings.resolveRuntimeEnv?.({
+        terminal: fallback.terminal,
+        distro: fallback.distro,
+      });
+      if (!result?.ok || !result.terminal)
+        return fallback;
+      const resolved: Required<ProviderEnv> = {
+        terminal: normalizeTerminalMode(result.terminal),
+        distro: String(result.distro || fallback.distro || "").trim(),
+      };
+      const changed = resolved.terminal !== fallback.terminal
+        || String(resolved.distro || "").toLowerCase() !== String(fallback.distro || "").toLowerCase();
+      const shouldUpdateState = options?.updateState !== false;
+      if (shouldUpdateState && (changed || options?.persist)) {
+        const nextMap = { ...providerEnvByIdRef.current, [providerId]: resolved };
+        providerEnvByIdRef.current = nextMap;
+        setProviderEnvById(nextMap);
+        if (providerId === activeProviderIdRef.current) {
+          setTerminalMode(resolved.terminal);
+          setWslDistro(resolved.distro);
+        }
+        if (options?.persist)
+          await persistProviders({ activeId: activeProviderIdRef.current, items: providerItemsRef.current, env: nextMap });
+      }
+      return resolved;
+    } catch {
+      return fallback;
+    }
+  }, [persistProviders, wslDistro]);
+
+  /**
+   * 按实际执行环境生成终端标签名称。
+   *
+   * @param env 实际执行环境
+   * @param projectId 项目 id
+   */
+  const buildConsoleTabNameForEnv = useCallback((env: Required<ProviderEnv>, projectId: string): string => {
+    return isWindowsLike(env.terminal as any)
+      ? toShellLabel(env.terminal as any)
+      : (env.distro || `Console ${((tabsByProjectRef.current[projectId] || []).length + 1).toString()}`);
+  }, []);
+
+  /**
+   * 生成执行环境展示名，用于环境回退与 CLI 缺失提示。
+   *
+   * @param env 实际执行环境
+   */
+  const formatProviderEnvLabel = useCallback((env: Required<ProviderEnv>): string => {
+    if (env.terminal === "wsl") {
+      const distro = String(env.distro || "").trim();
+      return distro ? `WSL (${distro})` : "WSL";
+    }
+    return toShellLabel(env.terminal as any);
+  }, []);
 
   /**
    * 中文说明：构造某个标签页真正打开 PTY 时使用的环境变量。
@@ -4807,16 +4913,30 @@ export default function CodexFlowManagerUI() {
   }, []);
 
   /**
-   * 构造某个 Provider 的启动命令（Codex 会按调试开关注入 trace 环境变量）。
+   * 构造某个 Provider 的基础启动命令，用于 CLI 可用性检查。
+   *
+   * @param providerId Provider 唯一标识
    */
-  const buildProviderStartupCmd = useCallback((providerId: string, env: Required<ProviderEnv>): string => {
+  const buildProviderBaseStartupCmd = useCallback((providerId: string): string => {
     const item = providerItems.find((x) => x.id === providerId) ?? { id: providerId };
     const resolved = resolveProvider(item);
-    if (providerId === "codex") {
-      return injectCodexTraceEnv({ cmd: resolved.startupCmd || codexCmd, traceEnabled: codexTraceEnabled, terminalMode: env.terminal as any });
-    }
+    if (providerId === "codex")
+      return resolved.startupCmd || codexCmd || "codex";
     return resolved.startupCmd;
-  }, [providerItems, codexCmd, codexTraceEnabled]);
+  }, [providerItems, codexCmd]);
+
+  /**
+   * 构造某个 Provider 的启动命令（Codex 会按调试开关注入 trace 环境变量）。
+   *
+   * @param providerId Provider 唯一标识
+   * @param env 实际执行环境
+   */
+  const buildProviderStartupCmd = useCallback((providerId: string, env: Required<ProviderEnv>): string => {
+    const baseCmd = buildProviderBaseStartupCmd(providerId);
+    if (providerId === "codex")
+      return injectCodexTraceEnv({ cmd: baseCmd, traceEnabled: codexTraceEnabled, terminalMode: env.terminal as any });
+    return baseCmd;
+  }, [buildProviderBaseStartupCmd, codexTraceEnabled]);
 
   /**
    * 构造 worktree 创建面板用的 Provider 启动命令（可临时覆盖 YOLO，不写入全局设置）。
@@ -4830,16 +4950,14 @@ export default function CodexFlowManagerUI() {
     const env = args.env;
     if (typeof args.useYolo !== "boolean") return buildProviderStartupCmd(providerId, env);
 
-    const item = providerItems.find((x) => x.id === providerId) ?? { id: providerId };
-    const resolved = resolveProvider(item);
-    const raw = providerId === "codex" ? (resolved.startupCmd || codexCmd) : resolved.startupCmd;
+    const raw = buildProviderBaseStartupCmd(providerId);
     const adjusted = resolveStartupCmdWithYolo({ providerId, startupCmd: raw, enabled: args.useYolo });
 
     if (providerId === "codex") {
       return injectCodexTraceEnv({ cmd: adjusted || raw || codexCmd, traceEnabled: codexTraceEnabled, terminalMode: env.terminal as any });
     }
     return adjusted;
-  }, [buildProviderStartupCmd, codexCmd, codexTraceEnabled, providerItems]);
+  }, [buildProviderBaseStartupCmd, buildProviderStartupCmd, codexTraceEnabled]);
 
   /**
    * 中文说明：按目标 Provider 的真实终端环境，编译 worktree 首次启动要注入的初始提示词。
@@ -4850,11 +4968,12 @@ export default function CodexFlowManagerUI() {
     providerId: GitWorktreeProviderId;
     prompt?: string;
     promptSource?: WorktreePromptSource;
+    envOverride?: Required<ProviderEnv>;
   }): string => {
     const prompt = typeof args.prompt === "string" ? String(args.prompt || "") : "";
     if (prompt) return prompt;
     if (!args.promptSource) return "";
-    const env = getProviderEnv(args.providerId);
+    const env = args.envOverride || getProviderEnv(args.providerId);
     return compileWorktreePromptText({
       chips: args.promptSource.chips,
       draft: args.promptSource.draft,
@@ -4879,17 +4998,213 @@ export default function CodexFlowManagerUI() {
   }, [providerItemById, t]);
 
   /**
+   * 展示环境回退提示，并写入 perf 日志。
+   *
+   * @param args 环境回退信息
+   */
+  const notifyRuntimeEnvFallback = useCallback(async (args: {
+    providerId?: string;
+    from: Required<ProviderEnv>;
+    to: Required<ProviderEnv>;
+    reason?: string;
+    source?: string;
+  }) => {
+    const fromLabel = formatProviderEnvLabel(args.from);
+    const toLabel = formatProviderEnvLabel(args.to);
+    if (fromLabel === toLabel && !args.reason) return;
+    const provider = args.providerId ? getProviderLabel(args.providerId) : "";
+    const reason = String(args.reason || "");
+    const title = t("terminal:envFallbackTitle", "已切换运行环境") as string;
+    const message = reason === "wsl_spawn_failed"
+      ? t("terminal:envFallbackWslStartFailed", "WSL 启动失败，已切换到 {to}。", { to: toLabel }) as string
+      : t("terminal:envFallbackMessage", "原 {from} 环境不可用，已切换到 {to}。", { from: fromLabel, to: toLabel }) as string;
+    setNoticeDialog({ open: true, title, message });
+    try {
+      await (window as any).host?.utils?.perfLog?.(
+        `[runtime-env] fallback source=${args.source || "ui"} provider=${provider || args.providerId || ""} from=${fromLabel} to=${toLabel} reason=${reason}`,
+      );
+    } catch {}
+  }, [formatProviderEnvLabel, getProviderLabel, t]);
+
+  /**
+   * 展示主进程修正设置环境后的提示。
+   *
+   * @param repair settings.get 返回的一次性修正信息
+   */
+  const notifyRuntimeEnvRepair = useCallback(async (repair: any): Promise<void> => {
+    if (!repair || repair.notify !== true || !Array.isArray(repair.entries) || repair.entries.length <= 0) return;
+    const first = repair.entries.find((item: any) => item && item.from && item.to) || null;
+    if (!first) return;
+    const from: Required<ProviderEnv> = {
+      terminal: normalizeTerminalMode(first.from?.terminal),
+      distro: String(first.from?.distro || ""),
+    };
+    const to: Required<ProviderEnv> = {
+      terminal: normalizeTerminalMode(first.to?.terminal),
+      distro: String(first.to?.distro || ""),
+    };
+    await notifyRuntimeEnvFallback({
+      providerId: String(first.providerId || ""),
+      from,
+      to,
+      reason: String(first.reason || ""),
+      source: "settings",
+    });
+  }, [notifyRuntimeEnvFallback]);
+
+  /**
+   * 检查 Provider CLI 是否存在；缺失时提示并阻止打开终端。
+   *
+   * @param providerId Provider 唯一标识
+   * @param env 实际执行环境
+   * @param startupCmd 用于检查的基础启动命令
+   */
+  const checkProviderCliBeforeLaunch = useCallback(async (
+    providerId: string,
+    env: Required<ProviderEnv>,
+    startupCmd?: string,
+  ): Promise<boolean> => {
+    if (!isBuiltInSessionProviderId(providerId)) return true;
+    const checkCmd = String(startupCmd || buildProviderBaseStartupCmd(providerId) || "").trim();
+    if (!checkCmd) return true;
+    try {
+      const result = await window.host.settings.checkRuntimeCli?.({
+        terminal: env.terminal,
+        distro: env.distro,
+        startupCmd: checkCmd,
+      });
+      if (!result || result.ok) return true;
+      const provider = getProviderLabel(providerId);
+      const cli = String(result.cli || checkCmd.split(/\s+/)[0] || providerId).trim();
+      const envLabel = formatProviderEnvLabel(env);
+      setNoticeDialog({
+        open: true,
+        title: t("terminal:cliMissingTitle", "{provider} CLI 未安装", { provider }) as string,
+        message: t("terminal:cliMissingMessage", "{provider} CLI 未安装，当前 {env} 环境无法访问 `{cli}` 命令。", { provider, env: envLabel, cli }) as string,
+      });
+      try {
+        await (window as any).host?.utils?.perfLog?.(
+          `[runtime-env] cli-block provider=${providerId} cli=${cli} env=${envLabel}`,
+        );
+      } catch {}
+      return false;
+    } catch (error: any) {
+      try {
+        await (window as any).host?.utils?.perfLog?.(
+          `[runtime-env] cli-check exception provider=${providerId} error=${String(error?.message || error)}`,
+        );
+      } catch {}
+      return true;
+    }
+  }, [buildProviderBaseStartupCmd, formatProviderEnvLabel, getProviderLabel, t]);
+
+  /**
+   * 准备 Provider 启动所需的实际环境与命令；检查失败时不创建终端。
+   *
+   * @param args Provider 启动请求
+   */
+  const prepareProviderLaunch = useCallback(async (args: {
+    providerId: string;
+    requestedEnv: Required<ProviderEnv>;
+    startupCmd?: string;
+    cliCheckCmd?: string;
+    persist?: boolean;
+    notifyEnvFallback?: boolean;
+    source?: string;
+  }): Promise<{ ok: true; env: Required<ProviderEnv>; startupCmd: string } | { ok: false; error?: string }> => {
+    const requestedEnv: Required<ProviderEnv> = {
+      terminal: normalizeTerminalMode(args.requestedEnv?.terminal),
+      distro: String(args.requestedEnv?.distro || wslDistro || "").trim(),
+    };
+    const env = await resolveVisibleProviderEnv(args.providerId, requestedEnv, { persist: args.persist });
+    const changed = env.terminal !== requestedEnv.terminal
+      || String(env.distro || "").toLowerCase() !== String(requestedEnv.distro || "").toLowerCase();
+    if (changed && args.notifyEnvFallback)
+      await notifyRuntimeEnvFallback({ providerId: args.providerId, from: requestedEnv, to: env, source: args.source || "prepare" });
+    const cliCheckCmd = String(args.cliCheckCmd || buildProviderBaseStartupCmd(args.providerId) || "").trim();
+    const cliReady = await checkProviderCliBeforeLaunch(args.providerId, env, cliCheckCmd);
+    if (!cliReady) return { ok: false, error: "cli_missing" };
+    const startupCmd = String(args.startupCmd ?? buildProviderStartupCmd(args.providerId, env)).trim();
+    return { ok: true, env, startupCmd };
+  }, [buildProviderBaseStartupCmd, buildProviderStartupCmd, checkProviderCliBeforeLaunch, notifyRuntimeEnvFallback, resolveVisibleProviderEnv, wslDistro]);
+
+  /**
+   * 若 PTY 启动阶段发生运行时兜底，则提醒用户。
+   *
+   * @param args PTY 打开结果
+   */
+  const notifyPtyFallbackIfNeeded = useCallback(async (args: {
+    providerId: string;
+    requestedEnv: Required<ProviderEnv>;
+    actualEnv: Required<ProviderEnv>;
+    fallbackReason?: string;
+  }) => {
+    const reason = String(args.fallbackReason || "").trim();
+    if (!reason) return;
+    const changed = args.actualEnv.terminal !== args.requestedEnv.terminal
+      || String(args.actualEnv.distro || "").toLowerCase() !== String(args.requestedEnv.distro || "").toLowerCase();
+    if (!changed && reason !== "wsl_spawn_failed") return;
+    await notifyRuntimeEnvFallback({
+      providerId: args.providerId,
+      from: args.requestedEnv,
+      to: args.actualEnv,
+      reason,
+      source: "pty",
+    });
+  }, [notifyRuntimeEnvFallback]);
+
+  /**
    * 切换当前 Provider，并将其环境同步到“当前默认环境”状态（仅影响后续新建/启动）。
    */
-  const changeActiveProvider = useCallback(async (nextId: string) => {
+  const changeActiveProvider = useCallback((nextId: string) => {
     const id = String(nextId || "").trim();
-    if (!id || id === activeProviderId) return;
-    const env = getProviderEnv(id);
+    if (!id || id === activeProviderIdRef.current) return;
+    const requestedEnv = getProviderEnv(id);
+    const seq = providerSwitchSeqRef.current + 1;
+    providerSwitchSeqRef.current = seq;
+
+    activeProviderIdRef.current = id;
+    const optimisticMap = { ...providerEnvByIdRef.current, [id]: requestedEnv };
+    providerEnvByIdRef.current = optimisticMap;
     setActiveProviderId(id);
-    setTerminalMode(env.terminal as any);
-    setWslDistro(env.distro);
-    await persistProviders({ activeId: id, items: providerItems, env: providerEnvById });
-  }, [activeProviderId, getProviderEnv, persistProviders, providerEnvById, providerItems]);
+    setProviderEnvById(optimisticMap);
+    setTerminalMode(requestedEnv.terminal as any);
+    setWslDistro(requestedEnv.distro);
+    queueProviderSettingsPersist();
+
+    void (async () => {
+      const env = await resolveVisibleProviderEnv(id, requestedEnv, { persist: false, updateState: false });
+      if (providerSwitchSeqRef.current !== seq || activeProviderIdRef.current !== id) return;
+      const changed = env.terminal !== requestedEnv.terminal
+        || String(env.distro || "").toLowerCase() !== String(requestedEnv.distro || "").toLowerCase();
+      if (changed)
+        await notifyRuntimeEnvFallback({ providerId: id, from: requestedEnv, to: env, source: "providerSwitch" });
+      const nextMap = { ...providerEnvByIdRef.current, [id]: env };
+      providerEnvByIdRef.current = nextMap;
+      setProviderEnvById(nextMap);
+      setTerminalMode(env.terminal as any);
+      setWslDistro(env.distro);
+      queueProviderSettingsPersist();
+    })();
+  }, [getProviderEnv, notifyRuntimeEnvFallback, queueProviderSettingsPersist, resolveVisibleProviderEnv]);
+
+  /**
+   * 用户主动选择左上角环境时，修正不可用环境并提示最终选择。
+   *
+   * @param requestedEnv 用户请求切换到的环境
+   */
+  const selectActiveProviderEnv = useCallback(async (requestedEnv: Required<ProviderEnv>): Promise<Required<ProviderEnv>> => {
+    const normalized: Required<ProviderEnv> = {
+      terminal: normalizeTerminalMode(requestedEnv.terminal),
+      distro: String(requestedEnv.distro || wslDistro || "").trim(),
+    };
+    const env = await resolveVisibleProviderEnv(activeProviderId, normalized, { persist: true });
+    const changed = env.terminal !== normalized.terminal
+      || String(env.distro || "").toLowerCase() !== String(normalized.distro || "").toLowerCase();
+    if (changed)
+      await notifyRuntimeEnvFallback({ providerId: activeProviderId, from: normalized, to: env, source: "envMenu" });
+    return env;
+  }, [activeProviderId, notifyRuntimeEnvFallback, resolveVisibleProviderEnv, wslDistro]);
 
   // WSL 发行版列表：供环境下拉与设置面板复用（缓存到内存，避免重复请求）
   const [availableDistros, setAvailableDistros] = useState<string[]>([]);
@@ -5285,6 +5600,7 @@ export default function CodexFlowManagerUI() {
           const codexItem = normalizedProviders.items.find((x) => x.id === "codex");
           const codexResolved = resolveProvider(codexItem ?? { id: "codex" });
           setCodexCmd(codexResolved.startupCmd || legacyCodexCmd);
+          void notifyRuntimeEnvRepair((s as any)._runtimeEnvRepair);
           setSendMode(s.sendMode || 'write_and_enter');
           setProjectPathStyle((s as any).projectPathStyle || 'absolute');
           setDragDropWarnOutsideProject(((s as any)?.dragDrop?.warnOutsideProject) !== false);
@@ -5715,9 +6031,10 @@ export default function CodexFlowManagerUI() {
 
   async function openConsoleForProject(project: Project) {
     if (!project) return;
-    const tabName = isWindowsLike(terminalMode)
-      ? toShellLabel(terminalMode)
-      : (wslDistro || `Console ${((tabsByProject[project.id] || []).length + 1).toString()}`);
+    // 中文说明：普通新建终端是点击热路径，直接使用已保存环境；环境修复由设置加载/显式切换/PTY 启动兜底承担。
+    const env = getProviderEnv(activeProviderId);
+    const startupCmd = buildProviderStartupCmd(activeProviderId, env);
+    const tabName = buildConsoleTabNameForEnv(env, project.id);
     const tab: ConsoleTab = {
       id: uid(),
       name: String(tabName),
@@ -5727,11 +6044,19 @@ export default function CodexFlowManagerUI() {
       createdAt: Date.now(),
     };
     let ptyId: string | undefined;
+    registerTabProject(tab.id, project.id);
+    const nextTabsByProject = {
+      ...tabsByProjectRef.current,
+      [project.id]: [...(tabsByProjectRef.current[project.id] || []), tab],
+    };
+    tabsByProjectRef.current = nextTabsByProject;
+    setTabsByProject(nextTabsByProject);
+    setActiveTab(tab.id, { focusMode: 'immediate', allowDuringRename: true, delay: 0 });
+    try { setCenterMode('console'); } catch {}
+
     try {
-      const env = getProviderEnv(activeProviderId);
-      const startupCmd = buildProviderStartupCmd(activeProviderId, env);
       const launchEnv = await buildProviderLaunchEnv(tab.id, tab.providerId, tab.name, env, startupCmd);
-      const { id } = await window.host.pty.openWSLConsole({
+      const openRes = await window.host.pty.openWSLConsole({
         terminal: env.terminal,
         distro: env.distro,
         wslPath: project.wslPath,
@@ -5741,13 +6066,29 @@ export default function CodexFlowManagerUI() {
         startupCmd,
         env: launchEnv.env,
       });
-      tabExecEnvByTabRef.current[tab.id] = env;
+      const actualEnv: Required<ProviderEnv> = {
+        terminal: normalizeTerminalMode(openRes.terminal || env.terminal),
+        distro: String(openRes.distro || env.distro || ""),
+      };
+      if (actualEnv.terminal !== env.terminal || String(actualEnv.distro || "").toLowerCase() !== String(env.distro || "").toLowerCase()) {
+        const nextName = buildConsoleTabNameForEnv(actualEnv, project.id);
+        tab.name = nextName;
+        const renamedTabsByProject = {
+          ...tabsByProjectRef.current,
+          [project.id]: (tabsByProjectRef.current[project.id] || []).map((item) => item.id === tab.id ? { ...item, name: nextName } : item),
+        };
+        tabsByProjectRef.current = renamedTabsByProject;
+        setTabsByProject(renamedTabsByProject);
+      }
+      await notifyPtyFallbackIfNeeded({ providerId: activeProviderId, requestedEnv: env, actualEnv, fallbackReason: openRes.fallbackReason });
+      tabExecEnvByTabRef.current[tab.id] = actualEnv;
       geminiWindowsEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWindowsEditorReady;
       geminiWslEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWslEditorReady;
       geminiExternalEditorShortcutByTabRef.current[tab.id] = launchEnv.geminiExternalEditorShortcut;
-      ptyId = id;
+      ptyId = openRes.id;
     } catch (e) {
       console.error('Failed to open PTY for project', e);
+      closeTab(tab.id, project.id);
       alert(String(t('terminal:openFailed', { error: String((e as any)?.message || e) })));
       return;
     }
@@ -5759,9 +6100,6 @@ export default function CodexFlowManagerUI() {
       void recordCustomProviderDirIfNeeded(project, activeProviderId);
     }
 
-    registerTabProject(tab.id, project.id);
-    setTabsByProject((m) => ({ ...m, [project.id]: [...(m[project.id] || []), tab] }));
-    setActiveTab(tab.id, { focusMode: 'immediate', allowDuringRename: true, delay: 0 });
     if (ptyId) {
       ptyByTabRef.current[tab.id] = ptyId;
       setPtyByTab((m) => ({ ...m, [tab.id]: ptyId }));
@@ -5773,8 +6111,6 @@ export default function CodexFlowManagerUI() {
     try { window.host.projects.touch(project.id); } catch {}
     // 打开控制台后，立即在内存中更新最近使用时间，保证"最近使用优先"实时生效
     markProjectUsed(project.id);
-    // 确保视图停留在控制台
-    try { setCenterMode('console'); } catch {}
   }
   // 点击"打开项目"：弹出系统选择目录并把选中目录加入项目，随后打开控制台
   async function openProjectPicker() {
@@ -5817,10 +6153,12 @@ export default function CodexFlowManagerUI() {
   }, [tm]);
 
   async function openNewConsole() {
-    if (!selectedProject) return;
-    const tabName = isWindowsLike(terminalMode)
-      ? toShellLabel(terminalMode)
-      : (wslDistro || `Console ${((tabsByProject[selectedProject.id] || []).length + 1).toString()}`);
+    const project = selectedProject;
+    if (!project) return;
+    // 中文说明：普通新增标签页优先保证按钮响应，避免启动前环境/CLI 检测阻塞交互。
+    const env = getProviderEnv(activeProviderId);
+    const startupCmd = buildProviderStartupCmd(activeProviderId, env);
+    const tabName = buildConsoleTabNameForEnv(env, project.id);
     const tab: ConsoleTab = {
       id: uid(),
       // 默认使用当前设置中的终端名称
@@ -5831,45 +6169,65 @@ export default function CodexFlowManagerUI() {
       createdAt: Date.now(),
     };
     let ptyId: string | undefined;
+    registerTabProject(tab.id, project.id);
+    const nextTabsByProject = {
+      ...tabsByProjectRef.current,
+      [project.id]: [...(tabsByProjectRef.current[project.id] || []), tab],
+    };
+    tabsByProjectRef.current = nextTabsByProject;
+    setTabsByProject(nextTabsByProject);
+    setActiveTab(tab.id, { focusMode: 'immediate', allowDuringRename: true, delay: 0 });
+
     // Open PTY in main (WSL)
     try {
-      try { await (window as any).host?.utils?.perfLog?.(`[ui] openNewConsole start project=${selectedProject?.name}`); } catch {}
-      const env = getProviderEnv(activeProviderId);
-      const startupCmd = buildProviderStartupCmd(activeProviderId, env);
+      try { await (window as any).host?.utils?.perfLog?.(`[ui] openNewConsole start project=${project.name}`); } catch {}
       const launchEnv = await buildProviderLaunchEnv(tab.id, tab.providerId, tab.name, env, startupCmd);
-      const { id } = await window.host.pty.openWSLConsole({
+      const openRes = await window.host.pty.openWSLConsole({
         terminal: env.terminal,
         distro: env.distro,
-        wslPath: selectedProject.wslPath,
-        winPath: selectedProject.winPath,
+        wslPath: project.wslPath,
+        winPath: project.winPath,
         cols: 80,
         rows: 24,
         startupCmd,
         env: launchEnv.env,
       });
-      try { await (window as any).host?.utils?.perfLog?.(`[ui] openNewConsole pty=${id}`); } catch {}
-      tabExecEnvByTabRef.current[tab.id] = env;
+      try { await (window as any).host?.utils?.perfLog?.(`[ui] openNewConsole pty=${openRes.id}`); } catch {}
+      const actualEnv: Required<ProviderEnv> = {
+        terminal: normalizeTerminalMode(openRes.terminal || env.terminal),
+        distro: String(openRes.distro || env.distro || ""),
+      };
+      if (actualEnv.terminal !== env.terminal || String(actualEnv.distro || "").toLowerCase() !== String(env.distro || "").toLowerCase()) {
+        const nextName = buildConsoleTabNameForEnv(actualEnv, project.id);
+        tab.name = nextName;
+        const renamedTabsByProject = {
+          ...tabsByProjectRef.current,
+          [project.id]: (tabsByProjectRef.current[project.id] || []).map((item) => item.id === tab.id ? { ...item, name: nextName } : item),
+        };
+        tabsByProjectRef.current = renamedTabsByProject;
+        setTabsByProject(renamedTabsByProject);
+      }
+      await notifyPtyFallbackIfNeeded({ providerId: activeProviderId, requestedEnv: env, actualEnv, fallbackReason: openRes.fallbackReason });
+      tabExecEnvByTabRef.current[tab.id] = actualEnv;
       geminiWindowsEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWindowsEditorReady;
       geminiWslEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWslEditorReady;
       geminiExternalEditorShortcutByTabRef.current[tab.id] = launchEnv.geminiExternalEditorShortcut;
-      ptyId = id;
+      ptyId = openRes.id;
     } catch (e) {
       console.error('Failed to open PTY', e);
       try { await (window as any).host?.utils?.perfLog?.(`[ui] openNewConsole error ${String((e as any)?.stack || e)}`); } catch {}
+      closeTab(tab.id, project.id);
       alert(String(t('terminal:openFailed', { error: String((e as any)?.message || e) })));
       return;
     }
 
     // 内置三引擎：即便会话记录落盘存在延迟，也先在 UI 侧标记，避免“自定义目录记录可移除”误判。
     if (isBuiltInSessionProviderId(activeProviderId)) {
-      markProjectHasBuiltInSessions(selectedProject.id);
+      markProjectHasBuiltInSessions(project.id);
     } else {
-      void recordCustomProviderDirIfNeeded(selectedProject, activeProviderId);
+      void recordCustomProviderDirIfNeeded(project, activeProviderId);
     }
 
-    registerTabProject(tab.id, selectedProject.id);
-    setTabsByProject((m) => ({ ...m, [selectedProject.id]: [...(m[selectedProject.id] || []), tab] }));
-    setActiveTab(tab.id, { focusMode: 'immediate', allowDuringRename: true, delay: 0 });
     if (ptyId) {
       ptyByTabRef.current[tab.id] = ptyId;
       setPtyByTab((m) => ({ ...m, [tab.id]: ptyId }));
@@ -5880,9 +6238,9 @@ export default function CodexFlowManagerUI() {
       try { tm.setPty(tab.id, ptyId); } catch (err) { console.warn('tm.setPty failed', err); }
     }
     // touch project lastOpenedAt
-    try { window.host.projects.touch(selectedProject.id); } catch {}
+    try { window.host.projects.touch(project.id); } catch {}
     // 同步更新内存，触发排序刷新；并抑制历史面板自动切换
-    markProjectUsed(selectedProject.id);
+    markProjectUsed(project.id);
   }
 
   /**
@@ -6118,10 +6476,9 @@ export default function CodexFlowManagerUI() {
     try { suppressAutoSelectRef.current = true; } catch {}
     setSelectedProjectId(target.id);
 
-    const env = getProviderEnv(activeProviderId);
-    const defaultTitle = isWindowsLike(env.terminal)
-      ? toShellLabel(env.terminal)
-      : (env.distro || `Console ${((tabsByProjectRef.current[target.id] || []).length + 1).toString()}`);
+    const requestedEnv = getProviderEnv(activeProviderId);
+    const env = await resolveVisibleProviderEnv(activeProviderId, requestedEnv, { persist: true });
+    const defaultTitle = buildConsoleTabNameForEnv(env, target.id);
     const tab: ConsoleTab = {
       id: uid(),
       name: String(args?.title || "").trim() || defaultTitle,
@@ -6135,7 +6492,7 @@ export default function CodexFlowManagerUI() {
     let ptyId: string | undefined;
     try {
       const launchEnv = await buildProviderLaunchEnv(tab.id, tab.providerId, tab.name, env, startupCmd);
-      const { id } = await window.host.pty.openWSLConsole({
+      const openRes = await window.host.pty.openWSLConsole({
         terminal: env.terminal,
         distro: env.distro,
         wslPath: target.wslPath,
@@ -6145,11 +6502,18 @@ export default function CodexFlowManagerUI() {
         startupCmd,
         env: launchEnv.env,
       });
-      tabExecEnvByTabRef.current[tab.id] = env;
+      const actualEnv: Required<ProviderEnv> = {
+        terminal: normalizeTerminalMode(openRes.terminal || env.terminal),
+        distro: String(openRes.distro || env.distro || ""),
+      };
+      if (actualEnv.terminal !== env.terminal || String(actualEnv.distro || "").toLowerCase() !== String(env.distro || "").toLowerCase())
+        tab.name = buildConsoleTabNameForEnv(actualEnv, target.id);
+      await notifyPtyFallbackIfNeeded({ providerId: activeProviderId, requestedEnv: env, actualEnv, fallbackReason: openRes.fallbackReason });
+      tabExecEnvByTabRef.current[tab.id] = actualEnv;
       geminiWindowsEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWindowsEditorReady;
       geminiWslEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWslEditorReady;
       geminiExternalEditorShortcutByTabRef.current[tab.id] = launchEnv.geminiExternalEditorShortcut;
-      ptyId = id;
+      ptyId = openRes.id;
     } catch {
       return false;
     }
@@ -6177,14 +6541,17 @@ export default function CodexFlowManagerUI() {
     return true;
   }, [
     activeProviderId,
+    buildConsoleTabNameForEnv,
     buildProviderLaunchEnv,
     currentWindowId,
     getProviderEnv,
     hiddenProjectIdSet,
     markProjectHasBuiltInSessions,
     markProjectUsed,
+    notifyPtyFallbackIfNeeded,
     recordCustomProviderDirIfNeeded,
     resolveProjectByPathAsync,
+    resolveVisibleProviderEnv,
     tm,
   ]);
 
@@ -6795,10 +7162,11 @@ export default function CodexFlowManagerUI() {
       delete next[tabId];
       return next;
     });
-    const nextActiveTabByProject = activeTabId === tabId
+    const isClosingActiveTab = activeTabIdRef.current === tabId;
+    const nextActiveTabByProject = isClosingActiveTab
       ? { ...activeTabByProject, [projectId]: null }
       : activeTabByProject;
-    if (activeTabId === tabId) setActiveTab(null, { projectId, focusMode: "immediate", allowDuringRename: true });
+    if (isClosingActiveTab) setActiveTab(null, { projectId, focusMode: "immediate", allowDuringRename: true });
     const latestSnapshot = loadConsoleSession({ currentBootId: appBootId });
     const currentProjectName = projectsRef.current.find((project) => project.id === selectedProjectId)?.name || "";
     persistConsoleSessionSnapshot(nextTabsByProject, {
@@ -7471,15 +7839,14 @@ export default function CodexFlowManagerUI() {
     project: Project;
     providerId: GitWorktreeProviderId;
     startupCmd: string;
+    envOverride?: Required<ProviderEnv>;
   }): Promise<{ ok: boolean; tabId?: string; error?: string }> => {
     const project = args.project;
     const providerId = args.providerId;
     if (!project?.id) return { ok: false, error: "missing project" };
-    const env = getProviderEnv(providerId);
+    const env = args.envOverride || await resolveVisibleProviderEnv(providerId, getProviderEnv(providerId), { persist: true });
 
-    const tabName = env.terminal !== "wsl"
-      ? toShellLabel(env.terminal as any)
-      : (env.distro || `Console ${((tabsByProjectRef.current[project.id] || []).length + 1).toString()}`);
+    const tabName = buildConsoleTabNameForEnv(env, project.id);
 
     const tab: ConsoleTab = {
       id: uid(),
@@ -7493,7 +7860,7 @@ export default function CodexFlowManagerUI() {
     let ptyId: string | undefined;
     try {
       const launchEnv = await buildProviderLaunchEnv(tab.id, tab.providerId, tab.name, env, args.startupCmd);
-      const { id } = await window.host.pty.openWSLConsole({
+      const openRes = await window.host.pty.openWSLConsole({
         terminal: env.terminal,
         distro: env.distro,
         wslPath: project.wslPath,
@@ -7503,11 +7870,18 @@ export default function CodexFlowManagerUI() {
         startupCmd: args.startupCmd,
         env: launchEnv.env,
       });
-      tabExecEnvByTabRef.current[tab.id] = env;
+      const actualEnv: Required<ProviderEnv> = {
+        terminal: normalizeTerminalMode(openRes.terminal || env.terminal),
+        distro: String(openRes.distro || env.distro || ""),
+      };
+      if (actualEnv.terminal !== env.terminal || String(actualEnv.distro || "").toLowerCase() !== String(env.distro || "").toLowerCase())
+        tab.name = buildConsoleTabNameForEnv(actualEnv, project.id);
+      await notifyPtyFallbackIfNeeded({ providerId, requestedEnv: env, actualEnv, fallbackReason: openRes.fallbackReason });
+      tabExecEnvByTabRef.current[tab.id] = actualEnv;
       geminiWindowsEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWindowsEditorReady;
       geminiWslEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWslEditorReady;
       geminiExternalEditorShortcutByTabRef.current[tab.id] = launchEnv.geminiExternalEditorShortcut;
-      ptyId = id;
+      ptyId = openRes.id;
     } catch (e: any) {
       return { ok: false, error: String(e?.message || e) };
     }
@@ -7534,7 +7908,7 @@ export default function CodexFlowManagerUI() {
     try { window.host.projects.touch(project.id); } catch {}
     markProjectUsed(project.id);
     return { ok: true, tabId: tab.id };
-  }, [buildProviderLaunchEnv, currentWindowId, getProviderEnv, markProjectHasBuiltInSessions, recordCustomProviderDirIfNeeded, tm, markProjectUsed]);
+  }, [buildConsoleTabNameForEnv, buildProviderLaunchEnv, currentWindowId, getProviderEnv, markProjectHasBuiltInSessions, notifyPtyFallbackIfNeeded, recordCustomProviderDirIfNeeded, resolveVisibleProviderEnv, tm, markProjectUsed]);
 
   /**
    * 在指定项目中启动某个引擎实例，并注入初始提示词（worktree 新建/复用共用）。
@@ -7551,15 +7925,27 @@ export default function CodexFlowManagerUI() {
       const project = args.project;
       const providerId = args.providerId;
       if (!project?.id) return { ok: false, error: "missing project" };
-      const env = getProviderEnv(providerId);
+      const requestedEnv = getProviderEnv(providerId);
+      const env = await resolveVisibleProviderEnv(providerId, requestedEnv, { persist: true });
+      const baseCmd = buildProviderStartupCmdForWorktreeCreate({ providerId, env, useYolo: args.useYolo });
+      const prepared = await prepareProviderLaunch({
+        providerId,
+        requestedEnv,
+        startupCmd: baseCmd,
+        cliCheckCmd: baseCmd,
+        persist: true,
+        notifyEnvFallback: true,
+        source: "worktree",
+      });
+      if (!prepared.ok) return prepared;
       const prompt = buildWorktreePromptForProvider({
         providerId,
         prompt: args.prompt,
         promptSource: args.promptSource,
+        envOverride: prepared.env,
       });
-      const baseCmd = buildProviderStartupCmdForWorktreeCreate({ providerId, env, useYolo: args.useYolo });
-      const startupCmd = buildProviderStartupCmdWithInitialPrompt({ providerId, terminalMode: env.terminal as any, baseCmd, prompt });
-      const started = await openProviderConsoleInProject({ project, providerId, startupCmd });
+      const startupCmd = buildProviderStartupCmdWithInitialPrompt({ providerId, terminalMode: prepared.env.terminal as any, baseCmd: prepared.startupCmd, prompt });
+      const started = await openProviderConsoleInProject({ project, providerId, startupCmd, envOverride: prepared.env });
       const hasInitialPrompt = String(prompt || "").trim().length > 0;
       const tabId = String(started.tabId || "").trim();
       if (started.ok && tabId && hasInitialPrompt && shouldEnableAgentTimerForProvider(providerId))
@@ -7568,7 +7954,7 @@ export default function CodexFlowManagerUI() {
     } catch (e: any) {
       return { ok: false, error: String(e?.message || e) };
     }
-  }, [buildProviderStartupCmdForWorktreeCreate, buildWorktreePromptForProvider, getProviderEnv, openProviderConsoleInProject, shouldEnableAgentTimerForProvider, startAgentTurnTimer]);
+  }, [buildProviderStartupCmdForWorktreeCreate, buildWorktreePromptForProvider, getProviderEnv, openProviderConsoleInProject, prepareProviderLaunch, resolveVisibleProviderEnv, shouldEnableAgentTimerForProvider, startAgentTurnTimer]);
 
   /**
    * 执行创建 worktree，并在每个 worktree 内启动对应引擎 CLI。
@@ -9442,11 +9828,7 @@ export default function CodexFlowManagerUI() {
               className="flex items-center justify-between gap-2"
               onClick={async () => {
                 const nextEnv: Required<ProviderEnv> = { ...getProviderEnv(activeProviderId), terminal: "wsl" };
-                const nextMap = { ...providerEnvById, [activeProviderId]: nextEnv };
-                setProviderEnvById(nextMap);
-                setTerminalMode("wsl");
-                setWslDistro(nextEnv.distro);
-                await persistProviders({ activeId: activeProviderId, items: providerItems, env: nextMap });
+                await selectActiveProviderEnv(nextEnv);
               }}
             >
               <span>{t("settings:terminalMode.wsl")}</span>
@@ -9456,10 +9838,7 @@ export default function CodexFlowManagerUI() {
               className="flex items-center justify-between gap-2"
               onClick={async () => {
                 const nextEnv: Required<ProviderEnv> = { ...getProviderEnv(activeProviderId), terminal: "windows" };
-                const nextMap = { ...providerEnvById, [activeProviderId]: nextEnv };
-                setProviderEnvById(nextMap);
-                setTerminalMode("windows" as any);
-                await persistProviders({ activeId: activeProviderId, items: providerItems, env: nextMap });
+                await selectActiveProviderEnv(nextEnv);
               }}
             >
               <span>{t("settings:terminalMode.windows")}</span>
@@ -9469,10 +9848,7 @@ export default function CodexFlowManagerUI() {
               className="flex items-center justify-between gap-2"
               onClick={async () => {
                 const nextEnv: Required<ProviderEnv> = { ...getProviderEnv(activeProviderId), terminal: "pwsh" };
-                const nextMap = { ...providerEnvById, [activeProviderId]: nextEnv };
-                setProviderEnvById(nextMap);
-                setTerminalMode("pwsh" as any);
-                await persistProviders({ activeId: activeProviderId, items: providerItems, env: nextMap });
+                await selectActiveProviderEnv(nextEnv);
               }}
             >
               <span>{t("settings:terminalMode.pwsh")}</span>
@@ -9482,10 +9858,7 @@ export default function CodexFlowManagerUI() {
               className="flex items-center justify-between gap-2"
               onClick={async () => {
                 const nextEnv: Required<ProviderEnv> = { ...getProviderEnv(activeProviderId), terminal: "cmd" };
-                const nextMap = { ...providerEnvById, [activeProviderId]: nextEnv };
-                setProviderEnvById(nextMap);
-                setTerminalMode("cmd" as any);
-                await persistProviders({ activeId: activeProviderId, items: providerItems, env: nextMap });
+                await selectActiveProviderEnv(nextEnv);
               }}
             >
               <span>{t("settings:terminalMode.cmd")}</span>
@@ -10660,18 +11033,25 @@ export default function CodexFlowManagerUI() {
 	  const executeResume = async (filePath: string, mode: ResumeExecutionMode, execEnv: Required<ProviderEnv>, forceLegacyCli: boolean, targetProject: Project): Promise<boolean> => {
 	    try {
 	      if (!filePath || !targetProject) return false;
-	      const { providerId, startupCmd, session, sessionId, resumeLabel, strategy, resumeHint, forceLegacyCli: finalForceLegacy } = buildResumeStartup(filePath, execEnv.terminal as any, { forceLegacyCli });
+        const resumeSession = findSessionForFile(filePath);
+        const resumeProviderId = resolveHistoryProviderId(resumeSession ?? null);
+        const visibleExecEnv = await resolveVisibleProviderEnv(resumeProviderId, execEnv, { persist: true });
+        const envChanged = visibleExecEnv.terminal !== execEnv.terminal
+          || String(visibleExecEnv.distro || "").toLowerCase() !== String(execEnv.distro || "").toLowerCase();
+        if (envChanged)
+          await notifyRuntimeEnvFallback({ providerId: resumeProviderId, from: execEnv, to: visibleExecEnv, source: "historyResume" });
+	      const { providerId, startupCmd, session, sessionId, resumeLabel, strategy, resumeHint, forceLegacyCli: finalForceLegacy } = buildResumeStartup(filePath, visibleExecEnv.terminal as any, { forceLegacyCli });
+        const cliReady = await checkProviderCliBeforeLaunch(providerId, visibleExecEnv, buildProviderBaseStartupCmd(providerId));
+        if (!cliReady) return false;
 	      try {
-	        const base = `[ui] history.resume ${mode} provider=${providerId} terminal=${execEnv.terminal} target=${resumeLabel}`;
+	        const base = `[ui] history.resume ${mode} provider=${providerId} terminal=${visibleExecEnv.terminal} target=${resumeLabel}`;
 	        const extra = providerId === "codex"
 	          ? ` strategy=${strategy} resumeHint=${resumeHint} forceLegacy=${finalForceLegacy ? '1' : '0'} sessionId=${sessionId || 'none'} sessionRaw=${session?.id || 'n/a'}`
 	          : ` sessionRaw=${session?.id || 'n/a'}`;
 	        await (window as any).host?.utils?.perfLog?.(`${base}${extra}`);
 	      } catch {}
 	      if (mode === 'internal') {
-	        const tabName = isWindowsLike(execEnv.terminal as any)
-	          ? toShellLabel(execEnv.terminal as any)
-	          : (execEnv.distro || `Console ${((tabsByProject[targetProject.id] || []).length + 1).toString()}`);
+	        const tabName = buildConsoleTabNameForEnv(visibleExecEnv, targetProject.id);
         const tab: ConsoleTab = {
           id: uid(),
           name: String(tabName),
@@ -10685,10 +11065,10 @@ export default function CodexFlowManagerUI() {
           await (window as any).host?.utils?.perfLog?.(`[ui] history.resume openWSLConsole start tab=${tab.id}`);
         } catch {}
 	        try {
-          const launchEnv = await buildProviderLaunchEnv(tab.id, tab.providerId, tab.name, execEnv, startupCmd);
-          const { id } = await window.host.pty.openWSLConsole({
-            terminal: execEnv.terminal as any,
-            distro: execEnv.distro,
+          const launchEnv = await buildProviderLaunchEnv(tab.id, tab.providerId, tab.name, visibleExecEnv, startupCmd);
+          const openRes = await window.host.pty.openWSLConsole({
+            terminal: visibleExecEnv.terminal as any,
+            distro: visibleExecEnv.distro,
             wslPath: targetProject.wslPath,
             winPath: targetProject.winPath,
             cols: 80,
@@ -10697,13 +11077,20 @@ export default function CodexFlowManagerUI() {
             env: launchEnv.env,
           });
           try {
-            await (window as any).host?.utils?.perfLog?.(`[ui] history.resume pty=${id} tab=${tab.id} - registering listener`);
+            await (window as any).host?.utils?.perfLog?.(`[ui] history.resume pty=${openRes.id} tab=${tab.id} - registering listener`);
           } catch {}
-          tabExecEnvByTabRef.current[tab.id] = execEnv;
+          const actualEnv: Required<ProviderEnv> = {
+            terminal: normalizeTerminalMode(openRes.terminal || visibleExecEnv.terminal),
+            distro: String(openRes.distro || visibleExecEnv.distro || ""),
+          };
+          if (actualEnv.terminal !== visibleExecEnv.terminal || String(actualEnv.distro || "").toLowerCase() !== String(visibleExecEnv.distro || "").toLowerCase())
+            tab.name = buildConsoleTabNameForEnv(actualEnv, targetProject.id);
+          await notifyPtyFallbackIfNeeded({ providerId, requestedEnv: visibleExecEnv, actualEnv, fallbackReason: openRes.fallbackReason });
+          tabExecEnvByTabRef.current[tab.id] = actualEnv;
           geminiWindowsEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWindowsEditorReady;
           geminiWslEditorReadyByTabRef.current[tab.id] = launchEnv.geminiWslEditorReady;
           geminiExternalEditorShortcutByTabRef.current[tab.id] = launchEnv.geminiExternalEditorShortcut;
-          ptyId = id;
+          ptyId = openRes.id;
         } catch (err) {
           console.warn('executeResume failed', err);
           alert(String(t('history:resumeFailed', { error: String((err as any)?.message || err) })));
@@ -10736,10 +11123,10 @@ export default function CodexFlowManagerUI() {
         return true;
 	      }
 	      const res: any = await (window.host.utils as any).openExternalConsole({
-	        terminal: execEnv.terminal,
+	        terminal: visibleExecEnv.terminal,
 	        wslPath: targetProject.wslPath,
 	        winPath: targetProject.winPath,
-	        distro: execEnv.distro,
+	        distro: visibleExecEnv.distro,
 	        startupCmd,
 	        title: getProviderLabel(providerId),
 	      });
@@ -11580,14 +11967,21 @@ export default function CodexFlowManagerUI() {
                 onClick={async () => {
 	                  if (proj) {
 	                    try {
-	                      const env = getProviderEnv(activeProviderId);
-	                      const startupCmd = buildProviderStartupCmd(activeProviderId, env);
+	                      const requestedEnv = getProviderEnv(activeProviderId);
+	                      const prepared = await prepareProviderLaunch({
+	                        providerId: activeProviderId,
+	                        requestedEnv,
+	                        persist: true,
+	                        notifyEnvFallback: true,
+	                        source: "projectExternal",
+	                      });
+	                      if (!prepared.ok) return;
 	                      const res: any = await (window.host.utils as any).openExternalConsole({
-	                        terminal: env.terminal,
+	                        terminal: prepared.env.terminal,
 	                        wslPath: proj.wslPath,
 	                        winPath: proj.winPath,
-	                        distro: env.distro,
-	                        startupCmd,
+	                        distro: prepared.env.distro,
+	                        startupCmd: prepared.startupCmd,
 	                        title: getProviderLabel(activeProviderId),
 	                      });
 	                      if (!(res && res.ok)) throw new Error(res?.error || 'failed');

--- a/web/src/locales/en/terminal.json
+++ b/web/src/locales/en/terminal.json
@@ -24,6 +24,11 @@
   "collapseInput": "Exit expand",
   "readyPlaceholder": "# Terminal ready. Embedded console placeholder (UI prototype; no real PTY yet).",
   "openFailed": "Failed to start console: {error}",
+  "envFallbackTitle": "Runtime Environment Changed",
+  "envFallbackMessage": "The previous {from} environment is unavailable. Switched to {to}.",
+  "envFallbackWslStartFailed": "WSL failed to start. Switched to {to}.",
+  "cliMissingTitle": "{provider} CLI Not Installed",
+  "cliMissingMessage": "{provider} CLI is not installed, or the current {env} environment cannot access the `{cli}` command.",
   "childTerminalsActive": "Active items in sub-projects",
   "childTerminalsPending": "Sub-projects have completed tasks awaiting review",
   "closeWorkingConfirm": {

--- a/web/src/locales/zh/terminal.json
+++ b/web/src/locales/zh/terminal.json
@@ -24,6 +24,11 @@
   "collapseInput": "退出大屏",
   "readyPlaceholder": "# 终端就绪。这里是内嵌控制台的视觉占位（UI 原型，未接真 PTY）。",
   "openFailed": "启动终端失败：{error}",
+  "envFallbackTitle": "已切换运行环境",
+  "envFallbackMessage": "原 {from} 环境不可用，已切换到 {to}。",
+  "envFallbackWslStartFailed": "WSL 启动失败，已切换到 {to}。",
+  "cliMissingTitle": "{provider} CLI 未安装",
+  "cliMissingMessage": "{provider} CLI 未安装，当前 {env} 环境无法访问 `{cli}` 命令。",
   "childTerminalsActive": "子项目有活动项",
   "childTerminalsPending": "子项目有已完成待查看任务",
   "closeWorkingConfirm": {

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -339,7 +339,7 @@ export type HistoryMessage = { role: string; content: MessageContent[] };
 
 // ---- Host API 声明 ----
 export interface PtyAPI {
-  openWSLConsole(args: { terminal?: TerminalMode; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string> }): Promise<{ id: string }>;
+  openWSLConsole(args: { terminal?: TerminalMode; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string> }): Promise<{ id: string; terminal?: TerminalMode; distro?: string; fallbackReason?: string }>;
   /** 读取 PTY 的尾部输出缓存（用于渲染进程 reload/HMR 后恢复终端滚动区）。 */
   backlog?: (id: string, args?: { maxChars?: number }) => Promise<{ ok: boolean; data?: string; error?: string }>;
   write(id: string, data: string): void;
@@ -700,6 +700,8 @@ export interface HistoryAPI {
 export interface SettingsAPI {
   get(): Promise<AppSettings>;
   update(partial: Partial<AppSettings>): Promise<AppSettings>;
+  resolveRuntimeEnv?(args: { terminal?: TerminalMode; distro?: string }): Promise<{ ok: boolean; terminal?: TerminalMode; distro?: string; changed?: boolean; reason?: string; availableDistros?: string[]; error?: string }>;
+  checkRuntimeCli?(args: { terminal?: TerminalMode; distro?: string; startupCmd?: string }): Promise<{ ok: boolean; cli?: string; terminal?: TerminalMode; distro?: string; reason?: string; error?: string }>;
   codexRoots(): Promise<string[]>;
   sessionRoots?(args: { providerId: "codex" | "claude" | "gemini" }): Promise<string[]>;
 }


### PR DESCRIPTION
完善 Provider 运行环境解析与启动前检查：
- 在启动前解析当前机器可见的 WSL/PowerShell 环境，并把不可用环境修正回设置
- 内置 Provider 启动前检查 CLI 是否可访问，缺失时给出用户可读提示
- PTY 启动 WSL 失败时回退到 Windows PowerShell，并把实际环境回传给渲染层
- 前端按实际环境记录标签执行上下文，避免后续发送、恢复和提示使用过期环境

修复审查发现的边界问题：
- 非 Windows 宿主检测 CLI 时使用 POSIX command -v，而不是 Windows where.exe
- 启动命令解析保留 Windows 路径反斜杠，并跳过 PowerShell 调用操作符