### PR TITLE
fix(runtime): 修复渲染恢复与终端回放卡顿

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -240,6 +240,8 @@ let quitConfirming = false;
 let gpuFallbackActive = false;
 const MAIN_APP_WINDOW_ID = "main";
 const appWindowMetaByWindow = new WeakMap<BrowserWindow, { windowId: string; windowMode: AppWindowMode }>();
+const rendererRecoveryClosingWindows = new WeakSet<BrowserWindow>();
+let rendererRecoveryRecreateDepth = 0;
 
 type AppWindowMode = "main" | "detached-tab";
 
@@ -292,6 +294,38 @@ type CreateWindowOptions = {
  */
 function getAppWindowMeta(win: BrowserWindow): { windowId: string; windowMode: AppWindowMode } {
   return appWindowMetaByWindow.get(win) || { windowId: MAIN_APP_WINDOW_ID, windowMode: "main" };
+}
+
+/**
+ * 判断窗口是否正由渲染恢复流程关闭。
+ */
+function isRendererRecoveryClosingWindow(win: BrowserWindow): boolean {
+  try { return rendererRecoveryClosingWindows.has(win); } catch { return false; }
+}
+
+/**
+ * 判断当前是否处于渲染恢复的窗口重建阶段。
+ */
+function isRendererRecoveryRecreateInFlight(): boolean {
+  return rendererRecoveryRecreateDepth > 0;
+}
+
+/**
+ * 标记渲染恢复开始重建窗口。
+ */
+function beginRendererRecoveryWindowRecreate(win: BrowserWindow, reason: string): void {
+  try { rendererRecoveryClosingWindows.add(win); } catch {}
+  rendererRecoveryRecreateDepth += 1;
+  logWhiteScreenDiagnostic(`[RECOVERY] recreate begin reason=${clampLogValue(reason, 160)}`);
+}
+
+/**
+ * 标记渲染恢复窗口重建结束，并清理旧窗口的关闭标记。
+ */
+function finishRendererRecoveryWindowRecreate(win: BrowserWindow): void {
+  try { rendererRecoveryClosingWindows.delete(win); } catch {}
+  rendererRecoveryRecreateDepth = Math.max(0, rendererRecoveryRecreateDepth - 1);
+  logWhiteScreenDiagnostic(`[RECOVERY] recreate end depth=${rendererRecoveryRecreateDepth}`);
 }
 
 /**
@@ -830,10 +864,11 @@ async function applyMergedGitRepoRootsAsync(): Promise<{ opened: number; closed:
 async function confirmQuitWithActiveTerminals(win: BrowserWindow | null, count: number): Promise<boolean> {
   try {
     // 优先使用渲染进程自定义弹窗（保持 UI 风格一致）
-    const rendererRes = await requestQuitConfirmFromRenderer(win, count, { timeoutMs: 30_000 });
+    const rendererRes = await requestQuitConfirmFromRenderer(win, count, { timeoutMs: 6_000 });
     if (rendererRes !== null) return rendererRes;
 
     // 回退：原生对话框（渲染进程不可用时）
+    try { perfLogger.logAlways(`[quitConfirm] fallback native count=${count} win=${win && !win.isDestroyed() ? 1 : 0}`); } catch {}
     const L = getQuitConfirmDialogTextForLocale(i18n.getCurrentLocale?.(), count);
     const options: Electron.MessageBoxOptions = {
       type: "warning",
@@ -847,6 +882,7 @@ async function confirmQuitWithActiveTerminals(win: BrowserWindow | null, count: 
       normalizeAccessKeys: true,
     };
     const res = win ? await dialog.showMessageBox(win, options) : await dialog.showMessageBox(options);
+    try { perfLogger.logAlways(`[quitConfirm] fallback native response=${res.response}`); } catch {}
     return res.response === 1;
   } catch {
     // 若对话框弹出失败，为避免卡死退出流程，默认允许退出
@@ -1641,12 +1677,15 @@ function recoverWindowRenderer(win: BrowserWindow, reason: RendererRecoveryReaso
  * 在恢复失败时重建窗口，并尽量保留原窗口的几何状态与宿主身份。
  */
 function recreateWindowForRecovery(win: BrowserWindow, reason: string): void {
+  let recreateStarted = false;
   try {
     const restoreBounds = (() => { try { return win.getBounds(); } catch { return undefined; } })();
     const startMaximized = (() => { try { return win.isMaximized(); } catch { return false; } })();
     const startFullScreen = (() => { try { return win.isFullScreen(); } catch { return false; } })();
     const { windowId, windowMode } = getAppWindowMeta(win);
     logWhiteScreenDiagnostic(`[RECOVERY] recreate reason=${reason}`);
+    beginRendererRecoveryWindowRecreate(win, reason);
+    recreateStarted = true;
     clearRendererRecoveryState(win);
     try { win.removeAllListeners("close"); } catch {}
     try { win.removeAllListeners("closed"); } catch {}
@@ -1655,6 +1694,8 @@ function recreateWindowForRecovery(win: BrowserWindow, reason: string): void {
     createWindow({ restoreBounds, startMaximized, startFullScreen, recoveryReason: reason, windowId, windowMode });
   } catch (e) {
     logWhiteScreenDiagnostic(`[RECOVERY] recreate failed reason=${reason} err=${String(e)}`);
+  } finally {
+    if (recreateStarted) finishRendererRecoveryWindowRecreate(win);
   }
 }
 
@@ -2099,6 +2140,10 @@ function createWindow(options?: CreateWindowOptions): void {
   win.on("close", (event) => {
     try {
       if (!isMainAppWindow) return;
+      if (isRendererRecoveryClosingWindow(win)) {
+        logWhiteScreenDiagnostic("[RECOVERY] skip close quit confirm during window recreate");
+        return;
+      }
       if (quitConfirmed) return;
       const count = ptyManager.getActiveSessionCount();
       if (count <= 0) return;
@@ -2516,6 +2561,11 @@ if (!gotLock) {
 
   app.on('before-quit', (event) => {
     try {
+      if (isRendererRecoveryRecreateInFlight()) {
+        logWhiteScreenDiagnostic("[RECOVERY] skip before-quit terminal confirm during window recreate");
+        event.preventDefault();
+        return;
+      }
       if (!quitConfirmed) {
         const count = ptyManager.getActiveSessionCount();
         if (count > 0) {
@@ -2582,6 +2632,10 @@ if (!gotLock) {
 
   app.on('window-all-closed', () => {
     // On Windows & Linux, quit on all closed
+    if (isRendererRecoveryRecreateInFlight()) {
+      logWhiteScreenDiagnostic("[RECOVERY] skip app quit during window recreate");
+      return;
+    }
     if (process.platform !== 'darwin') app.quit();
   });
 

--- a/electron/quitConfirmBridge.ts
+++ b/electron/quitConfirmBridge.ts
@@ -2,6 +2,7 @@
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
 import { ipcMain, type BrowserWindow } from "electron";
+import { perfLogger } from "./log";
 
 export type QuitConfirmRequestPayload = {
   token: string;
@@ -14,6 +15,13 @@ type Pending = {
 };
 
 const pendingByToken = new Map<string, Pending>();
+
+/**
+ * 写入退出确认桥接日志。
+ */
+function logQuitConfirmBridge(message: string): void {
+  try { perfLogger.logAlways(`[quitConfirm.bridge] ${message}`); } catch {}
+}
 
 function uidToken(): string {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
@@ -29,12 +37,17 @@ export function registerQuitConfirmIPC(): void {
       const token = String(args?.token || "");
       const ok = !!args?.ok;
       const p = pendingByToken.get(token);
-      if (!p) return { ok: false, error: "not_found" };
+      if (!p) {
+        logQuitConfirmBridge(`respond token=${token || "empty"} ok=${ok ? 1 : 0} result=not_found`);
+        return { ok: false, error: "not_found" };
+      }
       pendingByToken.delete(token);
       try { if (p.timer) clearTimeout(p.timer); } catch {}
       try { p.resolve(ok); } catch {}
+      logQuitConfirmBridge(`respond token=${token} ok=${ok ? 1 : 0}`);
       return { ok: true };
     } catch (e: any) {
+      logQuitConfirmBridge(`respond error=${String(e?.message || e)}`);
       return { ok: false, error: String(e) };
     }
   });
@@ -52,8 +65,14 @@ export async function requestQuitConfirmFromRenderer(
 ): Promise<boolean | null> {
   try {
     const target = win && !win.isDestroyed() ? win : null;
-    if (!target) return null;
-    if (!target.webContents || target.webContents.isDestroyed()) return null;
+    if (!target) {
+      logQuitConfirmBridge("skip reason=no-window");
+      return null;
+    }
+    if (!target.webContents || target.webContents.isDestroyed()) {
+      logQuitConfirmBridge("skip reason=no-webContents");
+      return null;
+    }
 
     const token = uidToken();
     const payload: QuitConfirmRequestPayload = { token, count: Math.max(0, Math.floor(Number(count) || 0)) };
@@ -62,19 +81,23 @@ export async function requestQuitConfirmFromRenderer(
     const done = await new Promise<boolean | null>((resolve) => {
       const timer = setTimeout(() => {
         pendingByToken.delete(token);
+        logQuitConfirmBridge(`timeout token=${token} timeoutMs=${timeoutMs}`);
         resolve(null);
       }, timeoutMs);
       pendingByToken.set(token, { resolve: (ok) => resolve(ok), timer });
       try {
+        logQuitConfirmBridge(`send token=${token} count=${payload.count} timeoutMs=${timeoutMs} loading=${target.webContents.isLoading() ? 1 : 0}`);
         target.webContents.send("app:quitConfirm", payload);
       } catch {
         pendingByToken.delete(token);
         try { clearTimeout(timer); } catch {}
+        logQuitConfirmBridge(`send failed token=${token}`);
         resolve(null);
       }
     });
     return done;
   } catch {
+    logQuitConfirmBridge("request error");
     return null;
   }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1715,6 +1715,9 @@ export default function CodexFlowManagerUI() {
   const codexErrorScanByTabRef = useRef<Record<string, CodexErrorScanState>>({});
   const ptyListenersRef = useRef<Record<string, () => void>>({});
   const ptyToTabRef = useRef<Record<string, string>>({});
+  const hydratedPtyBindingQueueRef = useRef<Array<{ tabId: string; ptyId: string; windowId: string; source: string }>>([]);
+  const hydratedPtyBindingQueuedRef = useRef<Record<string, string>>({});
+  const hydratedPtyBindingTimerRef = useRef<number | null>(null);
   const tabProjectRef = useRef<Record<string, string>>({});
   const tabsByProjectRef = useRef<Record<string, ConsoleTab[]>>(tabsByProject);
   const detachedWindowHasOwnedTabsRef = useRef(false);
@@ -1729,6 +1732,64 @@ export default function CodexFlowManagerUI() {
   const CODEX_OSC_EXTERNAL_WAIT_NO_DETAIL_MS = 3_000;
   const COMPLETION_DEDUPE_WINDOW_MS = 1_600;
   const COMPLETION_CROSS_SOURCE_WINDOW_MS = 5_000;
+
+  /**
+   * 判断待恢复的 tab 是否仍属于指定窗口，避免延迟任务绑定已被移动/关闭的终端。
+   */
+  function isQueuedTabStillVisible(tabId: string, windowId: string): boolean {
+    for (const list of Object.values(tabsByProjectRef.current || {})) {
+      for (const tab of list || []) {
+        if (tab.id === tabId && isTabOwnedByWindow(tab, windowId))
+          return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * 推进 PTY 恢复绑定队列，每次只处理一个 tab，避免 reload 后多个 backlog 同帧写入卡住渲染线程。
+   */
+  function scheduleHydratedPtyBindingPump(): void {
+    if (hydratedPtyBindingTimerRef.current !== null) return;
+    hydratedPtyBindingTimerRef.current = window.setTimeout(() => {
+      hydratedPtyBindingTimerRef.current = null;
+      const next = hydratedPtyBindingQueueRef.current.shift();
+      if (!next) return;
+      if (hydratedPtyBindingQueuedRef.current[next.tabId] === next.ptyId)
+        delete hydratedPtyBindingQueuedRef.current[next.tabId];
+
+      try {
+        const currentPtyId = ptyByTabRef.current[next.tabId];
+        if (currentPtyId === next.ptyId && isQueuedTabStillVisible(next.tabId, next.windowId)) {
+          try { registerPtyForTab(next.tabId, next.ptyId); } catch {}
+          try { tm.setPty(next.tabId, next.ptyId, { hydrateBacklog: true }); } catch {}
+        }
+      } catch {}
+
+      if (hydratedPtyBindingQueueRef.current.length > 0)
+        scheduleHydratedPtyBindingPump();
+    }, 24);
+  }
+
+  /**
+   * 将 PTY 恢复绑定加入分帧队列，同一 tab+ptyId 的重复请求会合并。
+   */
+  function scheduleHydratedPtyBindings(entries: Array<{ tabId: string; ptyId: string }>, source: string): void {
+    let added = 0;
+    for (const entry of entries) {
+      const tabId = String(entry?.tabId || "");
+      const ptyId = String(entry?.ptyId || "");
+      if (!tabId || !ptyId) continue;
+      if (hydratedPtyBindingQueuedRef.current[tabId] === ptyId) continue;
+      hydratedPtyBindingQueuedRef.current[tabId] = ptyId;
+      hydratedPtyBindingQueueRef.current.push({ tabId, ptyId, windowId: currentWindowId, source });
+      added += 1;
+    }
+    if (added > 0) {
+      try { uiLog(`ptyBinding.queue source=${source} added=${added} pending=${hydratedPtyBindingQueueRef.current.length}`); } catch {}
+      scheduleHydratedPtyBindingPump();
+    }
+  }
 
   useEffect(() => { editingTabIdRef.current = editingTabId; }, [editingTabId]);
   useEffect(() => { notificationPrefsRef.current = notificationPrefs; }, [notificationPrefs]);
@@ -1755,6 +1816,12 @@ export default function CodexFlowManagerUI() {
         }
       }
       codexErrorScanByTabRef.current = {};
+      if (hydratedPtyBindingTimerRef.current !== null) {
+        try { window.clearTimeout(hydratedPtyBindingTimerRef.current); } catch {}
+        hydratedPtyBindingTimerRef.current = null;
+      }
+      hydratedPtyBindingQueueRef.current = [];
+      hydratedPtyBindingQueuedRef.current = {};
     };
   }, []);
 
@@ -1784,11 +1851,12 @@ export default function CodexFlowManagerUI() {
           knownTabs.add(tab.id);
         }
       }
+      const restoreEntries: Array<{ tabId: string; ptyId: string }> = [];
       for (const [tabId, ptyId] of Object.entries(snapshot.ptyByTab || {})) {
         if (!knownTabs.has(tabId)) continue;
-        try { registerPtyForTab(tabId, ptyId); } catch {}
-        try { tm.setPty(tabId, ptyId, { hydrateBacklog: true }); } catch {}
+        restoreEntries.push({ tabId, ptyId });
       }
+      scheduleHydratedPtyBindings(restoreEntries, "snapshot");
     } catch {}
   }, [restoredConsoleSession, tm, currentWindowId]);
 
@@ -6181,16 +6249,17 @@ export default function CodexFlowManagerUI() {
 
   useEffect(() => {
     const visibleTabIds = new Set<string>();
+    const hydrateEntries: Array<{ tabId: string; ptyId: string }> = [];
     for (const list of Object.values(tabsByProject || {})) {
       for (const tab of list || []) {
         if (!isTabOwnedByWindow(tab, currentWindowId)) continue;
         visibleTabIds.add(tab.id);
         const ptyId = ptyByTabRef.current[tab.id];
         if (!ptyId) continue;
-        try { registerPtyForTab(tab.id, ptyId); } catch {}
-        try { tm.setPty(tab.id, ptyId, { hydrateBacklog: true }); } catch {}
+        hydrateEntries.push({ tabId: tab.id, ptyId });
       }
     }
+    scheduleHydratedPtyBindings(hydrateEntries, "visible-tabs");
     for (const tabId of Object.keys(ptyByTabRef.current || {})) {
       if (visibleTabIds.has(tabId)) continue;
       const ptyId = ptyByTabRef.current[tabId];

--- a/web/src/features/git/monaco-git-diff.tsx
+++ b/web/src/features/git/monaco-git-diff.tsx
@@ -52,10 +52,80 @@ type MonacoPartialCommitOverlayButton = {
 
 type MonacoThemeId = "vs" | "vs-dark";
 
+type MonacoDiffModelPaths = {
+  original: string;
+  modified: string;
+};
+
 /**
  * 强制使用本地打包的 Monaco，避免离线环境卡在 “Loading...”。
  */
 loader.config({ monaco: MonacoEditor as any });
+
+/**
+ * 计算短哈希，用于生成稳定且长度受控的 Monaco model URI。
+ */
+function hashModelPathKey(text: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+/**
+ * 构造左右 Diff model 的 URI，避免 @monaco-editor/react 使用匿名 model 后难以安全释放。
+ */
+function buildDiffModelPaths(key: string): MonacoDiffModelPaths {
+  const normalizedKey = hashModelPathKey(key || "empty");
+  return {
+    original: `inmemory://codexflow/git-diff/original/${normalizedKey}.txt`,
+    modified: `inmemory://codexflow/git-diff/modified/${normalizedKey}.txt`,
+  };
+}
+
+/**
+ * 当前 DiffEditor 仍引用目标 model 时，先置空 model，避免 Monaco 在 TextModel 先释放时抛错。
+ */
+function detachDiffEditorModelsIfMatching(
+  editor: MonacoNS.editor.IStandaloneDiffEditor | null,
+  paths: MonacoDiffModelPaths,
+): void {
+  if (!editor) return;
+  try {
+    const model = editor.getModel();
+    const originalUri = model?.original?.uri?.toString();
+    const modifiedUri = model?.modified?.uri?.toString();
+    if (originalUri === paths.original || modifiedUri === paths.modified)
+      editor.setModel(null);
+  } catch {}
+}
+
+/**
+ * 释放指定 URI 对应的 Monaco TextModel。
+ */
+function disposeMonacoModelByPath(monaco: typeof MonacoNS, path: string): void {
+  try {
+    const model = monaco.editor.getModel(monaco.Uri.parse(path));
+    if (model && !model.isDisposed())
+      model.dispose();
+  } catch {}
+}
+
+/**
+ * 安全释放一组 Diff model：先从 DiffEditor 脱钩，再释放 TextModel。
+ */
+function disposeDiffModels(
+  monaco: typeof MonacoNS | null,
+  editor: MonacoNS.editor.IStandaloneDiffEditor | null,
+  paths: MonacoDiffModelPaths,
+): void {
+  if (!monaco) return;
+  detachDiffEditorModelsIfMatching(editor, paths);
+  disposeMonacoModelByPath(monaco, paths.original);
+  disposeMonacoModelByPath(monaco, paths.modified);
+}
 
 /**
  * 根据当前文档根节点的主题类名，解析 Monaco 应使用的亮暗主题标识。
@@ -430,6 +500,7 @@ export default function MonacoGitDiff(props: MonacoGitDiffProps): JSX.Element {
   const overlayListenerRefs = useRef<MonacoNS.IDisposable[]>([]);
   const overlayFrameRef = useRef<number | null>(null);
   const focusSideRef = useRef<GitDiffEditorSelection["focusSide"]>(null);
+  const modelPathsRef = useRef<MonacoDiffModelPaths | null>(null);
   const [overlayButtons, setOverlayButtons] = useState<MonacoPartialCommitOverlayButton[]>([]);
 
   const language = useMemo(() => detectLanguageId(String(diff?.path || "")), [diff?.path]);
@@ -443,6 +514,7 @@ export default function MonacoGitDiff(props: MonacoGitDiffProps): JSX.Element {
       Array.isArray(diff?.hashes) ? diff?.hashes.join("|") : "",
     ].join("::");
   }, [diff?.hash, diff?.hashes, diff?.mode, diff?.path]);
+  const modelPaths = useMemo(() => buildDiffModelPaths(editorKey), [editorKey]);
   const theme = useMonacoTheme();
 
   /**
@@ -597,6 +669,7 @@ export default function MonacoGitDiff(props: MonacoGitDiffProps): JSX.Element {
   const onMount = useCallback((editor: MonacoNS.editor.IStandaloneDiffEditor, monaco: typeof MonacoNS): void => {
     diffEditorRef.current = editor;
     monacoRef.current = monaco;
+    modelPathsRef.current = modelPaths;
     decorationRef.current = editor.getModifiedEditor().createDecorationsCollection();
     originalExcludedDecorationRef.current = editor.getOriginalEditor().createDecorationsCollection();
     modifiedExcludedDecorationRef.current = editor.getModifiedEditor().createDecorationsCollection();
@@ -617,7 +690,20 @@ export default function MonacoGitDiff(props: MonacoGitDiffProps): JSX.Element {
     ignoreWhitespace,
     onModifiedContentChange,
     sideBySide,
+    modelPaths,
   ]);
+
+  /**
+   * Diff 切换或组件卸载时释放当前 Monaco model；必须先从 DiffEditor 脱钩，再释放 TextModel。
+   */
+  useEffect(() => {
+    modelPathsRef.current = modelPaths;
+    return () => {
+      disposeDiffModels(monacoRef.current, diffEditorRef.current, modelPaths);
+      if (modelPathsRef.current?.original === modelPaths.original && modelPathsRef.current.modified === modelPaths.modified)
+        modelPathsRef.current = null;
+    };
+  }, [modelPaths]);
 
   useEffect(() => {
     if (!diff) {
@@ -777,6 +863,10 @@ export default function MonacoGitDiff(props: MonacoGitDiffProps): JSX.Element {
         overlayFrameRef.current = null;
       }
       focusSideRef.current = null;
+      const paths = modelPathsRef.current;
+      if (paths)
+        disposeDiffModels(monacoRef.current, diffEditorRef.current, paths);
+      modelPathsRef.current = null;
       diffEditorRef.current = null;
       monacoRef.current = null;
     };
@@ -867,6 +957,10 @@ export default function MonacoGitDiff(props: MonacoGitDiffProps): JSX.Element {
         language={language}
         original={original}
         modified={modified}
+        originalModelPath={modelPaths.original}
+        modifiedModelPath={modelPaths.modified}
+        keepCurrentOriginalModel
+        keepCurrentModifiedModel
         theme={theme}
         onMount={onMount}
         options={{

--- a/web/src/lib/TerminalManager.ts
+++ b/web/src/lib/TerminalManager.ts
@@ -204,6 +204,8 @@ export default class TerminalManager {
   private adapterResizeReadyUnsubByTab: Record<string, (() => void) | null> = {};
   private hostElByTab: Record<string, HTMLElement | null> = {};
   private backlogHydratedPtyByTab: Record<string, string | undefined> = {};
+  private backlogHydratingPtyByTab: Record<string, string | undefined> = {};
+  private lastResumeAllPtyAt = 0;
   private windowResizeStableSampleByTab: Record<string, WindowResizeStableSample | undefined> = {};
   private getPtyId: (tabId: string) => string | undefined;
   private hostPty: HostPtyAPI;
@@ -2675,9 +2677,15 @@ export default class TerminalManager {
       return;
     }
 
-    // 同一 tab + 同一 ptyId：避免重复回放导致内容叠加
+    // 同一 tab + 同一 ptyId：已完成回放时只重新接线，避免重复回放导致内容叠加。
     if (this.backlogHydratedPtyByTab[tabId] === ptyId) {
       this.wireUp(tabId, ptyId);
+      return;
+    }
+
+    // 正在回放时只重接监听，不触发初始 resize，避免恢复期额外 pause/resume 放大卡顿。
+    if (this.backlogHydratingPtyByTab[tabId] === ptyId) {
+      this.wireUp(tabId, ptyId, { skipInitialResize: true });
       return;
     }
 
@@ -2689,6 +2697,7 @@ export default class TerminalManager {
     }
 
     // 回放阶段：先尝试暂停数据流，避免乱序
+    this.backlogHydratingPtyByTab[tabId] = ptyId;
     try { this.hostPty.pause?.(ptyId); } catch {}
     this.wireUp(tabId, ptyId, { skipInitialResize: true });
 
@@ -2717,6 +2726,9 @@ export default class TerminalManager {
               resolve({ ok: false, error: String((err as any)?.message || err) });
             });
         });
+        // 回放结果返回时再次确认绑定关系，避免延迟结果写入已切换 PTY 的 tab。
+        if (this.getPtyId(tabId) !== ptyId || this.backlogHydratingPtyByTab[tabId] !== ptyId)
+          return;
         if (res && res.ok && typeof res.data === "string" && res.data.length > 0) {
           try { this.adapters[tabId]?.write(res.data); } catch {}
         }
@@ -2724,6 +2736,8 @@ export default class TerminalManager {
       } catch {
         // ignore
       } finally {
+        if (this.backlogHydratingPtyByTab[tabId] === ptyId)
+          delete this.backlogHydratingPtyByTab[tabId];
         try { this.hostPty.resume?.(ptyId); } catch {}
         try { this.scheduleResizeSync(tabId, true); } catch {}
       }
@@ -2741,12 +2755,16 @@ export default class TerminalManager {
       this.blurTab(this.lastFocusedTabId, "switch");
     }
     this.lastFocusedTabId = tabId;
-    // 先确保所有 PTY 均处于 resume 状态：后台标签仍需接收 OSC 事件以触发完成通知
+    // 先确保所有 PTY 均处于 resume 状态：后台标签仍需接收 OSC 事件以触发完成通知；短时间内去重，避免切换/恢复时放大 IPC 压力。
     try {
-      for (const t of Object.keys(this.adapters)) {
-        const pid = this.getPtyId(t);
-        if (!pid) continue;
-        try { this.hostPty.resume?.(pid); this.dlog(`resume pty=${pid} tab=${t}`); } catch {}
+      const now = Date.now();
+      if (now - this.lastResumeAllPtyAt > 1500) {
+        this.lastResumeAllPtyAt = now;
+        for (const t of Object.keys(this.adapters)) {
+          const pid = this.getPtyId(t);
+          if (!pid) continue;
+          try { this.hostPty.resume?.(pid); this.dlog(`resume pty=${pid} tab=${t}`); } catch {}
+        }
       }
     } catch {}
     // 精确度量并立即同步尺寸
@@ -2758,6 +2776,7 @@ export default class TerminalManager {
     const pid = this.getPtyId(tabId);
     if (pid) {
       try {
+        this.hostPty.resume?.(pid);
         this.hostPty.write(pid, "\u001b[I");
         this.dlog(`tabActivate.injectFocusGain tab=${tabId} pty=${pid}`);
       } catch (err) {
@@ -2907,6 +2926,7 @@ export default class TerminalManager {
     delete this.containers[tabId];
     delete this.scrollSnapshotByTab[tabId];
     delete this.backlogHydratedPtyByTab[tabId];
+    delete this.backlogHydratingPtyByTab[tabId];
 
     if (alsoClosePty) {
       const pid = this.getPtyId(tabId);

--- a/web/src/lib/terminal-manager-backlog.test.ts
+++ b/web/src/lib/terminal-manager-backlog.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const createTerminalAdapterMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/adapters/TerminalAdapter", () => ({
+  createTerminalAdapter: createTerminalAdapterMock,
+}));
+
+import TerminalManager from "./TerminalManager";
+
+describe("TerminalManager（PTY 尾部回放）", () => {
+  afterEach(() => {
+    try { vi.useRealTimers(); } catch {}
+    try { createTerminalAdapterMock.mockReset(); } catch {}
+  });
+
+  /**
+   * 创建最小可用的终端适配器 stub，便于断言 backlog 写入次数。
+   */
+  function createAdapterStub() {
+    return {
+      mount: vi.fn(() => ({ cols: 80, rows: 24 })),
+      write: vi.fn(),
+      paste: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      resize: vi.fn(() => ({ cols: 80, rows: 24 })),
+      getScrollSnapshot: vi.fn(() => null),
+      restoreScrollSnapshot: vi.fn(),
+      readCursorTextSnapshot: vi.fn(() => null),
+      focus: vi.fn(),
+      blur: vi.fn(),
+      setAppearance: vi.fn(),
+      dispose: vi.fn(),
+    };
+  }
+
+  /**
+   * 创建带可控 backlog promise 的 hostPty stub。
+   */
+  function createHostPtyStub() {
+    const backlogResolvers: Array<(value: { ok: boolean; data?: string }) => void> = [];
+    return {
+      backlogResolvers,
+      onData: vi.fn(() => () => {}),
+      write: vi.fn(),
+      resize: vi.fn(),
+      close: vi.fn(),
+      pause: vi.fn(),
+      resume: vi.fn(),
+      backlog: vi.fn(() => new Promise<{ ok: boolean; data?: string }>((resolve) => {
+        backlogResolvers.push(resolve);
+      })),
+    };
+  }
+
+  it("同一 tab+pty 的并发 hydrate 只拉取并写入一次 backlog", async () => {
+    const adapter: any = createAdapterStub();
+    const hostPty = createHostPtyStub();
+    createTerminalAdapterMock.mockReturnValue(adapter);
+
+    const ptyByTab: Record<string, string> = { "tab-a": "pty-a" };
+    const tm = new TerminalManager((tabId) => ptyByTab[tabId], hostPty as any, {});
+
+    tm.setPty("tab-a", "pty-a", { hydrateBacklog: true });
+    tm.setPty("tab-a", "pty-a", { hydrateBacklog: true });
+
+    expect(hostPty.backlog).toHaveBeenCalledTimes(1);
+    expect(hostPty.pause).toHaveBeenCalledTimes(1);
+    expect(hostPty.onData).toHaveBeenCalledTimes(2);
+
+    hostPty.backlogResolvers[0]?.({ ok: true, data: "历史输出" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.write.mock.calls.filter((call: any[]) => call[0] === "历史输出")).toHaveLength(1);
+    expect(hostPty.resume).toHaveBeenCalledWith("pty-a");
+
+    tm.disposeAll(false);
+  });
+
+  it("旧 PTY 的延迟 backlog 返回后不会写入已换绑的 tab", async () => {
+    const adapter: any = createAdapterStub();
+    const hostPty = createHostPtyStub();
+    createTerminalAdapterMock.mockReturnValue(adapter);
+
+    const ptyByTab: Record<string, string> = { "tab-a": "pty-old" };
+    const tm = new TerminalManager((tabId) => ptyByTab[tabId], hostPty as any, {});
+
+    tm.setPty("tab-a", "pty-old", { hydrateBacklog: true });
+    ptyByTab["tab-a"] = "pty-new";
+    tm.setPty("tab-a", "pty-new");
+
+    hostPty.backlogResolvers[0]?.({ ok: true, data: "旧历史输出" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.write.mock.calls.some((call: any[]) => call[0] === "旧历史输出")).toBe(false);
+    expect(hostPty.resume).toHaveBeenCalledWith("pty-old");
+
+    tm.disposeAll(false);
+  });
+});


### PR DESCRIPTION
本次修改聚焦渲染进程卡死/白屏后的可恢复性，以及 reload/HMR 后终端会话恢复时的前端压力控制。

技术变更：
- 为渲染进程异常退出、加载失败、长时间无响应和 GPU 进程异常增加分级恢复流程，优先 reload，连续失败后重建窗口，并避免恢复重建误触发退出确认。
- 缩短退出确认渲染弹窗等待时间，增加桥接与原生回退日志，防止渲染不可用时退出流程长时间悬挂。
- 将恢复的 PTY 绑定分帧排队，避免多个终端 backlog 同帧回放造成渲染线程卡顿。
- 在 TerminalManager 中去重同一 tab+pty 的 backlog hydrate，校验延迟返回的旧 PTY，避免历史输出写入已换绑 tab。
- 强制 Git diff 视图使用本地 Monaco 实例，并显式管理 diff model 生命周期，降低离线或 worker 初始化异常导致的 Loading 卡住概率。

产品影响：
- 应用窗口在渲染层卡死或白屏后更容易自动恢复，用户无需手动结束主进程。
- 运行中的终端任务在同一主进程生命周期内 reload 后能更平滑恢复输出，减少“控制台丢失”或“窗口内容卡死”的体感。
- Git 差异预览在离线或资源加载异常场景下更稳定。