### PR TITLE
fix(codex): 识别 413 Payload Too Large 错误

### DIFF
--- a/electron/settings.ts
+++ b/electron/settings.ts
@@ -47,7 +47,7 @@ export type CodexErrorHandlingSettings = {
   /** 是否在可恢复错误后自动发送 continue */
   autoContinueEnabled?: boolean;
   /** 自动 continue 适用的可恢复错误类型 */
-  autoContinueErrorKinds?: Array<'rateLimited' | 'concurrency' | 'networkStream' | 'badGateway' | 'serviceUnavailable' | 'highDemand' | 'modelCapacity' | 'forbidden' | 'badRequest'>;
+  autoContinueErrorKinds?: Array<'rateLimited' | 'concurrency' | 'networkStream' | 'badGateway' | 'serviceUnavailable' | 'highDemand' | 'modelCapacity' | 'forbidden' | 'badRequest' | 'payloadTooLarge'>;
   /** 自动 continue 错误类型列表版本，用于一次性默认项迁移 */
   autoContinueErrorKindsVersion?: number;
   /** 自动发送 continue 前等待的秒数 */
@@ -246,6 +246,10 @@ const DEFAULT_CODEX_ERROR_HANDLING: Required<CodexErrorHandlingSettings> = {
   autoContinueDelaySeconds: 30,
   autoContinueMaxAttempts: 2,
 };
+const CODEX_AUTO_CONTINUE_ERROR_KINDS: Required<CodexErrorHandlingSettings>['autoContinueErrorKinds'] = [
+  ...DEFAULT_CODEX_ERROR_HANDLING.autoContinueErrorKinds,
+  'payloadTooLarge',
+];
 const CODEX_AUTO_CONTINUE_ERROR_KINDS_VERSION = 3;
 const LEGACY_CODEX_AUTO_CONTINUE_ERROR_KINDS_V1: Required<CodexErrorHandlingSettings>['autoContinueErrorKinds'] = [
   'networkStream',
@@ -421,7 +425,7 @@ function shouldUpgradeLegacyCodexAutoContinueDefaultKinds(
  */
 function normalizeCodexAutoContinueErrorKinds(raw: unknown, version: number): Required<CodexErrorHandlingSettings>['autoContinueErrorKinds'] {
   if (!Array.isArray(raw)) return [...DEFAULT_CODEX_ERROR_HANDLING.autoContinueErrorKinds];
-  const allowed = new Set(DEFAULT_CODEX_ERROR_HANDLING.autoContinueErrorKinds);
+  const allowed = new Set(CODEX_AUTO_CONTINUE_ERROR_KINDS);
   const next: Required<CodexErrorHandlingSettings>['autoContinueErrorKinds'] = [];
   for (const item of raw) {
     const kind = String(item || '').trim() as Required<CodexErrorHandlingSettings>['autoContinueErrorKinds'][number];

--- a/web/src/lib/codex-cli-error-classifier.test.ts
+++ b/web/src/lib/codex-cli-error-classifier.test.ts
@@ -57,6 +57,22 @@ describe("codex-cli-error-classifier（Codex TUI 错误识别）", () => {
       retryable: true,
     },
     {
+      text: `unexpected status 413 Payload Too Large: <html>
+<head><title>413 Request Entity Too Large</title></head>
+<body>
+<center><h1>413 Request Entity Too Large</h1></center>
+<hr><center>nginx</center>
+</body>
+</html>, url: https://example.test/v1/responses, cf-ray: a04d1f6`,
+      kind: "payloadTooLarge",
+      retryable: true,
+    },
+    {
+      text: "unexpected status 413, url: https://example.test/v1/responses",
+      kind: "payloadTooLarge",
+      retryable: true,
+    },
+    {
       text: "unexpected status 503 Service Unavailable: openai_error, url: https://example.test/v1/responses, cf-ray: a03f93882b23f591-SJC",
       kind: "serviceUnavailable",
       retryable: true,
@@ -203,6 +219,9 @@ describe("codex-cli-error-classifier（Codex TUI 错误识别）", () => {
       classifyCodexCliErrorText("<html><body><h1>400 Bad Request</h1></body></html>"),
     )).toBe(false);
     expect(shouldDelayCodexCliFinalErrorForReconnect(
+      classifyCodexCliErrorText("<html><body><h1>413 Request Entity Too Large</h1></body></html>"),
+    )).toBe(false);
+    expect(shouldDelayCodexCliFinalErrorForReconnect(
       classifyCodexCliErrorText("We're currently experiencing high demand, which may cause temporary errors."),
     )).toBe(false);
   });
@@ -215,6 +234,7 @@ describe("codex-cli-error-classifier（Codex TUI 错误识别）", () => {
     expect(getCodexCliErrorKindLabel("rateLimited")).toBe("429 Too Many Requests");
     expect(getCodexCliErrorKindLabel("networkStream")).toBe("stream disconnected before completion");
     expect(getCodexCliErrorKindLabel("serviceUnavailable")).toBe("503 Service Unavailable");
+    expect(getCodexCliErrorKindLabel("payloadTooLarge")).toBe("413 Payload Too Large");
     expect(getCodexCliErrorKindLabel("highDemand")).toBe("We're currently experiencing high demand, which may cause temporary errors.");
   });
 });

--- a/web/src/lib/codex-cli-error-classifier.ts
+++ b/web/src/lib/codex-cli-error-classifier.ts
@@ -9,6 +9,7 @@ export type CodexCliErrorKind =
   | "highDemand"
   | "forbidden"
   | "badRequest"
+  | "payloadTooLarge"
   | "unknownHttp";
 
 export type CodexCliErrorSeverity = "temporary" | "blocking";
@@ -42,6 +43,7 @@ export const CODEX_CLI_ERROR_KIND_LABELS: Record<CodexCliErrorKind, string> = {
   highDemand: "We're currently experiencing high demand, which may cause temporary errors.",
   forbidden: "403 Forbidden",
   badRequest: "400 Bad Request",
+  payloadTooLarge: "413 Payload Too Large",
   unknownHttp: "unexpected status",
 };
 
@@ -88,6 +90,11 @@ const CODEX_CLI_ERROR_RULES: CodexCliErrorRule[] = [
     pattern: /(?:unexpected status\s+400|400\s+Bad Request|<h1>\s*400\s+Bad Request\s*<\/h1>)/i,
   },
   {
+    kind: "payloadTooLarge",
+    severity: "blocking",
+    pattern: /(?:unexpected status\s+413(?:\s+(?:Payload Too Large|Request Entity Too Large))?|413\s+(?:Payload Too Large|Request Entity Too Large)|<h1>\s*413\s+(?:Payload Too Large|Request Entity Too Large)\s*<\/h1>)/i,
+  },
+  {
     kind: "concurrency",
     severity: "temporary",
     pattern: /concurrency limit exceeded/i,
@@ -117,7 +124,7 @@ const MAX_MATCHED_TEXT_LENGTH = 280;
 const RECONNECTING_STATUS_PATTERN = /Reconnecting\.\.\.\s+(\d+)\/(\d+)/gi;
 const WORKING_STATUS_PATTERN = /\bWorking\s*\(/gi;
 const EXPLICIT_FINAL_ERROR_PATTERN =
-  /(?:exceeded retry limit|selected model is at capacity|you['’]ve hit your usage limit|usage limit(?:ed)?(?:\s+reached)?|currently experiencing high demand|400\s+Bad Request|<h1>\s*400\s+Bad Request\s*<\/h1>)/i;
+  /(?:exceeded retry limit|selected model is at capacity|you['’]ve hit your usage limit|usage limit(?:ed)?(?:\s+reached)?|currently experiencing high demand|400\s+Bad Request|<h1>\s*400\s+Bad Request\s*<\/h1>|unexpected status\s+413\b|413\s+Payload Too Large|413\s+Request Entity Too Large|<h1>\s*413\s+(?:Payload Too Large|Request Entity Too Large)\s*<\/h1>)/i;
 
 /**
  * 去除终端 ANSI/控制序列，并保留足够的换行信息用于错误文本识别。
@@ -142,7 +149,8 @@ export function isCodexCliErrorAutoRetryable(kind: CodexCliErrorKind): boolean {
     kind === "highDemand" ||
     kind === "modelCapacity" ||
     kind === "forbidden" ||
-    kind === "badRequest"
+    kind === "badRequest" ||
+    kind === "payloadTooLarge"
   );
 }
 

--- a/web/src/lib/codex-error-handling-settings.test.ts
+++ b/web/src/lib/codex-error-handling-settings.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   CODEX_AUTO_CONTINUE_ERROR_KINDS,
   CODEX_AUTO_CONTINUE_ERROR_KINDS_VERSION,
+  CODEX_DEFAULT_AUTO_CONTINUE_ERROR_KINDS,
   normalizeCodexErrorHandlingPrefs,
 } from "./codex-error-handling-settings";
 
@@ -11,9 +12,19 @@ describe("codex-error-handling-settings（Codex 错误处理设置）", () => {
     expect(normalizeCodexErrorHandlingPrefs({ notifyReconnectErrors: true }).notifyReconnectErrors).toBe(true);
   });
 
-  it("旧配置缺少错误类型列表时默认覆盖全部可恢复错误", () => {
+  it("旧配置缺少错误类型列表时默认覆盖默认可自动 continue 错误", () => {
     expect(normalizeCodexErrorHandlingPrefs({ autoContinueEnabled: true }).autoContinueErrorKinds)
-      .toEqual(CODEX_AUTO_CONTINUE_ERROR_KINDS);
+      .toEqual(CODEX_DEFAULT_AUTO_CONTINUE_ERROR_KINDS);
+  });
+
+  it("413 错误可手动配置自动 continue 但默认不勾选", () => {
+    expect(CODEX_AUTO_CONTINUE_ERROR_KINDS).toContain("payloadTooLarge");
+    expect(CODEX_DEFAULT_AUTO_CONTINUE_ERROR_KINDS).not.toContain("payloadTooLarge");
+    expect(normalizeCodexErrorHandlingPrefs({}).autoContinueErrorKinds).not.toContain("payloadTooLarge");
+    expect(normalizeCodexErrorHandlingPrefs({
+      autoContinueErrorKinds: ["payloadTooLarge"],
+      autoContinueErrorKindsVersion: CODEX_AUTO_CONTINUE_ERROR_KINDS_VERSION,
+    }).autoContinueErrorKinds).toEqual(["payloadTooLarge"]);
   });
 
   it("用户显式清空错误类型列表时应保留空选择", () => {
@@ -29,14 +40,14 @@ describe("codex-error-handling-settings（Codex 错误处理设置）", () => {
   it("旧版默认 5 项应自动升级为新版全选", () => {
     expect(normalizeCodexErrorHandlingPrefs({
       autoContinueErrorKinds: ["networkStream", "rateLimited", "concurrency", "badGateway", "serviceUnavailable"],
-    }).autoContinueErrorKinds).toEqual(CODEX_AUTO_CONTINUE_ERROR_KINDS);
+    }).autoContinueErrorKinds).toEqual(CODEX_DEFAULT_AUTO_CONTINUE_ERROR_KINDS);
   });
 
   it("旧版默认 8 项应自动升级为新版全选", () => {
     expect(normalizeCodexErrorHandlingPrefs({
       autoContinueErrorKinds: ["networkStream", "rateLimited", "concurrency", "modelCapacity", "badGateway", "serviceUnavailable", "forbidden", "badRequest"],
       autoContinueErrorKindsVersion: 2,
-    }).autoContinueErrorKinds).toEqual(CODEX_AUTO_CONTINUE_ERROR_KINDS);
+    }).autoContinueErrorKinds).toEqual(CODEX_DEFAULT_AUTO_CONTINUE_ERROR_KINDS);
   });
 
   it("当前版本手动保留旧 5 项时不应反复升级", () => {

--- a/web/src/lib/codex-error-handling-settings.ts
+++ b/web/src/lib/codex-error-handling-settings.ts
@@ -2,7 +2,7 @@ import type { CodexCliErrorKind } from "./codex-cli-error-classifier";
 
 export type CodexAutoContinueErrorKind = Extract<
   CodexCliErrorKind,
-  "rateLimited" | "concurrency" | "networkStream" | "badGateway" | "serviceUnavailable" | "highDemand" | "modelCapacity" | "forbidden" | "badRequest"
+  "rateLimited" | "concurrency" | "networkStream" | "badGateway" | "serviceUnavailable" | "highDemand" | "modelCapacity" | "forbidden" | "badRequest" | "payloadTooLarge"
 >;
 
 export type CodexErrorHandlingPrefs = {
@@ -21,6 +21,18 @@ export const CODEX_ERROR_AUTO_CONTINUE_ATTEMPTS_MIN = 0;
 export const CODEX_ERROR_AUTO_CONTINUE_ATTEMPTS_MAX = 10;
 export const CODEX_AUTO_CONTINUE_ERROR_KINDS_VERSION = 3;
 export const CODEX_AUTO_CONTINUE_ERROR_KINDS: CodexAutoContinueErrorKind[] = [
+  "networkStream",
+  "rateLimited",
+  "concurrency",
+  "modelCapacity",
+  "badGateway",
+  "serviceUnavailable",
+  "highDemand",
+  "forbidden",
+  "badRequest",
+  "payloadTooLarge",
+];
+export const CODEX_DEFAULT_AUTO_CONTINUE_ERROR_KINDS: CodexAutoContinueErrorKind[] = [
   "networkStream",
   "rateLimited",
   "concurrency",
@@ -55,7 +67,7 @@ export const DEFAULT_CODEX_ERROR_HANDLING_PREFS: CodexErrorHandlingPrefs = {
   detectionEnabled: true,
   notifyReconnectErrors: false,
   autoContinueEnabled: false,
-  autoContinueErrorKinds: [...CODEX_AUTO_CONTINUE_ERROR_KINDS],
+  autoContinueErrorKinds: [...CODEX_DEFAULT_AUTO_CONTINUE_ERROR_KINDS],
   autoContinueErrorKindsVersion: CODEX_AUTO_CONTINUE_ERROR_KINDS_VERSION,
   autoContinueDelaySeconds: 30,
   autoContinueMaxAttempts: 2,

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -61,7 +61,7 @@ export type CodexErrorHandlingSettings = {
   /** 是否在可恢复错误后自动发送 continue。 */
   autoContinueEnabled?: boolean;
   /** 自动 continue 适用的可恢复错误类型。 */
-  autoContinueErrorKinds?: Array<"rateLimited" | "concurrency" | "networkStream" | "badGateway" | "serviceUnavailable" | "highDemand" | "modelCapacity" | "forbidden" | "badRequest">;
+  autoContinueErrorKinds?: Array<"rateLimited" | "concurrency" | "networkStream" | "badGateway" | "serviceUnavailable" | "highDemand" | "modelCapacity" | "forbidden" | "badRequest" | "payloadTooLarge">;
   /** 自动 continue 错误类型列表版本，用于一次性默认项迁移。 */
   autoContinueErrorKindsVersion?: number;
   /** 自动发送 continue 前等待的秒数。 */


### PR DESCRIPTION
补充 Codex CLI 输出中的 413 Payload Too Large / Request Entity Too Large 识别，避免被归类为 unknownHttp。

- 将 payloadTooLarge 纳入错误分类标签、设置类型与可配置自动 continue 类型列表
- 保持 413 自动 continue 默认不勾选，但允许用户手动开启
- 补充 413 HTML、裸状态码与设置归一化测试