### PR TITLE
perf(git): 优化Git工作台热会话与自动刷新

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -263,6 +263,15 @@ type TabDragPreviewWindowEntry = {
   lastBounds: Electron.Rectangle | null;
 };
 
+type GitWorkbenchSnapshotEntry = {
+  key: string;
+  tabId: string;
+  repoRoot: string;
+  snapshot: any;
+  updatedAt: number;
+  lastAccessedAt: number;
+};
+
 type RendererRecoveryReason = "render-process-gone" | "did-fail-load" | "unresponsive-timeout" | "gpu-process-gone";
 type RendererRecoveryAction = "reload" | "recreate";
 type RendererRecoveryState = {
@@ -276,9 +285,67 @@ const TAB_DRAG_PREVIEW_MAX_WIDTH = 228;
 const TAB_DRAG_PREVIEW_HEIGHT = 36;
 const TAB_DRAG_PREVIEW_CURSOR_OFFSET_X = 12;
 const TAB_DRAG_PREVIEW_CURSOR_OFFSET_Y = 10;
+const GIT_WORKBENCH_SNAPSHOT_MAX_ENTRIES = 3;
+const GIT_WORKBENCH_SNAPSHOT_IDLE_TTL_MS = 2 * 60 * 60 * 1000;
+const GIT_WORKBENCH_SNAPSHOT_TRIM_INTERVAL_MS = 5 * 60 * 1000;
+const GIT_WORKBENCH_SNAPSHOT_DELETE_TOMBSTONE_MS = 30 * 1000;
 const tabDragPreviewWindowsById = new Map<string, TabDragPreviewWindowEntry>();
 const tabDragPreviewWindowIdByOwner = new Map<string, string>();
+const gitWorkbenchSnapshotsByKey = new Map<string, GitWorkbenchSnapshotEntry>();
+const gitWorkbenchSnapshotDeletedTabIds = new Map<string, number>();
 let cachedAppBrandIconDataUrl: string | null | undefined;
+
+/**
+ * 构造 Git 工作台热会话缓存键，按 tab 与仓库根隔离跨窗口快照。
+ */
+function buildGitWorkbenchSnapshotKey(tabId: string, repoRoot: string): string {
+  const safeTabId = String(tabId || "").trim();
+  const safeRepoRoot = String(repoRoot || "").trim().replace(/\\/g, "/").toLowerCase();
+  if (!safeTabId || !safeRepoRoot) return "";
+  return `${safeTabId}\n${safeRepoRoot}`;
+}
+
+/**
+ * 清理过期或超出数量预算的 Git 工作台热会话快照。
+ */
+function trimGitWorkbenchSnapshots(now: number = Date.now()): void {
+  for (const [tabId, deletedAt] of Array.from(gitWorkbenchSnapshotDeletedTabIds.entries())) {
+    if (now - deletedAt > GIT_WORKBENCH_SNAPSHOT_DELETE_TOMBSTONE_MS)
+      gitWorkbenchSnapshotDeletedTabIds.delete(tabId);
+  }
+  for (const [key, entry] of Array.from(gitWorkbenchSnapshotsByKey.entries())) {
+    if (now - entry.lastAccessedAt > GIT_WORKBENCH_SNAPSHOT_IDLE_TTL_MS)
+      gitWorkbenchSnapshotsByKey.delete(key);
+  }
+  const entries = Array.from(gitWorkbenchSnapshotsByKey.entries())
+    .sort((a, b) => a[1].lastAccessedAt - b[1].lastAccessedAt);
+  while (entries.length > GIT_WORKBENCH_SNAPSHOT_MAX_ENTRIES) {
+    const [key] = entries.shift()!;
+    gitWorkbenchSnapshotsByKey.delete(key);
+  }
+}
+
+/**
+ * 读取指定 Git 工作台热会话；repoRoot 未命中时回退到同 tabId 的最近快照，支撑拖出窗口首帧恢复。
+ */
+function resolveGitWorkbenchSnapshotEntry(tabId: string, repoRoot: string): GitWorkbenchSnapshotEntry | null {
+  const safeTabId = String(tabId || "").trim();
+  if (!safeTabId) return null;
+  const key = buildGitWorkbenchSnapshotKey(safeTabId, repoRoot);
+  if (key) {
+    const entry = gitWorkbenchSnapshotsByKey.get(key);
+    if (entry) return entry;
+  }
+  const candidates = Array.from(gitWorkbenchSnapshotsByKey.values())
+    .filter((entry) => entry.tabId === safeTabId)
+    .sort((a, b) => b.lastAccessedAt - a.lastAccessedAt);
+  return candidates[0] || null;
+}
+
+const gitWorkbenchSnapshotTrimTimer = setInterval(() => {
+  trimGitWorkbenchSnapshots();
+}, GIT_WORKBENCH_SNAPSHOT_TRIM_INTERVAL_MS);
+try { (gitWorkbenchSnapshotTrimTimer as any).unref?.(); } catch {}
 
 type CreateWindowOptions = {
   restoreBounds?: Electron.Rectangle;
@@ -3433,6 +3500,79 @@ ipcMain.handle("gitFeature.call", async (event, args: { action: string; payload?
     });
   } catch (e: any) {
     return { ok: false, error: String(e?.message || e) };
+  }
+});
+
+/**
+ * Git 工作台热会话：写入跨窗口内存快照。
+ */
+ipcMain.handle("gitWorkbench.snapshot.put", async (_event, args: { tabId?: string; repoRoot?: string; snapshot?: any }) => {
+  try {
+    const tabId = String(args?.tabId || "").trim();
+    const repoRoot = String(args?.repoRoot || "").trim();
+    const key = buildGitWorkbenchSnapshotKey(tabId, repoRoot);
+    if (!key) return { ok: false, error: "missing tabId or repoRoot" };
+    const now = Date.now();
+    trimGitWorkbenchSnapshots(now);
+    if (gitWorkbenchSnapshotDeletedTabIds.has(tabId))
+      return { ok: true, ignored: true, count: gitWorkbenchSnapshotsByKey.size } as const;
+    gitWorkbenchSnapshotsByKey.set(key, {
+      key,
+      tabId,
+      repoRoot,
+      snapshot: args?.snapshot && typeof args.snapshot === "object" ? args.snapshot : {},
+      updatedAt: now,
+      lastAccessedAt: now,
+    });
+    trimGitWorkbenchSnapshots(now);
+    return { ok: true, updatedAt: now, count: gitWorkbenchSnapshotsByKey.size } as const;
+  } catch (e: any) {
+    return { ok: false, error: String(e?.message || e) } as const;
+  }
+});
+
+/**
+ * Git 工作台热会话：读取跨窗口内存快照。
+ */
+ipcMain.handle("gitWorkbench.snapshot.get", async (_event, args: { tabId?: string; repoRoot?: string }) => {
+  try {
+    const tabId = String(args?.tabId || "").trim();
+    if (!tabId) return { ok: false, error: "missing tabId" };
+    trimGitWorkbenchSnapshots();
+    const entry = resolveGitWorkbenchSnapshotEntry(tabId, String(args?.repoRoot || ""));
+    if (!entry) return { ok: true, snapshot: null } as const;
+    entry.lastAccessedAt = Date.now();
+    return { ok: true, snapshot: entry.snapshot, repoRoot: entry.repoRoot, updatedAt: entry.updatedAt } as const;
+  } catch (e: any) {
+    return { ok: false, error: String(e?.message || e) } as const;
+  }
+});
+
+/**
+ * Git 工作台热会话：删除指定快照，通常用于标签关闭后的资源回收。
+ */
+ipcMain.handle("gitWorkbench.snapshot.delete", async (_event, args: { tabId?: string; repoRoot?: string }) => {
+  try {
+    const tabId = String(args?.tabId || "").trim();
+    const repoRoot = String(args?.repoRoot || "").trim();
+    if (!tabId) return { ok: false, error: "missing tabId" };
+    const key = buildGitWorkbenchSnapshotKey(tabId, repoRoot);
+    let deletedCount = 0;
+    if (key) {
+      if (gitWorkbenchSnapshotsByKey.delete(key)) deletedCount += 1;
+    } else {
+      for (const [entryKey, entry] of Array.from(gitWorkbenchSnapshotsByKey.entries())) {
+        if (entry.tabId !== tabId) continue;
+        gitWorkbenchSnapshotsByKey.delete(entryKey);
+        deletedCount += 1;
+      }
+    }
+    gitWorkbenchSnapshotDeletedTabIds.set(tabId, Date.now());
+    trimGitWorkbenchSnapshots();
+    const deleted = deletedCount > 0;
+    return { ok: true, deleted } as const;
+  } catch (e: any) {
+    return { ok: false, error: String(e?.message || e) } as const;
   }
 });
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -530,6 +530,17 @@ contextBridge.exposeInMainWorld('host', {
     },
   },
   gitWorkbench: {
+    snapshot: {
+      get: async (args: { tabId: string; repoRoot?: string }) => {
+        return await ipcRenderer.invoke("gitWorkbench.snapshot.get", args);
+      },
+      put: async (args: { tabId: string; repoRoot: string; snapshot: any }) => {
+        return await ipcRenderer.invoke("gitWorkbench.snapshot.put", args);
+      },
+      delete: async (args: { tabId: string; repoRoot: string }) => {
+        return await ipcRenderer.invoke("gitWorkbench.snapshot.delete", args);
+      },
+    },
     /** 请求宿主打开 Git 工作台，并可按公共 actionId 触发提交、提交并推送、更新、拉取、获取、推送、冲突解决与搁置入口。 */
     show: async (args: {
       actionId?: string;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -325,7 +325,31 @@ import type {
   WorktreeRecycleProgressState,
 } from "@/app/app-shared";
 
-const GitWorkbench = React.lazy(async () => await import("@/features/git/git-workbench"));
+let gitWorkbenchModulePromise: Promise<typeof import("@/features/git/git-workbench")> | null = null;
+
+/**
+ * 预加载 Git 工作台模块，减少打开或拖出 Git 标签时的 lazy fallback 闪烁。
+ */
+function preloadGitWorkbenchModule(): void {
+  if (!gitWorkbenchModulePromise)
+    gitWorkbenchModulePromise = import("@/features/git/git-workbench");
+}
+
+const GitWorkbench = React.lazy(async () => {
+  if (!gitWorkbenchModulePromise)
+    gitWorkbenchModulePromise = import("@/features/git/git-workbench");
+  return await gitWorkbenchModulePromise;
+});
+
+type GitWorkbenchPublishSnapshotDoneDetail = {
+  tabId?: string;
+  requestId?: string;
+  ok?: boolean;
+};
+
+const GIT_WORKBENCH_PUBLISH_SNAPSHOT_EVENT = "cf:git-workbench-publish-snapshot";
+const GIT_WORKBENCH_PUBLISH_SNAPSHOT_DONE_EVENT = "cf:git-workbench-publish-snapshot-done";
+const GIT_WORKBENCH_PUBLISH_SNAPSHOT_TIMEOUT_MS = 350;
 
 type HistorySearchScope = "current_project" | "project_group" | "all_sessions";
 
@@ -1610,6 +1634,10 @@ export default function CodexFlowManagerUI() {
   const allProjectTabs = tabsByProject[selectedProjectId] || [];
   const tabs = useMemo(() => allProjectTabs.filter((tab) => isTabOwnedByWindow(tab, currentWindowId)), [allProjectTabs, currentWindowId]);
   const hasProjectGitWorkbenchTab = allProjectTabs.some((tab) => tab.kind === "git");
+  useEffect(() => {
+    if (!Object.values(tabsByProject).some((list) => (list || []).some((tab) => tab.kind === "git"))) return;
+    preloadGitWorkbenchModule();
+  }, [tabsByProject]);
   const [activeTabId, setActiveTabId] = useState<string | null>(() => {
     const state = restoredConsoleSession?.windowUiStateById?.[currentWindowId];
     return state?.activeTabIdByProject?.[selectedProjectId] || null;
@@ -2489,6 +2517,42 @@ export default function CodexFlowManagerUI() {
   }, [closeTabDragPreviewWindow]);
 
   /**
+   * 请求当前渲染进程里的 Git 工作台立即发布快照，供拖出窗口首帧恢复。
+   */
+  const requestGitWorkbenchSnapshotPublishAsync = useCallback(async (tabId: string): Promise<void> => {
+    const safeTabId = String(tabId || "").trim();
+    if (!safeTabId || typeof window === "undefined") return;
+    const tab = Object.values(tabsByProjectRef.current || {}).flat().find((item) => item.id === safeTabId) || null;
+    if (tab?.kind !== "git") return;
+    preloadGitWorkbenchModule();
+    const requestId = `git-snapshot-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        window.clearTimeout(timerId);
+        window.removeEventListener(GIT_WORKBENCH_PUBLISH_SNAPSHOT_DONE_EVENT, handleDone);
+        resolve();
+      };
+      const handleDone = (event: Event) => {
+        const detail = (event as CustomEvent<GitWorkbenchPublishSnapshotDoneDetail>).detail || {};
+        if (String(detail.tabId || "").trim() !== safeTabId) return;
+        if (String(detail.requestId || "").trim() !== requestId) return;
+        finish();
+      };
+      const timerId = window.setTimeout(finish, GIT_WORKBENCH_PUBLISH_SNAPSHOT_TIMEOUT_MS);
+      window.addEventListener(GIT_WORKBENCH_PUBLISH_SNAPSHOT_DONE_EVENT, handleDone);
+      window.dispatchEvent(new CustomEvent(GIT_WORKBENCH_PUBLISH_SNAPSHOT_EVENT, {
+        detail: {
+          tabId: safeTabId,
+          requestId,
+        },
+      }));
+    });
+  }, []);
+
+  /**
    * 将标签页分离到新窗口中；先写入快照再开窗，避免新窗口首帧读到“空标签”状态。
    */
   const detachTabToNewWindow = useCallback(async (
@@ -2497,6 +2561,7 @@ export default function CodexFlowManagerUI() {
   ) => {
     const safeTabId = String(tabId || "").trim();
     if (!safeTabId || isDetachedTabWindow) return;
+    await requestGitWorkbenchSnapshotPublishAsync(safeTabId);
     const nextWindowId = `detached-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
     const previousTabsByProject = tabsByProjectRef.current;
     const previousSelectedProjectId = selectedProjectId;
@@ -2562,6 +2627,7 @@ export default function CodexFlowManagerUI() {
     currentWindowId,
     isDetachedTabWindow,
     persistConsoleSessionSnapshot,
+    requestGitWorkbenchSnapshotPublishAsync,
     selectedProjectId,
     showHistoryPanel,
   ]);
@@ -7026,6 +7092,7 @@ export default function CodexFlowManagerUI() {
   const openGitWorkbenchTabForProjectId = useCallback((projectId: string): void => {
     const id = String(projectId || "").trim();
     if (!id) return;
+    preloadGitWorkbenchModule();
     const currentTabsByProject = tabsByProjectRef.current;
     const projectTabs = currentTabsByProject[id] || [];
     const existing = projectTabs.find((tab) => tab.kind === "git" && isTabOwnedByWindow(tab, currentWindowId));
@@ -7317,6 +7384,7 @@ export default function CodexFlowManagerUI() {
    */
   function openGitWorkbenchTab() {
     if (!selectedProject) return;
+    preloadGitWorkbenchModule();
     openGitWorkbenchTabForProjectId(selectedProject.id);
   }
 
@@ -7873,6 +7941,16 @@ export default function CodexFlowManagerUI() {
     if (!tabId) return;
     const projectId = String(projectIdOverride || selectedProject?.id || "").trim();
     if (!projectId) return;
+    const closingTab = (tabsByProjectRef.current[projectId] || []).find((tab) => tab.id === tabId) || null;
+    if (closingTab?.kind === "git") {
+      const projectRoot = String(projectsRef.current.find((project) => project.id === projectId)?.winPath || selectedProject?.winPath || "").trim();
+      if (projectRoot) {
+        void window.host.gitWorkbench?.snapshot?.delete?.({
+          tabId,
+          repoRoot: projectRoot,
+        });
+      }
+    }
     const pid = ptyByTabRef.current[tabId];
     if (pid) {
       try { window.host.pty.close(pid); } catch {}
@@ -11489,6 +11567,7 @@ export default function CodexFlowManagerUI() {
                   <Card className="relative flex flex-1 min-h-0 flex-col overflow-hidden">
                     <React.Suspense fallback={<div className="flex h-full items-center justify-center text-xs text-[var(--cf-text-secondary)]">{t("projects:gitModuleLoading", "正在加载 Git 模块...") as string}</div>}>
                       <GitWorkbench
+                        tabId={tab.id}
                         repoPath={selectedProject?.winPath || ""}
                         active={activeTabId === tab.id && !!selectedProject}
                         onOpenProjectInApp={openGitWorkbenchForPathAsync}

--- a/web/src/features/git/git-workbench-utils.test.ts
+++ b/web/src/features/git/git-workbench-utils.test.ts
@@ -312,7 +312,7 @@ describe("git workbench utils", () => {
     })).toBe(false);
   });
 
-  it("同一激活周期内，同仓库首刷只应触发一次；失活后重新激活可再次触发", () => {
+  it("同一仓库首刷只应触发一次；失活后重新激活应复用已初始化标记", () => {
     expect(resolveGitWorkbenchBootstrapRefresh({
       active: true,
       repoPath: "G:/Repo",
@@ -335,14 +335,14 @@ describe("git workbench utils", () => {
       lastBootstrapRepoPath: "G:/Repo",
     })).toEqual({
       shouldRefresh: false,
-      nextBootstrapRepoPath: "",
+      nextBootstrapRepoPath: "G:/Repo",
     });
     expect(resolveGitWorkbenchBootstrapRefresh({
       active: true,
       repoPath: "G:/Repo",
-      lastBootstrapRepoPath: "",
+      lastBootstrapRepoPath: "G:/Repo",
     })).toEqual({
-      shouldRefresh: true,
+      shouldRefresh: false,
       nextBootstrapRepoPath: "G:/Repo",
     });
   });

--- a/web/src/features/git/git-workbench-utils.ts
+++ b/web/src/features/git/git-workbench-utils.ts
@@ -352,13 +352,20 @@ export function resolveGitWorkbenchBootstrapRefresh(args: {
   lastBootstrapRepoPath: string;
 }): { shouldRefresh: boolean; nextBootstrapRepoPath: string } {
   const cleanRepoPath = String(args.repoPath || "").trim();
-  if (!args.active || !cleanRepoPath) {
+  const lastRepoPath = String(args.lastBootstrapRepoPath || "").trim();
+  if (!args.active) {
     return {
       shouldRefresh: false,
-      nextBootstrapRepoPath: "",
+      nextBootstrapRepoPath: lastRepoPath,
     };
   }
-  if (cleanRepoPath === String(args.lastBootstrapRepoPath || "").trim()) {
+  if (!cleanRepoPath) {
+    return {
+      shouldRefresh: false,
+      nextBootstrapRepoPath: lastRepoPath,
+    };
+  }
+  if (cleanRepoPath === lastRepoPath) {
     return {
       shouldRefresh: false,
       nextBootstrapRepoPath: cleanRepoPath,

--- a/web/src/features/git/git-workbench.tsx
+++ b/web/src/features/git/git-workbench.tsx
@@ -587,10 +587,70 @@ import {
 const MonacoGitDiff = React.lazy(async () => await import("./monaco-git-diff"));
 
 type GitWorkbenchProps = {
+  tabId?: string;
   repoPath: string;
   active: boolean;
   onOpenProjectInApp?: (projectPath: string) => Promise<boolean>;
   onOpenTerminalInApp?: (args: { projectPath: string; startupCmd: string; title?: string }) => Promise<boolean>;
+};
+
+type GitWorkbenchDiffSnapshotRef = Pick<
+  GitDiffSnapshot,
+  "path" | "oldPath" | "mode" | "hash" | "hashes" | "shelfRef" | "selectionPaths" | "selectionKind" | "selectionIndex" | "fingerprint"
+>;
+
+type GitWorkbenchHotSessionSnapshot = {
+  version: 1;
+  tabId: string;
+  repoPath: string;
+  repoRoot: string;
+  capturedAt: number;
+  isRepo: boolean;
+  repoBranch: string;
+  repoDetached: boolean;
+  status: GitStatusSnapshot | null;
+  branchPopup: GitBranchPopupSnapshot | null;
+  shelfItems: GitShelfItem[];
+  shelfViewState: GitShelfViewState;
+  stashItems: GitStashItem[];
+  worktreeItems: GitWorktreeItem[];
+  logItems: GitLogItem[];
+  logGraphItems: GitLogItem[];
+  logCursor: number;
+  logHasMore: boolean;
+  logFilters: GitLogFilters;
+  selectedPaths: string[];
+  exactlySelectedPaths: string[];
+  selectedCommitTreeKeys: string[];
+  selectedDiffableCommitNodeKey: string;
+  commitTreeExpanded: Record<string, boolean>;
+  commitGroupExpanded: Record<string, boolean>;
+  selectedCommitHashes: string[];
+  selectedDetailNodeKeys: string[];
+  detailTreeExpanded: Record<string, boolean>;
+  branchCompareFilesTreeExpanded: Record<string, boolean>;
+  leftTab: "commit" | "shelve";
+  bottomTab: "git" | "log" | "worktrees" | "conflicts";
+  bottomCollapsed: boolean;
+  leftCollapsed: boolean;
+  diffRef: GitWorkbenchDiffSnapshotRef | null;
+  scroll: {
+    commitTreeTop: number;
+    logTop: number;
+    logLeft: number;
+    detailTreeTop: number;
+  };
+};
+
+type GitWorkbenchPublishSnapshotRequestDetail = {
+  tabId?: string;
+  requestId?: string;
+};
+
+type GitWorkbenchPublishSnapshotDoneDetail = {
+  tabId: string;
+  requestId: string;
+  ok: boolean;
 };
 
 type MenuState = {
@@ -920,6 +980,13 @@ const DEFAULT_LOG_FILTERS: GitLogFilters = normalizeGitLogFilters({
 
 const LOG_ROW_HEIGHT = 32;
 const VIRTUAL_OVERSCAN = 8;
+const GIT_WORKBENCH_SNAPSHOT_VERSION = 1 as const;
+const GIT_WORKBENCH_SNAPSHOT_MAX_LOG_ITEMS = 400;
+const GIT_WORKBENCH_HOT_SESSION_STALE_MS = 30 * 60 * 1000;
+const GIT_WORKBENCH_LOCAL_HOT_SESSION_IDLE_TTL_MS = 2 * 60 * 60 * 1000;
+const GIT_WORKBENCH_LOCAL_HOT_SESSION_MAX_KEYS = 8;
+const GIT_WORKBENCH_PUBLISH_SNAPSHOT_EVENT = "cf:git-workbench-publish-snapshot";
+const GIT_WORKBENCH_PUBLISH_SNAPSHOT_DONE_EVENT = "cf:git-workbench-publish-snapshot-done";
 const CONTEXT_MENU_SAFE_GAP = 6;
 const TREE_DEPTH_INDENT = 18;
 const DETAIL_TREE_BASE_PADDING = 12;
@@ -938,6 +1005,182 @@ const GIT_TONE_CLASSNAME: Record<GitUiTone, string> = {
   info: "cf-git-tone-info",
   muted: "cf-git-tone-muted",
 };
+const gitWorkbenchLocalHotSessionSnapshotsByKey = new Map<string, GitWorkbenchHotSessionSnapshot>();
+
+/**
+ * 把 Diff 快照压缩成可恢复选择的轻量引用，避免把大文本和 patch 放入热会话缓存。
+ */
+function toGitWorkbenchDiffSnapshotRef(diff: GitDiffSnapshot | null): GitWorkbenchDiffSnapshotRef | null {
+  if (!diff?.path || !diff.mode) return null;
+  return {
+    path: String(diff.path || ""),
+    oldPath: String(diff.oldPath || "").trim() || undefined,
+    mode: diff.mode,
+    hash: String(diff.hash || "").trim() || undefined,
+    hashes: Array.isArray(diff.hashes) ? diff.hashes.map((one) => String(one || "").trim()).filter(Boolean) : undefined,
+    shelfRef: String(diff.shelfRef || "").trim() || undefined,
+    selectionPaths: Array.isArray(diff.selectionPaths) ? diff.selectionPaths.map((one) => String(one || "").trim()).filter(Boolean) : undefined,
+    selectionKind: diff.selectionKind,
+    selectionIndex: Number.isFinite(Number(diff.selectionIndex)) ? Number(diff.selectionIndex) : undefined,
+    fingerprint: String(diff.fingerprint || "").trim() || undefined,
+  };
+}
+
+/**
+ * 把外部快照规整为当前版本可消费的数据结构，防止脏数据破坏工作台状态。
+ */
+function normalizeGitWorkbenchHotSessionSnapshot(raw: any): GitWorkbenchHotSessionSnapshot | null {
+  if (!raw || typeof raw !== "object") return null;
+  if (Number(raw.version) !== GIT_WORKBENCH_SNAPSHOT_VERSION) return null;
+  const tabId = String(raw.tabId || "").trim();
+  const repoRoot = String(raw.repoRoot || "").trim();
+  if (!tabId || !repoRoot) return null;
+  const diffRefRaw = raw.diffRef && typeof raw.diffRef === "object" ? raw.diffRef : null;
+  return {
+    version: GIT_WORKBENCH_SNAPSHOT_VERSION,
+    tabId,
+    repoPath: String(raw.repoPath || "").trim(),
+    repoRoot,
+    capturedAt: Math.max(0, Math.floor(Number(raw.capturedAt) || 0)),
+    isRepo: raw.isRepo === true,
+    repoBranch: String(raw.repoBranch || ""),
+    repoDetached: raw.repoDetached === true,
+    status: raw.status && typeof raw.status === "object" ? raw.status as GitStatusSnapshot : null,
+    branchPopup: raw.branchPopup && typeof raw.branchPopup === "object" ? raw.branchPopup as GitBranchPopupSnapshot : null,
+    shelfItems: Array.isArray(raw.shelfItems) ? raw.shelfItems as GitShelfItem[] : [],
+    shelfViewState: raw.shelfViewState && typeof raw.shelfViewState === "object"
+      ? raw.shelfViewState as GitShelfViewState
+      : { showRecycled: false, groupByDirectory: false },
+    stashItems: Array.isArray(raw.stashItems) ? raw.stashItems as GitStashItem[] : [],
+    worktreeItems: Array.isArray(raw.worktreeItems) ? raw.worktreeItems as GitWorktreeItem[] : [],
+    logItems: Array.isArray(raw.logItems) ? (raw.logItems as GitLogItem[]).slice(0, GIT_WORKBENCH_SNAPSHOT_MAX_LOG_ITEMS) : [],
+    logGraphItems: Array.isArray(raw.logGraphItems) ? (raw.logGraphItems as GitLogItem[]).slice(0, GIT_WORKBENCH_SNAPSHOT_MAX_LOG_ITEMS) : [],
+    logCursor: Math.max(0, Math.floor(Number(raw.logCursor) || 0)),
+    logHasMore: raw.logHasMore === true,
+    logFilters: normalizeGitLogFilters(raw.logFilters || DEFAULT_LOG_FILTERS),
+    selectedPaths: Array.isArray(raw.selectedPaths) ? raw.selectedPaths.map((one: unknown) => String(one || "")).filter(Boolean) : [],
+    exactlySelectedPaths: Array.isArray(raw.exactlySelectedPaths) ? raw.exactlySelectedPaths.map((one: unknown) => String(one || "")).filter(Boolean) : [],
+    selectedCommitTreeKeys: Array.isArray(raw.selectedCommitTreeKeys) ? raw.selectedCommitTreeKeys.map((one: unknown) => String(one || "")).filter(Boolean) : [],
+    selectedDiffableCommitNodeKey: String(raw.selectedDiffableCommitNodeKey || ""),
+    commitTreeExpanded: raw.commitTreeExpanded && typeof raw.commitTreeExpanded === "object" ? raw.commitTreeExpanded as Record<string, boolean> : {},
+    commitGroupExpanded: raw.commitGroupExpanded && typeof raw.commitGroupExpanded === "object" ? raw.commitGroupExpanded as Record<string, boolean> : {},
+    selectedCommitHashes: Array.isArray(raw.selectedCommitHashes) ? raw.selectedCommitHashes.map((one: unknown) => String(one || "")).filter(Boolean) : [],
+    selectedDetailNodeKeys: Array.isArray(raw.selectedDetailNodeKeys) ? raw.selectedDetailNodeKeys.map((one: unknown) => String(one || "")).filter(Boolean) : [],
+    detailTreeExpanded: raw.detailTreeExpanded && typeof raw.detailTreeExpanded === "object" ? raw.detailTreeExpanded as Record<string, boolean> : {},
+    branchCompareFilesTreeExpanded: raw.branchCompareFilesTreeExpanded && typeof raw.branchCompareFilesTreeExpanded === "object" ? raw.branchCompareFilesTreeExpanded as Record<string, boolean> : {},
+    leftTab: raw.leftTab === "shelve" ? "shelve" : "commit",
+    bottomTab: raw.bottomTab === "log" || raw.bottomTab === "worktrees" || raw.bottomTab === "conflicts" ? raw.bottomTab : "git",
+    bottomCollapsed: raw.bottomCollapsed === true,
+    leftCollapsed: raw.leftCollapsed === true,
+    diffRef: diffRefRaw?.path && diffRefRaw?.mode ? {
+      path: String(diffRefRaw.path || ""),
+      oldPath: String(diffRefRaw.oldPath || "").trim() || undefined,
+      mode: diffRefRaw.mode as GitDiffMode,
+      hash: String(diffRefRaw.hash || "").trim() || undefined,
+      hashes: Array.isArray(diffRefRaw.hashes) ? diffRefRaw.hashes.map((one: unknown) => String(one || "").trim()).filter(Boolean) : undefined,
+      shelfRef: String(diffRefRaw.shelfRef || "").trim() || undefined,
+      selectionPaths: Array.isArray(diffRefRaw.selectionPaths) ? diffRefRaw.selectionPaths.map((one: unknown) => String(one || "").trim()).filter(Boolean) : undefined,
+      selectionKind: diffRefRaw.selectionKind,
+      selectionIndex: Number.isFinite(Number(diffRefRaw.selectionIndex)) ? Number(diffRefRaw.selectionIndex) : undefined,
+      fingerprint: String(diffRefRaw.fingerprint || "").trim() || undefined,
+    } : null,
+    scroll: {
+      commitTreeTop: Math.max(0, Math.floor(Number(raw.scroll?.commitTreeTop) || 0)),
+      logTop: Math.max(0, Math.floor(Number(raw.scroll?.logTop) || 0)),
+      logLeft: Math.max(0, Math.floor(Number(raw.scroll?.logLeft) || 0)),
+      detailTreeTop: Math.max(0, Math.floor(Number(raw.scroll?.detailTreeTop) || 0)),
+    },
+  };
+}
+
+/**
+ * 构造渲染进程本地热会话键，避免同窗口项目切换时还要等待 IPC 恢复。
+ */
+function buildGitWorkbenchLocalHotSessionKey(tabId: string, path: string): string {
+  const safeTabId = String(tabId || "").trim();
+  const pathKey = normalizeGitWorkbenchProjectPathKey(path);
+  if (!safeTabId || !pathKey) return "";
+  return `${safeTabId}\n${pathKey}`;
+}
+
+/**
+ * 构造“已恢复”标记键，让 bootstrap 能识别当前 tab/path 已经有可用快照。
+ */
+function buildGitWorkbenchHotSessionAppliedKey(tabId: string, path: string): string {
+  const safeTabId = String(tabId || "").trim();
+  const pathKey = normalizeGitWorkbenchProjectPathKey(path);
+  if (!safeTabId || !pathKey) return "";
+  return `${safeTabId}:${pathKey}`;
+}
+
+/**
+ * 用快照自身路径补齐恢复键，支持独立窗口首帧暂时没有 repoPath 的情况。
+ */
+function buildGitWorkbenchSnapshotAppliedKey(snapshot: GitWorkbenchHotSessionSnapshot, currentPath: string): string {
+  return buildGitWorkbenchHotSessionAppliedKey(snapshot.tabId, currentPath || snapshot.repoPath || snapshot.repoRoot);
+}
+
+/**
+ * 判断热会话快照是否属于目标路径；目标路径为空时只按 tabId 恢复，等待宿主项目路径随后补齐。
+ */
+function isGitWorkbenchHotSessionSnapshotForPath(snapshot: GitWorkbenchHotSessionSnapshot, currentPath: string): boolean {
+  const currentPathKey = normalizeGitWorkbenchProjectPathKey(currentPath);
+  if (!currentPathKey) return true;
+  const snapshotRepoPathKey = normalizeGitWorkbenchProjectPathKey(snapshot.repoPath || "");
+  const snapshotRepoRootKey = normalizeGitWorkbenchProjectPathKey(snapshot.repoRoot || "");
+  if (!snapshotRepoRootKey) return false;
+  return snapshotRepoPathKey === currentPathKey
+    || snapshotRepoRootKey === currentPathKey
+    || currentPathKey.startsWith(`${snapshotRepoRootKey}/`)
+    || snapshotRepoRootKey.startsWith(`${currentPathKey}/`);
+}
+
+/**
+ * 清理本地热会话缓存，容量按 key 计算，实际仓库数通常只有 1-2 个。
+ */
+function trimLocalGitWorkbenchHotSessionSnapshots(now: number = Date.now()): void {
+  for (const [key, snapshot] of Array.from(gitWorkbenchLocalHotSessionSnapshotsByKey.entries())) {
+    if (now - Math.max(0, Number(snapshot.capturedAt) || 0) > GIT_WORKBENCH_LOCAL_HOT_SESSION_IDLE_TTL_MS)
+      gitWorkbenchLocalHotSessionSnapshotsByKey.delete(key);
+  }
+  const entries = Array.from(gitWorkbenchLocalHotSessionSnapshotsByKey.entries())
+    .sort((a, b) => Math.max(0, Number(a[1].capturedAt) || 0) - Math.max(0, Number(b[1].capturedAt) || 0));
+  while (entries.length > GIT_WORKBENCH_LOCAL_HOT_SESSION_MAX_KEYS) {
+    const [key] = entries.shift()!;
+    gitWorkbenchLocalHotSessionSnapshotsByKey.delete(key);
+  }
+}
+
+/**
+ * 记录渲染进程本地热会话，优先服务同窗口项目切换后的同步首帧恢复。
+ */
+function rememberLocalGitWorkbenchHotSessionSnapshot(snapshot: GitWorkbenchHotSessionSnapshot): void {
+  const normalized = normalizeGitWorkbenchHotSessionSnapshot(snapshot);
+  if (!normalized) return;
+  for (const path of [normalized.repoRoot, normalized.repoPath]) {
+    const key = buildGitWorkbenchLocalHotSessionKey(normalized.tabId, path);
+    if (!key) continue;
+    gitWorkbenchLocalHotSessionSnapshotsByKey.delete(key);
+    gitWorkbenchLocalHotSessionSnapshotsByKey.set(key, normalized);
+  }
+  trimLocalGitWorkbenchHotSessionSnapshots();
+}
+
+/**
+ * 从本地热会话里读取当前 tab/path 最合适的快照，路径为空时回退到同 tab 最新快照。
+ */
+function findLocalGitWorkbenchHotSessionSnapshot(tabId: string, currentPath: string): GitWorkbenchHotSessionSnapshot | null {
+  const safeTabId = String(tabId || "").trim();
+  if (!safeTabId) return null;
+  trimLocalGitWorkbenchHotSessionSnapshots();
+  const exactKey = buildGitWorkbenchLocalHotSessionKey(safeTabId, currentPath);
+  const exact = exactKey ? gitWorkbenchLocalHotSessionSnapshotsByKey.get(exactKey) || null : null;
+  if (exact && isGitWorkbenchHotSessionSnapshotForPath(exact, currentPath)) return exact;
+  const candidates = Array.from(new Set(gitWorkbenchLocalHotSessionSnapshotsByKey.values()))
+    .filter((snapshot) => snapshot.tabId === safeTabId && isGitWorkbenchHotSessionSnapshotForPath(snapshot, currentPath))
+    .sort((a, b) => Math.max(0, Number(b.capturedAt) || 0) - Math.max(0, Number(a.capturedAt) || 0));
+  return candidates[0] || null;
+}
 
 type GitWorkbenchLayout = {
   leftPanelWidth: number;
@@ -3001,7 +3244,7 @@ function ToolbarDropdownSubmenu(props: ToolbarDropdownSubmenuProps): JSX.Element
  */
 export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   const { t } = useTranslation(["git", "common"]);
-  const { repoPath, active, onOpenProjectInApp, onOpenTerminalInApp } = props;
+  const { tabId, repoPath, active, onOpenProjectInApp, onOpenTerminalInApp } = props;
   const gt = useCallback((key: string, fallback: string, values?: Record<string, unknown>): string => {
     return interpolateI18nText(String(t(key, {
       ns: "git",
@@ -3016,13 +3259,18 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     return toErrorText(raw, gt(key, fallback, values));
   }, [gt]);
   const projectScopePath = String(repoPath || "").trim();
+  const hotSessionTabId = String(tabId || "").trim();
+  const initialHotSessionSnapshot = useMemo(() => {
+    return findLocalGitWorkbenchHotSessionSnapshot(hotSessionTabId, projectScopePath);
+  }, [hotSessionTabId, projectScopePath]);
   const initialLayout = useMemo(() => loadWorkbenchLayout(), []);
   const initialBranchPopupState = useMemo(() => loadGitBranchPopupState(), []);
 
-  const [repoRoot, setRepoRoot] = useState<string>("");
-  const [repoBranch, setRepoBranch] = useState<string>("");
-  const [repoDetached, setRepoDetached] = useState<boolean>(false);
-  const [isRepo, setIsRepo] = useState<boolean>(false);
+  const [repoRoot, setRepoRoot] = useState<string>(() => initialHotSessionSnapshot?.repoRoot || "");
+  const [repoBranch, setRepoBranch] = useState<string>(() => initialHotSessionSnapshot?.repoBranch || initialHotSessionSnapshot?.branchPopup?.currentBranch || initialHotSessionSnapshot?.status?.branch || "");
+  const [repoDetached, setRepoDetached] = useState<boolean>(() => initialHotSessionSnapshot?.repoDetached || initialHotSessionSnapshot?.branchPopup?.detached === true || initialHotSessionSnapshot?.status?.detached === true);
+  const [isRepo, setIsRepo] = useState<boolean>(() => !!initialHotSessionSnapshot && (initialHotSessionSnapshot.isRepo || !!initialHotSessionSnapshot.status || !!initialHotSessionSnapshot.branchPopup));
+  const [repoProbeSettled, setRepoProbeSettled] = useState<boolean>(() => !!initialHotSessionSnapshot || (!projectScopePath && !hotSessionTabId));
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
   const [gitNotices, setGitNotices] = useState<GitNoticeItem[]>([]);
@@ -3048,30 +3296,34 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   const [branchPopupOpen, setBranchPopupOpen] = useState<boolean>(false);
   const [branchPopupQuery, setBranchPopupQuery] = useState<string>("");
   const [branchPopupIndex, setBranchPopupIndex] = useState<number>(0);
-  const [branchPopup, setBranchPopup] = useState<GitBranchPopupSnapshot | null>(null);
-  const [branchSelectedRepoRoot, setBranchSelectedRepoRoot] = useState<string>(initialBranchPopupState.selectedRepoRoot);
+  const [branchPopup, setBranchPopup] = useState<GitBranchPopupSnapshot | null>(() => initialHotSessionSnapshot?.branchPopup || null);
+  const [branchSelectedRepoRoot, setBranchSelectedRepoRoot] = useState<string>(() => initialHotSessionSnapshot?.branchPopup?.selectedRepoRoot || initialHotSessionSnapshot?.repoRoot || initialBranchPopupState.selectedRepoRoot);
   const [branchPopupStep, setBranchPopupStep] = useState<GitBranchPopupStep>(initialBranchPopupState.step);
   const [branchPanelSpeedSearch, setBranchPanelSpeedSearch] = useState<string>("");
   const [branchPanelSpeedSearchOpen, setBranchPanelSpeedSearchOpen] = useState<boolean>(false);
   const [branchPanelFocusedRowKey, setBranchPanelFocusedRowKey] = useState<string>("");
   const [logBranchesDashboardState, setLogBranchesDashboardState] = useState<GitLogBranchesDashboardState>(() => loadGitLogBranchesDashboardState());
 
-  const [leftTab, setLeftTab] = useState<"commit" | "shelve">("commit");
+  const [leftTab, setLeftTab] = useState<"commit" | "shelve">(() => initialHotSessionSnapshot?.leftTab || "commit");
   const [commitMessage, setCommitMessage] = useState<string>("");
-  const [status, setStatus] = useState<GitStatusSnapshot | null>(null);
-  const [ignoredEntries, setIgnoredEntries] = useState<GitStatusEntry[]>([]);
+  const [status, setStatus] = useState<GitStatusSnapshot | null>(() => initialHotSessionSnapshot?.status || null);
+  const [ignoredEntries, setIgnoredEntries] = useState<GitStatusEntry[]>(() => {
+    return initialHotSessionSnapshot?.status?.viewOptions?.showIgnored && Array.isArray(initialHotSessionSnapshot.status.ignoredEntries)
+      ? initialHotSessionSnapshot.status.ignoredEntries
+      : [];
+  });
   const [ignoredLoading, setIgnoredLoading] = useState<boolean>(false);
   const [commitTreeBusy, setCommitTreeBusy] = useState<boolean>(false);
   const [commitTreeResetPending, setCommitTreeResetPending] = useState<boolean>(false);
   const [commitInclusionState, setCommitInclusionState] = useState<CommitInclusionState>(() => createCommitInclusionState());
   const [partialCommitSelectionState, setPartialCommitSelectionState] = useState<PartialCommitSelectionState>(() => createPartialCommitSelectionState());
-  const [selectedPaths, setSelectedPaths] = useState<string[]>([]);
-  const [exactlySelectedPaths, setExactlySelectedPaths] = useState<string[]>([]);
-  const [selectedCommitTreeKeys, setSelectedCommitTreeKeys] = useState<string[]>([]);
-  const [selectedDiffableCommitNodeKey, setSelectedDiffableCommitNodeKey] = useState<string>("");
+  const [selectedPaths, setSelectedPaths] = useState<string[]>(() => initialHotSessionSnapshot?.selectedPaths || []);
+  const [exactlySelectedPaths, setExactlySelectedPaths] = useState<string[]>(() => initialHotSessionSnapshot?.exactlySelectedPaths || []);
+  const [selectedCommitTreeKeys, setSelectedCommitTreeKeys] = useState<string[]>(() => initialHotSessionSnapshot?.selectedCommitTreeKeys || []);
+  const [selectedDiffableCommitNodeKey, setSelectedDiffableCommitNodeKey] = useState<string>(() => initialHotSessionSnapshot?.selectedDiffableCommitNodeKey || "");
   const [commitSelectionAnchors, setCommitSelectionAnchors] = useState<CommitSelectionAnchor[]>([]);
-  const [commitTreeExpanded, setCommitTreeExpanded] = useState<Record<string, boolean>>({});
-  const [commitGroupExpanded, setCommitGroupExpanded] = useState<Record<string, boolean>>({});
+  const [commitTreeExpanded, setCommitTreeExpanded] = useState<Record<string, boolean>>(() => initialHotSessionSnapshot?.commitTreeExpanded || {});
+  const [commitGroupExpanded, setCommitGroupExpanded] = useState<Record<string, boolean>>(() => initialHotSessionSnapshot?.commitGroupExpanded || {});
   const [commitAmendEnabled, setCommitAmendEnabled] = useState<boolean>(false);
   const [commitAmendLoading, setCommitAmendLoading] = useState<boolean>(false);
   const [commitAmendDetails, setCommitAmendDetails] = useState<CommitAmendDetails | null>(null);
@@ -3113,10 +3365,10 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     modifiedSelectedLines: [],
   });
 
-  const [bottomCollapsed, setBottomCollapsed] = useState<boolean>(false);
+  const [bottomCollapsed, setBottomCollapsed] = useState<boolean>(() => initialHotSessionSnapshot?.bottomCollapsed || false);
   const [bottomHeight, setBottomHeight] = useState<number>(initialLayout.bottomHeight);
-  const [bottomTab, setBottomTab] = useState<"git" | "log" | "worktrees" | "conflicts">("git");
-  const [leftCollapsed, setLeftCollapsed] = useState<boolean>(false);
+  const [bottomTab, setBottomTab] = useState<"git" | "log" | "worktrees" | "conflicts">(() => initialHotSessionSnapshot?.bottomTab || "git");
+  const [leftCollapsed, setLeftCollapsed] = useState<boolean>(() => initialHotSessionSnapshot?.leftCollapsed || false);
   const [leftPanelWidth, setLeftPanelWidth] = useState<number>(initialLayout.leftPanelWidth);
   const [leftPanelProportion, setLeftPanelProportion] = useState<number | null>(null);
   const [branchPanelWidth, setBranchPanelWidth] = useState<number>(initialLayout.branchPanelWidth);
@@ -3147,22 +3399,25 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   const updateInfoAutoOpenedRequestIdsRef = useRef<Set<number>>(new Set());
   const conflictPanelSignatureRef = useRef<string>("");
 
-  const [logItems, setLogItems] = useState<GitLogItem[]>([]);
-  const [logGraphItems, setLogGraphItems] = useState<GitLogItem[]>([]);
+  const [logItems, setLogItems] = useState<GitLogItem[]>(() => initialHotSessionSnapshot?.logItems || []);
+  const [logGraphItems, setLogGraphItems] = useState<GitLogItem[]>(() => {
+    if (!initialHotSessionSnapshot) return [];
+    return initialHotSessionSnapshot.logGraphItems.length > 0 ? initialHotSessionSnapshot.logGraphItems : initialHotSessionSnapshot.logItems;
+  });
   const [logColumnLayout, setLogColumnLayout] = useState<GitLogColumnLayout>(() => loadGitLogColumnLayout());
-  const [logCursor, setLogCursor] = useState<number>(0);
-  const [logHasMore, setLogHasMore] = useState<boolean>(false);
+  const [logCursor, setLogCursor] = useState<number>(() => initialHotSessionSnapshot?.logCursor || 0);
+  const [logHasMore, setLogHasMore] = useState<boolean>(() => initialHotSessionSnapshot?.logHasMore || false);
   const [logLoading, setLogLoading] = useState<boolean>(false);
-  const [logFilters, setLogFilters] = useState<GitLogFilters>(DEFAULT_LOG_FILTERS);
-  const [selectedCommitHashes, setSelectedCommitHashes] = useState<string[]>([]);
+  const [logFilters, setLogFilters] = useState<GitLogFilters>(() => initialHotSessionSnapshot?.logFilters || DEFAULT_LOG_FILTERS);
+  const [selectedCommitHashes, setSelectedCommitHashes] = useState<string[]>(() => initialHotSessionSnapshot?.selectedCommitHashes || []);
   const [pendingLogSelectionHash, setPendingLogSelectionHash] = useState<string>("");
   const [logActionAvailability, setLogActionAvailability] = useState<GitLogActionAvailability | null>(null);
   const [logActionAvailabilityHashesKey, setLogActionAvailabilityHashesKey] = useState<string>("");
   const [logActionAvailabilityLoading, setLogActionAvailabilityLoading] = useState<boolean>(false);
   const [details, setDetails] = useState<GitLogDetails | null>(null);
-  const [selectedDetailNodeKeys, setSelectedDetailNodeKeys] = useState<string[]>([]);
-  const [detailTreeExpanded, setDetailTreeExpanded] = useState<Record<string, boolean>>({});
-  const [branchCompareFilesTreeExpanded, setBranchCompareFilesTreeExpanded] = useState<Record<string, boolean>>({});
+  const [selectedDetailNodeKeys, setSelectedDetailNodeKeys] = useState<string[]>(() => initialHotSessionSnapshot?.selectedDetailNodeKeys || []);
+  const [detailTreeExpanded, setDetailTreeExpanded] = useState<Record<string, boolean>>(() => initialHotSessionSnapshot?.detailTreeExpanded || {});
+  const [branchCompareFilesTreeExpanded, setBranchCompareFilesTreeExpanded] = useState<Record<string, boolean>>(() => initialHotSessionSnapshot?.branchCompareFilesTreeExpanded || {});
   const [detailSpeedSearch, setDetailSpeedSearch] = useState<string>("");
   const [detailSpeedSearchOpen, setDetailSpeedSearchOpen] = useState<boolean>(false);
   const [showParentChanges, setShowParentChanges] = useState<boolean>(true);
@@ -3193,9 +3448,9 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   const [rollbackViewerRefreshing, setRollbackViewerRefreshing] = useState<boolean>(false);
   const [rollbackDiffOverlayOpen, setRollbackDiffOverlayOpen] = useState<boolean>(false);
 
-  const [shelfItems, setShelfItems] = useState<GitShelfItem[]>([]);
-  const [shelfViewState, setShelfViewState] = useState<GitShelfViewState>({ showRecycled: false, groupByDirectory: false });
-  const [stashItems, setStashItems] = useState<GitStashItem[]>([]);
+  const [shelfItems, setShelfItems] = useState<GitShelfItem[]>(() => initialHotSessionSnapshot?.shelfItems || []);
+  const [shelfViewState, setShelfViewState] = useState<GitShelfViewState>(() => initialHotSessionSnapshot?.shelfViewState || { showRecycled: false, groupByDirectory: false });
+  const [stashItems, setStashItems] = useState<GitStashItem[]>(() => initialHotSessionSnapshot?.stashItems || []);
   const [shelfRestoreDialogOpen, setShelfRestoreDialogOpen] = useState<boolean>(false);
   const [shelfRestoreDialogSubmitting, setShelfRestoreDialogSubmitting] = useState<boolean>(false);
   const [shelfRestoreDialogShelf, setShelfRestoreDialogShelf] = useState<GitShelfItem | null>(null);
@@ -3204,7 +3459,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     targetChangeListId: "",
     removeAppliedFromShelf: true,
   });
-  const [worktreeItems, setWorktreeItems] = useState<GitWorktreeItem[]>([]);
+  const [worktreeItems, setWorktreeItems] = useState<GitWorktreeItem[]>(() => initialHotSessionSnapshot?.worktreeItems || []);
   const [worktreeTreeExpanded, setWorktreeTreeExpanded] = useState<Record<string, boolean>>({});
   const [gitConsoleItems, setGitConsoleItems] = useState<GitConsoleEntry[]>([]);
   const [gitConsoleLoading, setGitConsoleLoading] = useState<boolean>(false);
@@ -3259,8 +3514,20 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   const [branchRemoteManagerDialogState, setBranchRemoteManagerDialogState] = useState<BranchRemoteManagerDialogState | null>(null);
   const actionDialogResolveRef = useRef<((value: Record<string, string> | null) => void) | null>(null);
   const commitOptionsTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const hotSessionRestoreKeyRef = useRef<string>("");
+  const hotSessionAppliedRestoreKeyRef = useRef<string>(initialHotSessionSnapshot ? buildGitWorkbenchSnapshotAppliedKey(initialHotSessionSnapshot, projectScopePath) : "");
+  const hotSessionSnapshotTimerRef = useRef<number | null>(null);
+  const hotSessionRestoringRef = useRef<boolean>(false);
+  const pendingRestoreScrollRef = useRef<GitWorkbenchHotSessionSnapshot["scroll"] | null>(initialHotSessionSnapshot?.scroll || null);
+  const latestHotSessionSnapshotRef = useRef<GitWorkbenchHotSessionSnapshot | null>(null);
+  const hotSessionStaleCheckKeyRef = useRef<string>(initialHotSessionSnapshot && Date.now() - Math.max(0, Number(initialHotSessionSnapshot.capturedAt) || 0) > GIT_WORKBENCH_HOT_SESSION_STALE_MS
+    ? `${initialHotSessionSnapshot.tabId}:${initialHotSessionSnapshot.repoRoot}:${initialHotSessionSnapshot.capturedAt}`
+    : "");
+  const repoProbePathKeyRef = useRef<string>(normalizeGitWorkbenchProjectPathKey(projectScopePath));
+  const [hotSessionRestoreSettledKey, setHotSessionRestoreSettledKey] = useState<string>(() => initialHotSessionSnapshot ? buildGitWorkbenchSnapshotAppliedKey(initialHotSessionSnapshot, projectScopePath) : "");
   const diffRequestSeqRef = useRef<number>(0);
-  const bootstrapRefreshRepoPathRef = useRef<string>("");
+  const bootstrapRefreshRepoPathRef = useRef<string>(initialHotSessionSnapshot?.repoPath || initialHotSessionSnapshot?.repoRoot || "");
+  const lastLogReloadKeyRef = useRef<string>("");
   const logRequestSeqRef = useRef<number>(0);
   const worktreeRequestSeqRef = useRef<number>(0);
   const detailRequestSeqRef = useRef<number>(0);
@@ -3337,6 +3604,166 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   const detailTreeSpeedSearchRootRef = useRef<HTMLDivElement>(null);
   const detailTreeContainerRef = useRef<HTMLDivElement>(null);
   const [activeSelectionScope, setActiveSelectionScope] = useState<"commit" | "detail" | null>(null);
+
+  /**
+   * 把热会话快照应用到当前工作台，只恢复可直接显示的小型状态。
+   */
+  function applyHotSessionSnapshot(snapshot: GitWorkbenchHotSessionSnapshot): void {
+    hotSessionRestoringRef.current = true;
+    try {
+      rememberLocalGitWorkbenchHotSessionSnapshot(snapshot);
+      setRepoRoot(snapshot.repoRoot);
+      setRepoBranch(snapshot.repoBranch || snapshot.branchPopup?.currentBranch || snapshot.status?.branch || "HEAD");
+      setRepoDetached(snapshot.repoDetached || snapshot.branchPopup?.detached === true || snapshot.status?.detached === true);
+      setIsRepo(snapshot.isRepo || !!snapshot.status || !!snapshot.branchPopup);
+      setRepoProbeSettled(true);
+      setStatus(snapshot.status);
+      setBranchPopup(snapshot.branchPopup);
+      setBranchSelectedRepoRoot(snapshot.branchPopup?.selectedRepoRoot || snapshot.repoRoot);
+      setShelfItems(snapshot.shelfItems);
+      setShelfViewState(snapshot.shelfViewState);
+      setStashItems(snapshot.stashItems);
+      setWorktreeItems(snapshot.worktreeItems);
+      setLogItems(snapshot.logItems);
+      setLogGraphItems(snapshot.logGraphItems.length > 0 ? snapshot.logGraphItems : snapshot.logItems);
+      setLogCursor(snapshot.logCursor);
+      setLogHasMore(snapshot.logHasMore);
+      setLogFilters(snapshot.logFilters);
+      setSelectedPaths(snapshot.selectedPaths);
+      setExactlySelectedPaths(snapshot.exactlySelectedPaths);
+      setSelectedCommitTreeKeys(snapshot.selectedCommitTreeKeys);
+      setSelectedDiffableCommitNodeKey(snapshot.selectedDiffableCommitNodeKey);
+      setCommitTreeExpanded(snapshot.commitTreeExpanded);
+      setCommitGroupExpanded(snapshot.commitGroupExpanded);
+      setSelectedCommitHashes(snapshot.selectedCommitHashes);
+      setSelectedDetailNodeKeys(snapshot.selectedDetailNodeKeys);
+      setDetailTreeExpanded(snapshot.detailTreeExpanded);
+      setBranchCompareFilesTreeExpanded(snapshot.branchCompareFilesTreeExpanded);
+      setLeftTab(snapshot.leftTab);
+      setBottomTab(snapshot.bottomTab);
+      setBottomCollapsed(snapshot.bottomCollapsed);
+      setLeftCollapsed(snapshot.leftCollapsed);
+      setDiff(null);
+      loadedDiffRequestSignatureRef.current = "";
+      pendingRestoreScrollRef.current = snapshot.scroll;
+      bootstrapRefreshRepoPathRef.current = snapshot.repoPath || snapshot.repoRoot;
+      hotSessionAppliedRestoreKeyRef.current = buildGitWorkbenchSnapshotAppliedKey(snapshot, projectScopePath);
+      const snapshotAgeMs = Date.now() - Math.max(0, Number(snapshot.capturedAt) || 0);
+      hotSessionStaleCheckKeyRef.current = snapshotAgeMs > GIT_WORKBENCH_HOT_SESSION_STALE_MS
+        ? `${snapshot.tabId}:${snapshot.repoRoot}:${snapshot.capturedAt}`
+        : "";
+      if (snapshot.status?.viewOptions?.showIgnored && Array.isArray(snapshot.status.ignoredEntries)) {
+        setIgnoredEntries(snapshot.status.ignoredEntries);
+      }
+    } finally {
+      window.setTimeout(() => {
+        hotSessionRestoringRef.current = false;
+      }, 0);
+    }
+  }
+
+  /**
+   * 判断热会话快照是否属于当前工作台路径，避免 tabId 被复用后误恢复旧仓库状态。
+   */
+  function isHotSessionSnapshotForCurrentPath(snapshot: GitWorkbenchHotSessionSnapshot): boolean {
+    return isGitWorkbenchHotSessionSnapshotForPath(snapshot, projectScopePath);
+  }
+
+  /**
+   * 采集当前工作台小型结构化状态；大 diff、patch、blob 内容只保留轻量引用。
+   */
+  function captureHotSessionSnapshot(): GitWorkbenchHotSessionSnapshot | null {
+    if (!hotSessionTabId || !repoRoot) return null;
+    return {
+      version: GIT_WORKBENCH_SNAPSHOT_VERSION,
+      tabId: hotSessionTabId,
+      repoPath: projectScopePath,
+      repoRoot,
+      capturedAt: Date.now(),
+      isRepo,
+      repoBranch,
+      repoDetached,
+      status,
+      branchPopup,
+      shelfItems,
+      shelfViewState,
+      stashItems,
+      worktreeItems,
+      logItems: logItems.slice(0, GIT_WORKBENCH_SNAPSHOT_MAX_LOG_ITEMS),
+      logGraphItems: logGraphItems.slice(0, GIT_WORKBENCH_SNAPSHOT_MAX_LOG_ITEMS),
+      logCursor,
+      logHasMore,
+      logFilters,
+      selectedPaths,
+      exactlySelectedPaths,
+      selectedCommitTreeKeys,
+      selectedDiffableCommitNodeKey,
+      commitTreeExpanded,
+      commitGroupExpanded,
+      selectedCommitHashes,
+      selectedDetailNodeKeys,
+      detailTreeExpanded,
+      branchCompareFilesTreeExpanded,
+      leftTab,
+      bottomTab,
+      bottomCollapsed,
+      leftCollapsed,
+      diffRef: toGitWorkbenchDiffSnapshotRef(diff),
+      scroll: {
+        commitTreeTop: commitTreeContainerRef.current?.scrollTop || 0,
+        logTop: logVirtual.containerRef.current?.scrollTop || 0,
+        logLeft: logVirtual.containerRef.current?.scrollLeft || 0,
+        detailTreeTop: detailTreeContainerRef.current?.scrollTop || 0,
+      },
+    };
+  }
+
+  /**
+   * 把当前热会话写入主进程内存 registry，供普通切换和独立窗口接管复用。
+   */
+  async function publishHotSessionSnapshotAsync(): Promise<void> {
+    const snapshot = latestHotSessionSnapshotRef.current;
+    if (!snapshot) return;
+    rememberLocalGitWorkbenchHotSessionSnapshot(snapshot);
+    try {
+      await window.host.gitWorkbench?.snapshot?.put({
+        tabId: snapshot.tabId,
+        repoRoot: snapshot.repoRoot,
+        snapshot,
+      });
+    } catch {}
+  }
+
+  /**
+   * 监听宿主拖窗前的快照发布请求，确保独立窗口接管前主进程已经有最新热会话。
+   */
+  useEffect(() => {
+    if (!hotSessionTabId) return;
+    const handlePublishSnapshot = (event: Event): void => {
+      const detail = (event as CustomEvent<GitWorkbenchPublishSnapshotRequestDetail>).detail || {};
+      if (String(detail.tabId || "").trim() !== hotSessionTabId) return;
+      const requestId = String(detail.requestId || "").trim();
+      void (async () => {
+        let ok = false;
+        try {
+          await publishHotSessionSnapshotAsync();
+          ok = true;
+        } finally {
+          if (requestId) {
+            window.dispatchEvent(new CustomEvent<GitWorkbenchPublishSnapshotDoneDetail>(GIT_WORKBENCH_PUBLISH_SNAPSHOT_DONE_EVENT, {
+              detail: {
+                tabId: hotSessionTabId,
+                requestId,
+                ok,
+              },
+            }));
+          }
+        }
+      })();
+    };
+    window.addEventListener(GIT_WORKBENCH_PUBLISH_SNAPSHOT_EVENT, handlePublishSnapshot);
+    return () => window.removeEventListener(GIT_WORKBENCH_PUBLISH_SNAPSHOT_EVENT, handlePublishSnapshot);
+  }, [hotSessionTabId]);
 
   /**
    * 当日志修订筛选不再匹配当前 compare range 时，自动清空比较态，避免 chip 文案与实际过滤条件脱节。
@@ -4377,6 +4804,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
       writeLastCommitMessage(window.localStorage, commitMessageValueRef.current);
     };
   }, [commitAdvancedOptionsState, repoRoot]);
+
   const availableCommitGroupingKeys = useMemo<CommitGroupingKey[]>(() => {
     return normalizeCommitGroupingKeys(viewOptions.availableGroupingKeys, true);
   }, [viewOptions.availableGroupingKeys]);
@@ -5417,6 +5845,147 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   const logHeaderScrollRef = useRef<HTMLDivElement>(null);
   const logScrollSyncLockRef = useRef<boolean>(false);
   const logVirtual = useVirtualWindow(logItems.length, LOG_ROW_HEIGHT, VIRTUAL_OVERSCAN, `${bottomTab}:${bottomCollapsed ? 1 : 0}:${diffFullscreen ? 1 : 0}`);
+  latestHotSessionSnapshotRef.current = captureHotSessionSnapshot();
+
+  /**
+   * 项目路径变化时重新进入仓库检测态，避免把旧仓库或旧空状态短暂渲染到新路径。
+   */
+  useEffect(() => {
+    const nextPathKey = normalizeGitWorkbenchProjectPathKey(projectScopePath);
+    if (repoProbePathKeyRef.current === nextPathKey) return;
+    repoProbePathKeyRef.current = nextPathKey;
+    const snapshot = findLocalGitWorkbenchHotSessionSnapshot(hotSessionTabId, projectScopePath);
+    if (snapshot) {
+      applyHotSessionSnapshot(snapshot);
+      const appliedKey = buildGitWorkbenchSnapshotAppliedKey(snapshot, projectScopePath);
+      setHotSessionRestoreSettledKey(appliedKey);
+      return;
+    }
+    setRepoProbeSettled(!nextPathKey && !hotSessionTabId);
+    setIsRepo(false);
+    setRepoRoot("");
+    setRepoBranch("");
+    setRepoDetached(false);
+    setError("");
+    bootstrapRefreshRepoPathRef.current = "";
+    hotSessionRestoreKeyRef.current = "";
+    hotSessionAppliedRestoreKeyRef.current = "";
+    hotSessionStaleCheckKeyRef.current = "";
+    setHotSessionRestoreSettledKey("");
+  }, [hotSessionTabId, projectScopePath]);
+
+  /**
+   * 首帧优先尝试恢复主进程热会话快照；成功后 UI 立即可见，后续刷新由 watcher 或手动刷新驱动。
+   */
+  useEffect(() => {
+    if (!hotSessionTabId) return;
+    const pathKey = normalizeGitWorkbenchProjectPathKey(projectScopePath);
+    const restoreKey = buildGitWorkbenchHotSessionAppliedKey(hotSessionTabId, projectScopePath) || `${hotSessionTabId}:pending`;
+    const requestKey = restoreKey;
+    if (hotSessionAppliedRestoreKeyRef.current === restoreKey) return;
+    if (hotSessionRestoreKeyRef.current === requestKey) return;
+    const localSnapshot = findLocalGitWorkbenchHotSessionSnapshot(hotSessionTabId, projectScopePath);
+    if (localSnapshot) {
+      applyHotSessionSnapshot(localSnapshot);
+      setHotSessionRestoreSettledKey(buildGitWorkbenchSnapshotAppliedKey(localSnapshot, projectScopePath));
+      return;
+    }
+    hotSessionRestoreKeyRef.current = requestKey;
+    setHotSessionRestoreSettledKey("");
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await window.host.gitWorkbench?.snapshot?.get({
+          tabId: hotSessionTabId,
+          repoRoot: projectScopePath,
+        });
+        if (cancelled || !res?.ok) return;
+        const snapshot = normalizeGitWorkbenchHotSessionSnapshot(res.snapshot);
+        if (!snapshot || !isHotSessionSnapshotForCurrentPath(snapshot)) return;
+        applyHotSessionSnapshot(snapshot);
+        await window.host.utils?.perfLog?.(`[GIT_WORKBENCH] hot-session restore tab=${hotSessionTabId} repo=${snapshot.repoRoot}`);
+      } catch {
+      } finally {
+        if (!cancelled) setHotSessionRestoreSettledKey(pathKey ? requestKey : `${hotSessionTabId}:pending`);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (hotSessionRestoreKeyRef.current === requestKey)
+        hotSessionRestoreKeyRef.current = "";
+    };
+  }, [hotSessionTabId, projectScopePath]);
+
+  /**
+   * 工作台状态变化后防抖发布热会话快照；切走或拖出窗口时可复用最近一次结构化状态。
+   */
+  useEffect(() => {
+    if (hotSessionRestoringRef.current) return;
+    if (!hotSessionTabId || !repoRoot) return;
+    if (hotSessionSnapshotTimerRef.current != null)
+      window.clearTimeout(hotSessionSnapshotTimerRef.current);
+    hotSessionSnapshotTimerRef.current = window.setTimeout(() => {
+      hotSessionSnapshotTimerRef.current = null;
+      void publishHotSessionSnapshotAsync();
+    }, active ? 400 : 0);
+    return () => {
+      if (hotSessionSnapshotTimerRef.current == null) return;
+      window.clearTimeout(hotSessionSnapshotTimerRef.current);
+      hotSessionSnapshotTimerRef.current = null;
+    };
+  }, [
+    active,
+    hotSessionTabId,
+    projectScopePath,
+    repoRoot,
+    isRepo,
+    repoBranch,
+    repoDetached,
+    status,
+    branchPopup,
+    shelfItems,
+    shelfViewState,
+    stashItems,
+    worktreeItems,
+    logItems,
+    logGraphItems,
+    logCursor,
+    logHasMore,
+    logFilters,
+    selectedPaths,
+    exactlySelectedPaths,
+    selectedCommitTreeKeys,
+    selectedDiffableCommitNodeKey,
+    commitTreeExpanded,
+    commitGroupExpanded,
+    selectedCommitHashes,
+    selectedDetailNodeKeys,
+    detailTreeExpanded,
+    branchCompareFilesTreeExpanded,
+    leftTab,
+    bottomTab,
+    bottomCollapsed,
+    leftCollapsed,
+    diff,
+  ]);
+
+  /**
+   * 快照恢复后把关键滚动位置回写到真实容器。
+   */
+  useEffect(() => {
+    const scroll = pendingRestoreScrollRef.current;
+    if (!scroll) return;
+    pendingRestoreScrollRef.current = null;
+    window.setTimeout(() => {
+      if (commitTreeContainerRef.current) commitTreeContainerRef.current.scrollTop = scroll.commitTreeTop;
+      if (logVirtual.containerRef.current) {
+        logVirtual.containerRef.current.scrollTop = scroll.logTop;
+        logVirtual.containerRef.current.scrollLeft = scroll.logLeft;
+      }
+      if (detailTreeContainerRef.current) detailTreeContainerRef.current.scrollTop = scroll.detailTreeTop;
+    }, 0);
+  }, [logItems.length, selectedCommitTreeKeys, selectedDetailNodeKeys, logVirtual.containerRef]);
+
   const worktreeTreeRows = useMemo<WorktreeTreeRow[]>(() => {
     return buildWorktreeTreeRows(repoRoot, displayWorktreeItems, worktreeTreeExpanded);
   }, [displayWorktreeItems, repoRoot, worktreeTreeExpanded]);
@@ -6043,6 +6612,68 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [refreshWorktreeItemsAsync]);
 
   /**
+   * 自动刷新链路的状态轻量刷新入口，只更新本地变更树和提交 inclusion 状态。
+   */
+  const refreshStatusForAutoRefreshAsync = useCallback(async (
+    options?: { debounceMs?: number },
+  ): Promise<void> => {
+    const targetRepoRoot = String(repoRoot || projectScopePath || "").trim();
+    if (!targetRepoRoot) return;
+    const debounceMs = Math.max(0, Math.floor(Number(options?.debounceMs) || 0));
+    if (debounceMs > 0) {
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, debounceMs);
+      });
+    }
+    setCommitTreeBusy(true);
+    try {
+      const statusRes = await getStatusAsync(projectScopePath || targetRepoRoot);
+      if (!statusRes.ok || !statusRes.data) return;
+      const statusData = statusRes.data;
+      setStatus(statusData);
+      setCommitInclusionState((prev) => syncCommitInclusionState(
+        prev,
+        buildCommitInclusionItems(statusData.entries || []),
+        String(statusData.changeLists?.activeListId || ""),
+        effectiveCommitAllSetting,
+      ));
+      if (statusData.viewOptions?.showIgnored) {
+        void refreshIgnoredEntriesAsync(targetRepoRoot, { preferCache: true });
+      } else {
+        ignoredRequestSeqRef.current += 1;
+        setIgnoredLoading(false);
+        setIgnoredEntries([]);
+      }
+    } finally {
+      setCommitTreeBusy(false);
+    }
+  }, [buildCommitInclusionItems, effectiveCommitAllSetting, projectScopePath, refreshIgnoredEntriesAsync, repoRoot, syncCommitInclusionState]);
+
+  /**
+   * 自动刷新链路的引用轻量刷新入口，只更新分支状态与日志首屏。
+   */
+  const refreshRefsForAutoRefreshAsync = useCallback(async (
+    options?: { debounceMs?: number },
+  ): Promise<void> => {
+    const targetRepoRoot = String(repoRoot || "").trim();
+    if (!targetRepoRoot) return;
+    const debounceMs = Math.max(0, Math.floor(Number(options?.debounceMs) || 0));
+    if (debounceMs > 0) {
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, debounceMs);
+      });
+    }
+    const branchRes = await getBranchPopupAsync(targetRepoRoot);
+    if (branchRes.ok && branchRes.data) {
+      setBranchPopup(branchRes.data);
+      setRepoBranch(String(branchRes.data.currentBranch || repoBranch || "HEAD"));
+      setRepoDetached(!!branchRes.data.detached);
+    }
+    if (active)
+      await loadLogAsync(targetRepoRoot, 0, true);
+  }, [active, loadLogAsync, repoBranch, repoRoot]);
+
+  /**
    * 执行通用刷新（状态/日志/分支/搁置/worktree），并始终使用最新日志筛选条件重载列表。
    */
   const runRefreshAllTaskAsync = useCallback(async (options?: { keepLog?: boolean }): Promise<void> => {
@@ -6060,6 +6691,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
       const repo = detect.data;
       if (!repo?.isRepo || !repo.repoRoot) {
         setIsRepo(false);
+        setRepoProbeSettled(true);
         setRepoRoot("");
         setRepoBranch("");
         setRepoDetached(false);
@@ -6075,6 +6707,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
       }
 
       setIsRepo(true);
+      setRepoProbeSettled(true);
       setRepoRoot(repo.repoRoot);
       setRepoBranch(String(repo.branch || "HEAD"));
       setRepoDetached(!!repo.detached);
@@ -6138,6 +6771,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
         await loadLogAsync(repo.repoRoot, 0, true);
       }
     } finally {
+      setRepoProbeSettled(true);
       setLoading(false);
       setCommitTreeBusy(false);
     }
@@ -6327,8 +6961,24 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     repoRoot,
     repoRoots: autoRefreshRepoRoots,
     refreshAllAsync,
+    refreshStatusAsync: refreshStatusForAutoRefreshAsync,
+    refreshRefsAsync: refreshRefsForAutoRefreshAsync,
     refreshWorktreesAsync: refreshWorktreeItemsForAutoRefreshAsync,
   });
+
+  /**
+   * 宽松 TTL 命中后仍先展示旧快照，再后台做轻量校验，照顾慢机器返回 Git 页签的体验。
+   */
+  useEffect(() => {
+    if (!active || !repoRoot) return;
+    const staleKey = hotSessionStaleCheckKeyRef.current;
+    if (!staleKey) return;
+    hotSessionStaleCheckKeyRef.current = "";
+    void (async () => {
+      await refreshStatusForAutoRefreshAsync();
+      await refreshRefsForAutoRefreshAsync();
+    })();
+  }, [active, refreshRefsForAutoRefreshAsync, refreshStatusForAutoRefreshAsync, repoRoot]);
 
   /**
    * 统一展示历史改写反馈，供 interactive rebase / editMessage / deleteCommit 共用通知与刷新语义。
@@ -13599,9 +14249,14 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   }, [activeLogFilters.dateFrom, activeLogFilters.dateTo, openActionDialogAsync, updateActiveLogFilters]);
 
   /**
-   * 初始化与激活时加载数据，未激活时不做请求；同一激活周期内对同一 repoPath 只做一次首刷。
+   * 初始化时在热会话恢复尝试之后加载数据；同一 repoPath 只做一次首刷。
    */
   useEffect(() => {
+    const restoreKey = hotSessionTabId && repoPath
+      ? buildGitWorkbenchHotSessionAppliedKey(hotSessionTabId, repoPath)
+      : "";
+    if (hotSessionTabId && repoPath && hotSessionRestoreSettledKey !== restoreKey && hotSessionAppliedRestoreKeyRef.current !== restoreKey)
+      return;
     const bootstrap = resolveGitWorkbenchBootstrapRefresh({
       active,
       repoPath,
@@ -13610,7 +14265,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     bootstrapRefreshRepoPathRef.current = bootstrap.nextBootstrapRepoPath;
     if (!bootstrap.shouldRefresh) return;
     void invokeRefreshAllAsync({ keepLog: false });
-  }, [active, invokeRefreshAllAsync, repoPath]);
+  }, [active, hotSessionRestoreSettledKey, hotSessionTabId, invokeRefreshAllAsync, repoPath]);
 
   /**
    * 订阅底层 Git 活动，统一驱动状态栏文案，并在控制台页签下按操作完成后做一次去抖刷新。
@@ -13727,6 +14382,11 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
         window.clearInterval(gitConsoleLiveRefreshTimerRef.current);
         gitConsoleLiveRefreshTimerRef.current = null;
       }
+      if (hotSessionSnapshotTimerRef.current != null) {
+        window.clearTimeout(hotSessionSnapshotTimerRef.current);
+        hotSessionSnapshotTimerRef.current = null;
+      }
+      void publishHotSessionSnapshotAsync();
       for (const timerId of gitNoticeTimersRef.current.values()) {
         window.clearTimeout(timerId);
       }
@@ -13743,6 +14403,9 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
    */
   useEffect(() => {
     if (!active || !repoRoot) return;
+    const reloadKey = `${repoRoot}\n${JSON.stringify(activeLogFilters)}`;
+    if (lastLogReloadKeyRef.current === reloadKey) return;
+    lastLogReloadKeyRef.current = reloadKey;
     const id = window.setTimeout(() => {
       void loadLogAsync(repoRoot, 0, true);
     }, 260);
@@ -14548,6 +15211,20 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
               {gt("workbench.misc.noRepo.redetect", "重新检测")}
               </Button>
           </div>
+        </div>
+      </div>
+    );
+  };
+
+  /**
+   * 渲染仓库检测尚未完成时的轻量状态，避免首刷前误显示“未检测到 Git 仓库”。
+   */
+  const renderRepoProbePending = (): JSX.Element => {
+    return (
+      <div className="flex h-full items-center justify-center p-4 text-sm text-[var(--cf-text-secondary)]">
+        <div className="flex items-center gap-2">
+          <Loader2 className="h-4 w-4 animate-spin text-[var(--cf-accent)]" />
+          <span>{gt("workbench.misc.status.detecting", "正在检测 Git 仓库...")}</span>
         </div>
       </div>
     );
@@ -19284,14 +19961,13 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   };
 
   const gitBusy = gitActivityCount > 0;
+  const repoProbePending = !repoProbeSettled && !isRepo;
   const gitStatusText = gitBusy
     ? gt("workbench.misc.status.busy", "正在{{activity}}", { activity: gitActivityText })
-    : (isRepo ? gt("workbench.misc.status.ready", "就绪") : gt("workbench.misc.status.noRepo", "未检测到 Git 仓库"));
+    : (repoProbePending
+      ? gt("workbench.misc.status.detecting", "正在检测 Git 仓库...")
+      : (isRepo ? gt("workbench.misc.status.ready", "就绪") : gt("workbench.misc.status.noRepo", "未检测到 Git 仓库")));
   const commitToolbarActive = leftTab === "commit" && !leftCollapsed;
-
-  if (!active) {
-    return <div className="h-full w-full bg-[var(--cf-surface-solid)]"></div>;
-  }
 
   return (
     <div className="cf-git-workbench relative flex h-full min-h-0 flex-col overflow-hidden rounded-[inherit] bg-[var(--cf-surface-muted)]">
@@ -19617,7 +20293,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
         />
       ) : null}
 
-      {!isRepo ? renderNoRepo() : (
+      {repoProbePending ? renderRepoProbePending() : !isRepo ? renderNoRepo() : (
         diffFullscreen && diff ? (
           <div className="min-h-0 flex flex-1 flex-col bg-[var(--cf-surface-solid)]">
             {renderDiffPanel(true)}

--- a/web/src/features/git/use-git-auto-refresh.test.ts
+++ b/web/src/features/git/use-git-auto-refresh.test.ts
@@ -5,8 +5,6 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useGitAutoRefresh } from "./use-git-auto-refresh";
 
-type HostListener<TPayload> = ((payload: TPayload) => void) | null;
-
 type HostApis = {
   fileIndex: {
     setActiveRoots: ReturnType<typeof vi.fn>;
@@ -16,6 +14,8 @@ type HostApis = {
     setActiveRoots: ReturnType<typeof vi.fn>;
     onChanged: ReturnType<typeof vi.fn>;
   };
+  fileIndexListeners: Set<(payload: { root?: string; reason?: string }) => void>;
+  repoWatchListeners: Set<(payload: { repoRoot?: string; reason?: string; paths?: string[] }) => void>;
   emitFileIndex(payload: { root?: string; reason?: string }): void;
   emitRepoWatch(payload: { repoRoot?: string; reason?: string; paths?: string[] }): void;
 };
@@ -24,34 +24,36 @@ type HostApis = {
  * 构造最小 host watcher 桩，便于精确驱动 hook 的订阅、切仓与卸载行为。
  */
 function createHostApis(): HostApis {
-  let fileIndexListener: HostListener<{ root?: string; reason?: string }> = null;
-  let repoWatchListener: HostListener<{ repoRoot?: string; reason?: string; paths?: string[] }> = null;
+  const fileIndexListeners = new Set<(payload: { root?: string; reason?: string }) => void>();
+  const repoWatchListeners = new Set<(payload: { repoRoot?: string; reason?: string; paths?: string[] }) => void>();
   const fileIndex = {
     setActiveRoots: vi.fn(async (_roots: string[]) => {}),
     onChanged: vi.fn((listener: (payload: { root?: string; reason?: string }) => void) => {
-      fileIndexListener = listener;
+      fileIndexListeners.add(listener);
       return () => {
-        if (fileIndexListener === listener) fileIndexListener = null;
+        fileIndexListeners.delete(listener);
       };
     }),
   };
   const gitRepoWatch = {
     setActiveRoots: vi.fn(async (_roots: string[]) => {}),
     onChanged: vi.fn((listener: (payload: { repoRoot?: string; reason?: string; paths?: string[] }) => void) => {
-      repoWatchListener = listener;
+      repoWatchListeners.add(listener);
       return () => {
-        if (repoWatchListener === listener) repoWatchListener = null;
+        repoWatchListeners.delete(listener);
       };
     }),
   };
   return {
     fileIndex,
     gitRepoWatch,
+    fileIndexListeners,
+    repoWatchListeners,
     emitFileIndex(payload) {
-      fileIndexListener?.(payload);
+      for (const listener of Array.from(fileIndexListeners)) listener(payload);
     },
     emitRepoWatch(payload) {
-      repoWatchListener?.(payload);
+      for (const listener of Array.from(repoWatchListeners)) listener(payload);
     },
   };
 }
@@ -64,6 +66,8 @@ function TestHarness(props: {
   repoRoot: string;
   repoRoots?: string[];
   refreshAllAsync: (options?: { keepLog?: boolean; debounceMs?: number }) => Promise<void>;
+  refreshStatusAsync?: (options?: { debounceMs?: number }) => Promise<void>;
+  refreshRefsAsync?: (options?: { debounceMs?: number }) => Promise<void>;
   refreshWorktreesAsync?: (options?: { debounceMs?: number }) => Promise<void>;
 }): JSX.Element | null {
   useGitAutoRefresh(props);
@@ -100,10 +104,12 @@ describe("useGitAutoRefresh", () => {
     vi.restoreAllMocks();
   });
 
-  it("应同时订阅 fileIndex 与 gitRepoWatch，并按不同来源透传去抖参数", async () => {
+  it("应同时订阅 fileIndex 与 gitRepoWatch，并按来源选择轻量刷新入口", async () => {
     vi.useFakeTimers();
     const hostApis = createHostApis();
     const refreshAllAsync = vi.fn(async (_options?: { keepLog?: boolean; debounceMs?: number }) => {});
+    const refreshStatusAsync = vi.fn(async (_options?: { debounceMs?: number }) => {});
+    const refreshRefsAsync = vi.fn(async (_options?: { debounceMs?: number }) => {});
     const refreshWorktreesAsync = vi.fn(async (_options?: { debounceMs?: number }) => {});
     Object.defineProperty(window, "host", {
       configurable: true,
@@ -123,6 +129,8 @@ describe("useGitAutoRefresh", () => {
         active: true,
         repoRoot: "/repo-a",
         refreshAllAsync,
+        refreshStatusAsync,
+        refreshRefsAsync,
         refreshWorktreesAsync,
       }));
       await flushMicrotasksAsync();
@@ -135,26 +143,29 @@ describe("useGitAutoRefresh", () => {
       hostApis.emitRepoWatch({ repoRoot: "/repo-a", reason: "head", paths: ["/repo-a/.git/HEAD"] });
       await flushMicrotasksAsync();
     });
-    expect(refreshAllAsync).toHaveBeenLastCalledWith({ keepLog: false, debounceMs: 80 });
+    expect(refreshRefsAsync).toHaveBeenLastCalledWith({ debounceMs: 80 });
+    expect(refreshAllAsync).not.toHaveBeenCalled();
 
     await act(async () => {
       hostApis.emitFileIndex({ root: "/repo-a" });
       await flushMicrotasksAsync();
     });
-    expect(refreshAllAsync).toHaveBeenCalledTimes(1);
+    expect(refreshStatusAsync).not.toHaveBeenCalled();
 
     await act(async () => {
       vi.advanceTimersByTime(2500);
       await flushMicrotasksAsync();
     });
-    expect(refreshAllAsync).toHaveBeenCalledTimes(2);
-    expect(refreshAllAsync).toHaveBeenLastCalledWith({ keepLog: false, debounceMs: 180 });
+    expect(refreshStatusAsync).toHaveBeenCalledTimes(1);
+    expect(refreshStatusAsync).toHaveBeenLastCalledWith({ debounceMs: 180 });
+    expect(refreshAllAsync).not.toHaveBeenCalled();
 
     await act(async () => {
       hostApis.emitRepoWatch({ repoRoot: "/repo-b" });
       await flushMicrotasksAsync();
     });
-    expect(refreshAllAsync).toHaveBeenCalledTimes(2);
+    expect(refreshAllAsync).not.toHaveBeenCalled();
+    expect(refreshRefsAsync).toHaveBeenCalledTimes(1);
   });
 
   it("worktrees 元数据事件应只刷新 worktree 列表，不触发整仓刷新", async () => {
@@ -195,7 +206,81 @@ describe("useGitAutoRefresh", () => {
     expect(refreshWorktreesAsync).toHaveBeenLastCalledWith({ debounceMs: 80 });
   });
 
-  it("切仓与卸载时应清理旧订阅，并把活跃 roots 回收为空集", async () => {
+  it("状态类事件应只刷新 status", async () => {
+    const hostApis = createHostApis();
+    const refreshAllAsync = vi.fn(async (_options?: { keepLog?: boolean; debounceMs?: number }) => {});
+    const refreshStatusAsync = vi.fn(async (_options?: { debounceMs?: number }) => {});
+    Object.defineProperty(window, "host", {
+      configurable: true,
+      writable: true,
+      value: {
+        fileIndex: hostApis.fileIndex,
+        gitRepoWatch: hostApis.gitRepoWatch,
+      },
+    });
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(React.createElement(TestHarness, {
+        active: true,
+        repoRoot: "/repo-a",
+        refreshAllAsync,
+        refreshStatusAsync,
+      }));
+      await flushMicrotasksAsync();
+    });
+
+    await act(async () => {
+      hostApis.emitRepoWatch({ repoRoot: "/repo-a", reason: "index", paths: ["/repo-a/.git/index"] });
+      await flushMicrotasksAsync();
+    });
+
+    expect(refreshStatusAsync).toHaveBeenCalledTimes(1);
+    expect(refreshStatusAsync).toHaveBeenLastCalledWith({ debounceMs: 80 });
+    expect(refreshAllAsync).not.toHaveBeenCalled();
+  });
+
+  it("引用类事件应只刷新 refs", async () => {
+    const hostApis = createHostApis();
+    const refreshAllAsync = vi.fn(async (_options?: { keepLog?: boolean; debounceMs?: number }) => {});
+    const refreshRefsAsync = vi.fn(async (_options?: { debounceMs?: number }) => {});
+    Object.defineProperty(window, "host", {
+      configurable: true,
+      writable: true,
+      value: {
+        fileIndex: hostApis.fileIndex,
+        gitRepoWatch: hostApis.gitRepoWatch,
+      },
+    });
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(React.createElement(TestHarness, {
+        active: true,
+        repoRoot: "/repo-a",
+        refreshAllAsync,
+        refreshRefsAsync,
+      }));
+      await flushMicrotasksAsync();
+    });
+
+    await act(async () => {
+      hostApis.emitRepoWatch({ repoRoot: "/repo-a", reason: "head", paths: ["/repo-a/.git/HEAD"] });
+      await flushMicrotasksAsync();
+    });
+
+    expect(refreshRefsAsync).toHaveBeenCalledTimes(1);
+    expect(refreshRefsAsync).toHaveBeenLastCalledWith({ debounceMs: 80 });
+    expect(refreshAllAsync).not.toHaveBeenCalled();
+  });
+
+  it("切仓与卸载时应从窗口级 watcher 聚合中移除旧 roots", async () => {
     const hostApis = createHostApis();
     const refreshAllAsync = vi.fn(async (_options?: { keepLog?: boolean; debounceMs?: number }) => {});
     Object.defineProperty(window, "host", {
@@ -230,11 +315,9 @@ describe("useGitAutoRefresh", () => {
     });
 
     expect(hostApis.fileIndex.setActiveRoots).toHaveBeenNthCalledWith(1, ["/repo-a"]);
-    expect(hostApis.fileIndex.setActiveRoots).toHaveBeenNthCalledWith(2, []);
-    expect(hostApis.fileIndex.setActiveRoots).toHaveBeenNthCalledWith(3, ["/repo-b"]);
+    expect(hostApis.fileIndex.setActiveRoots).toHaveBeenNthCalledWith(2, ["/repo-b"]);
     expect(hostApis.gitRepoWatch.setActiveRoots).toHaveBeenNthCalledWith(1, ["/repo-a"]);
-    expect(hostApis.gitRepoWatch.setActiveRoots).toHaveBeenNthCalledWith(2, []);
-    expect(hostApis.gitRepoWatch.setActiveRoots).toHaveBeenNthCalledWith(3, ["/repo-b"]);
+    expect(hostApis.gitRepoWatch.setActiveRoots).toHaveBeenNthCalledWith(2, ["/repo-b"]);
 
     await act(async () => {
       hostApis.emitFileIndex({ root: "/repo-a" });
@@ -295,6 +378,132 @@ describe("useGitAutoRefresh", () => {
     });
 
     expect(refreshAllAsync).toHaveBeenCalledWith({ keepLog: false, debounceMs: 80 });
+  });
+
+  it("同窗口多个 Git 工作台应聚合 watcher roots，避免互相覆盖", async () => {
+    const hostApis = createHostApis();
+    const refreshAllAsync = vi.fn(async (_options?: { keepLog?: boolean; debounceMs?: number }) => {});
+    Object.defineProperty(window, "host", {
+      configurable: true,
+      writable: true,
+      value: {
+        fileIndex: hostApis.fileIndex,
+        gitRepoWatch: hostApis.gitRepoWatch,
+      },
+    });
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(React.createElement(React.Fragment, null,
+        React.createElement(TestHarness, {
+          active: true,
+          repoRoot: "/repo-a",
+          refreshAllAsync,
+        }),
+        React.createElement(TestHarness, {
+          active: false,
+          repoRoot: "/repo-b",
+          refreshAllAsync,
+        }),
+      ));
+      await flushMicrotasksAsync();
+    });
+
+    expect(hostApis.fileIndex.setActiveRoots).toHaveBeenLastCalledWith(["/repo-a", "/repo-b"]);
+    expect(hostApis.gitRepoWatch.setActiveRoots).toHaveBeenLastCalledWith(["/repo-a", "/repo-b"]);
+    expect(hostApis.fileIndexListeners.size).toBe(2);
+    expect(hostApis.repoWatchListeners.size).toBe(2);
+  });
+
+  it("inactive 热 watcher roots 到期后应自动释放", async () => {
+    vi.useFakeTimers();
+    const hostApis = createHostApis();
+    const refreshAllAsync = vi.fn(async (_options?: { keepLog?: boolean; debounceMs?: number }) => {});
+    Object.defineProperty(window, "host", {
+      configurable: true,
+      writable: true,
+      value: {
+        fileIndex: hostApis.fileIndex,
+        gitRepoWatch: hostApis.gitRepoWatch,
+      },
+    });
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(React.createElement(TestHarness, {
+        active: false,
+        repoRoot: "/repo-a",
+        refreshAllAsync,
+      }));
+      await flushMicrotasksAsync();
+    });
+
+    expect(hostApis.fileIndex.setActiveRoots).toHaveBeenLastCalledWith(["/repo-a"]);
+    expect(hostApis.gitRepoWatch.setActiveRoots).toHaveBeenLastCalledWith(["/repo-a"]);
+
+    await act(async () => {
+      vi.advanceTimersByTime((2 * 60 + 5) * 60 * 1000 + 1);
+      await flushMicrotasksAsync();
+    });
+
+    expect(hostApis.fileIndex.setActiveRoots).toHaveBeenLastCalledWith([]);
+    expect(hostApis.gitRepoWatch.setActiveRoots).toHaveBeenLastCalledWith([]);
+  });
+
+  it("失活期间的 watcher 事件只记录脏类型，重新激活后再按粒度刷新", async () => {
+    const hostApis = createHostApis();
+    const refreshAllAsync = vi.fn(async (_options?: { keepLog?: boolean; debounceMs?: number }) => {});
+    const refreshStatusAsync = vi.fn(async (_options?: { debounceMs?: number }) => {});
+    Object.defineProperty(window, "host", {
+      configurable: true,
+      writable: true,
+      value: {
+        fileIndex: hostApis.fileIndex,
+        gitRepoWatch: hostApis.gitRepoWatch,
+      },
+    });
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(React.createElement(TestHarness, {
+        active: false,
+        repoRoot: "/repo-a",
+        refreshAllAsync,
+        refreshStatusAsync,
+      }));
+      await flushMicrotasksAsync();
+    });
+
+    await act(async () => {
+      hostApis.emitFileIndex({ root: "/repo-a" });
+      await flushMicrotasksAsync();
+    });
+
+    expect(refreshStatusAsync).not.toHaveBeenCalled();
+    expect(refreshAllAsync).not.toHaveBeenCalled();
+
+    await act(async () => {
+      root!.render(React.createElement(TestHarness, {
+        active: true,
+        repoRoot: "/repo-a",
+        refreshAllAsync,
+        refreshStatusAsync,
+      }));
+      await flushMicrotasksAsync();
+    });
+
+    expect(refreshStatusAsync).toHaveBeenCalledTimes(1);
+    expect(refreshStatusAsync).toHaveBeenLastCalledWith({ debounceMs: 180 });
+    expect(refreshAllAsync).not.toHaveBeenCalled();
   });
 
   it("刷新中的 index 元数据事件应视为自噪音，不能继续触发无限回刷", async () => {

--- a/web/src/features/git/use-git-auto-refresh.ts
+++ b/web/src/features/git/use-git-auto-refresh.ts
@@ -9,12 +9,20 @@ type UseGitAutoRefreshArgs = {
   repoRoot: string;
   repoRoots?: string[];
   refreshAllAsync: (options?: { keepLog?: boolean; debounceMs?: number }) => Promise<void>;
+  refreshStatusAsync?: (options?: { debounceMs?: number }) => Promise<void>;
+  refreshRefsAsync?: (options?: { debounceMs?: number }) => Promise<void>;
   refreshWorktreesAsync?: (options?: { debounceMs?: number }) => Promise<void>;
 };
 
 const GIT_AUTO_REFRESH_SELF_NOISE_COOLDOWN_MS = 2000;
 
-type GitAutoRefreshKind = "full" | "worktrees";
+type GitAutoRefreshKind = "full" | "status" | "refs" | "worktrees";
+
+type GitAutoRefreshRootRegistration = {
+  roots: string[];
+  active: boolean;
+  lastAccessedAt: number;
+};
 
 type GitAutoRefreshState = {
   runningKind: GitAutoRefreshKind | null;
@@ -22,7 +30,127 @@ type GitAutoRefreshState = {
   pendingKind: GitAutoRefreshKind | null;
   pendingDebounceMs: number;
   pendingTimerId: number | null;
+  inactiveDirtyKind: GitAutoRefreshKind | null;
+  inactiveDirtyDebounceMs: number;
 };
+
+const GIT_AUTO_REFRESH_HOT_ROOT_MAX_ENTRIES = 3;
+const GIT_AUTO_REFRESH_HOT_ROOT_IDLE_TTL_MS = 2 * 60 * 60 * 1000;
+const GIT_AUTO_REFRESH_HOT_ROOT_TRIM_INTERVAL_MS = 5 * 60 * 1000;
+let gitAutoRefreshRegistrationSeq = 0;
+let lastPublishedGitAutoRefreshRootsKey = "";
+let gitAutoRefreshRootTrimTimerId: number | null = null;
+const gitAutoRefreshRootRegistrations = new Map<number, GitAutoRefreshRootRegistration>();
+
+/**
+ * 规范化 watcher 根路径，保持同一窗口内多 Git 工作台聚合时可稳定去重。
+ */
+function normalizeGitAutoRefreshRoot(root: string): string {
+  return String(root || "").trim();
+}
+
+/**
+ * 生成 Git watcher roots 的稳定 key，避免相同集合反复下发给主进程。
+ */
+function buildGitAutoRefreshRootsKey(roots: string[]): string {
+  return roots.join("\n");
+}
+
+/**
+ * 清理超过热保活预算的 inactive Git watcher roots。
+ */
+function trimGitAutoRefreshRootRegistrations(now: number = Date.now()): void {
+  for (const [id, registration] of Array.from(gitAutoRefreshRootRegistrations.entries())) {
+    if (registration.active) continue;
+    if (now - registration.lastAccessedAt > GIT_AUTO_REFRESH_HOT_ROOT_IDLE_TTL_MS)
+      gitAutoRefreshRootRegistrations.delete(id);
+  }
+}
+
+/**
+ * 计算当前窗口应交给主进程保活的 watcher roots；active roots 不限量，inactive roots 只保留最近几个仓库。
+ */
+function collectGitAutoRefreshPublishedRoots(now: number = Date.now()): string[] {
+  trimGitAutoRefreshRootRegistrations(now);
+  const activeRoots: string[] = [];
+  const activeRootSet = new Set<string>();
+  for (const registration of gitAutoRefreshRootRegistrations.values()) {
+    if (!registration.active) continue;
+    for (const root of registration.roots) {
+      if (activeRootSet.has(root)) continue;
+      activeRootSet.add(root);
+      activeRoots.push(root);
+    }
+  }
+
+  const hotRoots: string[] = [];
+  const hotRootSet = new Set<string>();
+  const inactiveRegistrations = Array.from(gitAutoRefreshRootRegistrations.values())
+    .filter((registration) => !registration.active)
+    .sort((a, b) => b.lastAccessedAt - a.lastAccessedAt);
+  for (const registration of inactiveRegistrations) {
+    for (const root of registration.roots) {
+      if (activeRootSet.has(root) || hotRootSet.has(root)) continue;
+      hotRootSet.add(root);
+      hotRoots.push(root);
+      if (hotRoots.length >= GIT_AUTO_REFRESH_HOT_ROOT_MAX_ENTRIES) break;
+    }
+    if (hotRoots.length >= GIT_AUTO_REFRESH_HOT_ROOT_MAX_ENTRIES) break;
+  }
+
+  return [...activeRoots, ...hotRoots];
+}
+
+/**
+ * 把窗口内所有 Git 工作台 roots 聚合后统一下发，避免多个 tab 互相覆盖主进程 watcher roots。
+ */
+function publishGitAutoRefreshRoots(): void {
+  const roots = collectGitAutoRefreshPublishedRoots();
+  const rootsKey = buildGitAutoRefreshRootsKey(roots);
+  if (rootsKey === lastPublishedGitAutoRefreshRootsKey) return;
+  lastPublishedGitAutoRefreshRootsKey = rootsKey;
+  void window.host.fileIndex?.setActiveRoots?.(roots);
+  void window.host.gitRepoWatch?.setActiveRoots?.(roots);
+}
+
+/**
+ * 启动窗口级 watcher roots 定时收敛，确保 inactive 热保活到期后主动释放主进程 watcher。
+ */
+function ensureGitAutoRefreshRootTrimTimer(): void {
+  if (gitAutoRefreshRootTrimTimerId != null) return;
+  gitAutoRefreshRootTrimTimerId = window.setInterval(() => {
+    publishGitAutoRefreshRoots();
+    if (gitAutoRefreshRootRegistrations.size > 0) return;
+    if (gitAutoRefreshRootTrimTimerId != null)
+      window.clearInterval(gitAutoRefreshRootTrimTimerId);
+    gitAutoRefreshRootTrimTimerId = null;
+  }, GIT_AUTO_REFRESH_HOT_ROOT_TRIM_INTERVAL_MS);
+}
+
+/**
+ * 更新当前工作台在窗口级 watcher registry 中的 roots 与活跃状态。
+ */
+function upsertGitAutoRefreshRootRegistration(id: number, roots: string[], active: boolean): void {
+  const now = Date.now();
+  gitAutoRefreshRootRegistrations.set(id, {
+    roots,
+    active,
+    lastAccessedAt: now,
+  });
+  ensureGitAutoRefreshRootTrimTimer();
+  publishGitAutoRefreshRoots();
+}
+
+/**
+ * 移除当前工作台的 watcher roots，并刷新窗口级 roots 聚合。
+ */
+function deleteGitAutoRefreshRootRegistration(id: number): void {
+  gitAutoRefreshRootRegistrations.delete(id);
+  publishGitAutoRefreshRoots();
+  if (gitAutoRefreshRootRegistrations.size > 0 || gitAutoRefreshRootTrimTimerId == null) return;
+  window.clearInterval(gitAutoRefreshRootTrimTimerId);
+  gitAutoRefreshRootTrimTimerId = null;
+}
 
 /**
  * 合并待执行刷新类型；只要任一请求需要整仓刷新，就以整仓刷新为准。
@@ -31,16 +159,37 @@ function mergeRefreshKind(
   currentKind: GitAutoRefreshKind | null,
   nextKind: GitAutoRefreshKind,
 ): GitAutoRefreshKind {
+  if (!currentKind || currentKind === nextKind) return currentKind || nextKind;
   if (currentKind === "full" || nextKind === "full") return "full";
-  return currentKind || nextKind;
+  return "full";
 }
 
 /**
  * 在 Git 面板激活时接入工作区文件 watcher 与 `.git` 元数据 watcher，
- * 所有外部变化都统一回落到既有 `refreshAllAsync()` 串行刷新链路。
+ * 并按 watcher 脏类型分派到状态、引用、worktree 或兜底全量刷新链路。
  */
 export function useGitAutoRefresh(args: UseGitAutoRefreshArgs): void {
+  const registrationIdRef = useRef<number>(0);
+  const rootsKeyRef = useRef<string>("");
+  if (registrationIdRef.current <= 0) {
+    gitAutoRefreshRegistrationSeq += 1;
+    registrationIdRef.current = gitAutoRefreshRegistrationSeq;
+  }
   const refreshRunner = useLatestAsyncRunner(args.refreshAllAsync);
+  const refreshStatusRunner = useLatestAsyncRunner(async (options?: { debounceMs?: number }) => {
+    if (args.refreshStatusAsync) {
+      await args.refreshStatusAsync(options);
+      return;
+    }
+    await args.refreshAllAsync({ keepLog: true, debounceMs: options?.debounceMs });
+  });
+  const refreshRefsRunner = useLatestAsyncRunner(async (options?: { debounceMs?: number }) => {
+    if (args.refreshRefsAsync) {
+      await args.refreshRefsAsync(options);
+      return;
+    }
+    await args.refreshAllAsync({ keepLog: false, debounceMs: options?.debounceMs });
+  });
   const refreshWorktreesRunner = useLatestAsyncRunner(async (options?: { debounceMs?: number }) => {
     if (args.refreshWorktreesAsync) {
       await args.refreshWorktreesAsync(options);
@@ -54,20 +203,30 @@ export function useGitAutoRefresh(args: UseGitAutoRefreshArgs): void {
     pendingKind: null,
     pendingDebounceMs: 0,
     pendingTimerId: null,
+    inactiveDirtyKind: null,
+    inactiveDirtyDebounceMs: 0,
   });
 
   useEffect(() => {
-    const fileIndexApi = window.host.fileIndex;
-    const repoWatchApi = window.host.gitRepoWatch;
-    const roots = args.active
-      ? Array.from(new Set(
-          [args.repoRoot, ...(args.repoRoots || [])]
-            .map((root) => String(root || "").trim())
-            .filter(Boolean),
-        ))
-      : [];
+    return () => {
+      deleteGitAutoRefreshRootRegistration(registrationIdRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    const roots = Array.from(new Set(
+      [args.repoRoot, ...(args.repoRoots || [])]
+        .map(normalizeGitAutoRefreshRoot)
+        .filter(Boolean),
+    ));
+    const rootsKey = buildGitAutoRefreshRootsKey(roots);
     const activeRootSet = new Set(roots);
     const refreshState = refreshStateRef.current;
+    if (rootsKeyRef.current !== rootsKey) {
+      rootsKeyRef.current = rootsKey;
+      refreshState.inactiveDirtyKind = null;
+      refreshState.inactiveDirtyDebounceMs = 0;
+    }
 
     /**
      * 清理延后自动刷新定时器，避免切仓或卸载后继续回刷旧仓库。
@@ -125,6 +284,10 @@ export function useGitAutoRefresh(args: UseGitAutoRefreshArgs): void {
       try {
         if (kind === "worktrees")
           await refreshWorktreesRunner({ debounceMs });
+        else if (kind === "status")
+          await refreshStatusRunner({ debounceMs });
+        else if (kind === "refs")
+          await refreshRefsRunner({ debounceMs });
         else
           await refreshRunner({ keepLog: false, debounceMs });
       } finally {
@@ -138,11 +301,28 @@ export function useGitAutoRefresh(args: UseGitAutoRefreshArgs): void {
     /**
      * 根据 watcher 来源与原因决定刷新粒度。
      * - `worktrees` 保持与参考实现一致的 `workingTreeHolder.scheduleReload()` 语义，仅刷新 worktree 列表；
-     * - 其它事件继续走整仓刷新链路。
+     * - `index`/工作区文件变化只刷新本地状态；
+     * - `HEAD`/refs/操作状态变化刷新分支与日志；
+     * - 未知事件继续走整仓刷新链路。
      */
     const resolveRefreshKind = (source: "fileIndex" | "repoWatch", reason?: string): GitAutoRefreshKind => {
+      if (source === "fileIndex")
+        return args.refreshStatusAsync ? "status" : "full";
+      const normalizedReason = String(reason || "").trim();
       if (source === "repoWatch" && String(reason || "").trim() === "worktrees" && args.refreshWorktreesAsync)
         return "worktrees";
+      if ((normalizedReason === "index" || normalizedReason === "exclude") && args.refreshStatusAsync)
+        return "status";
+      if (
+        (normalizedReason === "head"
+          || normalizedReason === "refs"
+          || normalizedReason === "rebase"
+          || normalizedReason === "merge"
+          || normalizedReason === "cherry-pick"
+          || normalizedReason === "revert")
+        && args.refreshRefsAsync
+      )
+        return "refs";
       return "full";
     };
 
@@ -153,6 +333,12 @@ export function useGitAutoRefresh(args: UseGitAutoRefreshArgs): void {
       const changedRoot = String(payloadRoot || "").trim();
       if (!changedRoot || !activeRootSet.has(changedRoot)) return;
       const nextKind = resolveRefreshKind(source, reason);
+      if (!args.active) {
+        refreshState.inactiveDirtyKind = mergeRefreshKind(refreshState.inactiveDirtyKind, nextKind);
+        refreshState.inactiveDirtyDebounceMs = Math.max(refreshState.inactiveDirtyDebounceMs, debounceMs);
+        upsertGitAutoRefreshRootRegistration(registrationIdRef.current, roots, false);
+        return;
+      }
       const inSuppressedWindow = !!refreshState.runningKind || Date.now() < refreshState.suppressedUntil;
       const normalizedReason = String(reason || "").trim();
       if (inSuppressedWindow && source === "repoWatch" && normalizedReason === "index")
@@ -165,27 +351,34 @@ export function useGitAutoRefresh(args: UseGitAutoRefreshArgs): void {
       void runRefreshAsync(nextKind, debounceMs);
     };
 
-    void fileIndexApi?.setActiveRoots?.(roots);
-    void repoWatchApi?.setActiveRoots?.(roots);
-
     if (roots.length <= 0) {
+      deleteGitAutoRefreshRootRegistration(registrationIdRef.current);
       return () => {
         clearPendingTimer();
         refreshState.runningKind = null;
         refreshState.suppressedUntil = 0;
         refreshState.pendingKind = null;
         refreshState.pendingDebounceMs = 0;
-        void fileIndexApi?.setActiveRoots?.([]);
-        void repoWatchApi?.setActiveRoots?.([]);
+        refreshState.inactiveDirtyKind = null;
+        refreshState.inactiveDirtyDebounceMs = 0;
       };
     }
 
-    const unsubscribeFileIndex = fileIndexApi?.onChanged?.((payload) => {
+    upsertGitAutoRefreshRootRegistration(registrationIdRef.current, roots, args.active);
+
+    const unsubscribeFileIndex = window.host.fileIndex?.onChanged?.((payload) => {
       triggerRefresh(payload?.root, 180, "fileIndex", payload?.reason);
     });
-    const unsubscribeRepoWatch = repoWatchApi?.onChanged?.((payload) => {
+    const unsubscribeRepoWatch = window.host.gitRepoWatch?.onChanged?.((payload) => {
       triggerRefresh(payload?.repoRoot, 80, "repoWatch", payload?.reason);
     });
+    if (args.active && refreshState.inactiveDirtyKind) {
+      const dirtyKind = refreshState.inactiveDirtyKind;
+      const debounceMs = refreshState.inactiveDirtyDebounceMs || 80;
+      refreshState.inactiveDirtyKind = null;
+      refreshState.inactiveDirtyDebounceMs = 0;
+      void runRefreshAsync(dirtyKind, debounceMs);
+    }
 
     return () => {
       try { unsubscribeFileIndex?.(); } catch {}
@@ -195,8 +388,17 @@ export function useGitAutoRefresh(args: UseGitAutoRefreshArgs): void {
       refreshState.suppressedUntil = 0;
       refreshState.pendingKind = null;
       refreshState.pendingDebounceMs = 0;
-      void fileIndexApi?.setActiveRoots?.([]);
-      void repoWatchApi?.setActiveRoots?.([]);
     };
-  }, [args.active, args.refreshWorktreesAsync, args.repoRoot, args.repoRoots, refreshRunner, refreshWorktreesRunner]);
+  }, [
+    args.active,
+    args.refreshRefsAsync,
+    args.refreshStatusAsync,
+    args.refreshWorktreesAsync,
+    args.repoRoot,
+    args.repoRoots,
+    refreshRefsRunner,
+    refreshRunner,
+    refreshStatusRunner,
+    refreshWorktreesRunner,
+  ]);
 }

--- a/web/src/locales/en/git.json
+++ b/web/src/locales/en/git.json
@@ -1443,6 +1443,7 @@
       "status": {
         "ready": "Ready",
         "busy": "Working on {{activity}}",
+        "detecting": "Detecting Git repository...",
         "noRepo": "No Git repository detected"
       },
       "actionUnsupported": "Action not supported: {{label}}",

--- a/web/src/locales/zh/git.json
+++ b/web/src/locales/zh/git.json
@@ -1443,6 +1443,7 @@
       "status": {
         "ready": "就绪",
         "busy": "正在{{activity}}",
+        "detecting": "正在检测 Git 仓库...",
         "noRepo": "未检测到 Git 仓库"
       },
       "actionUnsupported": "不支持的操作：{{label}}",

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -668,6 +668,14 @@ export interface GitFeatureAPI {
 }
 
 export interface GitWorkbenchAPI {
+  snapshot?: {
+    /** 读取同一主进程生命周期内的 Git 工作台热会话快照。 */
+    get(args: { tabId: string; repoRoot?: string }): Promise<{ ok: boolean; snapshot?: any | null; repoRoot?: string; updatedAt?: number; error?: string }>;
+    /** 写入 Git 工作台热会话快照；仅用于小型结构化状态，不持久化大 diff。 */
+    put(args: { tabId: string; repoRoot: string; snapshot: any }): Promise<{ ok: boolean; updatedAt?: number; count?: number; error?: string }>;
+    /** 删除指定 Git 工作台热会话快照。 */
+    delete(args: { tabId: string; repoRoot: string }): Promise<{ ok: boolean; deleted?: boolean; error?: string }>;
+  };
   /**
    * 请求宿主打开 GitWorkbench；可按公共 actionId 触发提交、提交并推送、拉取、获取、推送、更新项目、冲突解决、搁置等入口。
    */


### PR DESCRIPTION
新增 Git 工作台内存热会话快照，用于标签切换、拖出独立窗口和渲染恢复时快速复用状态，减少打开 Git 标签时的空白与重复首刷。 调整 Git 工作台自动刷新链路，将文件索引、仓库元数据、引用与 worktree 变化拆分为状态、引用、worktree 或全量刷新，并聚合同窗口多个工作台的 watcher roots，避免互相覆盖。 补充工作台首帧仓库探测状态、Git 模块预加载，以及自动刷新与首刷控制的单元测试和 i18n 文案。