### PR TITLE
fix(codex): 放宽自动 continue 尝试次数

### DIFF
--- a/electron/settings.ts
+++ b/electron/settings.ts
@@ -244,7 +244,7 @@ const DEFAULT_CODEX_ERROR_HANDLING: Required<CodexErrorHandlingSettings> = {
   autoContinueErrorKinds: ['networkStream', 'rateLimited', 'concurrency', 'modelCapacity', 'badGateway', 'serviceUnavailable', 'highDemand', 'forbidden', 'badRequest'],
   autoContinueErrorKindsVersion: 3,
   autoContinueDelaySeconds: 30,
-  autoContinueMaxAttempts: 2,
+  autoContinueMaxAttempts: 5,
 };
 const CODEX_AUTO_CONTINUE_ERROR_KINDS: Required<CodexErrorHandlingSettings>['autoContinueErrorKinds'] = [
   ...DEFAULT_CODEX_ERROR_HANDLING.autoContinueErrorKinds,
@@ -377,13 +377,14 @@ function normalizeTerminalTheme(raw: unknown): TerminalThemeId {
 }
 
 /**
- * 将输入值归一化为指定范围内的整数。
+ * 将输入值归一化为指定下限和可选上限内的整数。
  */
-function normalizeBoundedInteger(raw: unknown, fallback: number, min: number, max: number): number {
+function normalizeBoundedInteger(raw: unknown, fallback: number, min: number, max?: number): number {
   const numeric = Number(raw);
   if (!Number.isFinite(numeric)) return fallback;
   const rounded = Math.round(numeric);
-  return Math.min(max, Math.max(min, rounded));
+  const lowerBounded = Math.max(min, rounded);
+  return typeof max === 'number' ? Math.min(max, lowerBounded) : lowerBounded;
 }
 
 /**
@@ -452,7 +453,7 @@ function normalizeCodexErrorHandlingSettings(raw: unknown): CodexErrorHandlingSe
       autoContinueErrorKinds: normalizeCodexAutoContinueErrorKinds(obj.autoContinueErrorKinds, autoContinueErrorKindsVersion),
       autoContinueErrorKindsVersion: CODEX_AUTO_CONTINUE_ERROR_KINDS_VERSION,
       autoContinueDelaySeconds: normalizeBoundedInteger(obj.autoContinueDelaySeconds, DEFAULT_CODEX_ERROR_HANDLING.autoContinueDelaySeconds, 5, 600),
-      autoContinueMaxAttempts: normalizeBoundedInteger(obj.autoContinueMaxAttempts, DEFAULT_CODEX_ERROR_HANDLING.autoContinueMaxAttempts, 0, 10),
+      autoContinueMaxAttempts: normalizeBoundedInteger(obj.autoContinueMaxAttempts, DEFAULT_CODEX_ERROR_HANDLING.autoContinueMaxAttempts, 0),
     };
   } catch {
     return { ...DEFAULT_CODEX_ERROR_HANDLING };

--- a/web/src/features/settings/settings-dialog.tsx
+++ b/web/src/features/settings/settings-dialog.tsx
@@ -67,7 +67,6 @@ import type { TerminalThemeId } from "@/types/terminal-theme";
 import type { AppSettings, ProviderEnv, ProviderItem } from "@/types/host";
 import {
   CODEX_AUTO_CONTINUE_ERROR_KINDS,
-  CODEX_ERROR_AUTO_CONTINUE_ATTEMPTS_MAX,
   CODEX_ERROR_AUTO_CONTINUE_ATTEMPTS_MIN,
   CODEX_ERROR_AUTO_CONTINUE_DELAY_MAX_SECONDS,
   CODEX_ERROR_AUTO_CONTINUE_DELAY_MIN_SECONDS,
@@ -1718,7 +1717,6 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                             id="codex-error-auto-continue-attempts"
                             type="number"
                             min={CODEX_ERROR_AUTO_CONTINUE_ATTEMPTS_MIN}
-                            max={CODEX_ERROR_AUTO_CONTINUE_ATTEMPTS_MAX}
                             step={1}
                             value={codexErrorHandling.autoContinueMaxAttempts}
                             onChange={(event) => {

--- a/web/src/lib/codex-error-handling-settings.test.ts
+++ b/web/src/lib/codex-error-handling-settings.test.ts
@@ -7,6 +7,16 @@ import {
 } from "./codex-error-handling-settings";
 
 describe("codex-error-handling-settings（Codex 错误处理设置）", () => {
+  it("自动 continue 最大尝试次数默认 5 次且不设置上限", () => {
+    expect(normalizeCodexErrorHandlingPrefs({}).autoContinueMaxAttempts).toBe(5);
+    expect(normalizeCodexErrorHandlingPrefs({ autoContinueMaxAttempts: 30 }).autoContinueMaxAttempts).toBe(30);
+  });
+
+  it("自动 continue 最大尝试次数只保留非负整数下限", () => {
+    expect(normalizeCodexErrorHandlingPrefs({ autoContinueMaxAttempts: -1 }).autoContinueMaxAttempts).toBe(0);
+    expect(normalizeCodexErrorHandlingPrefs({ autoContinueMaxAttempts: 3.6 }).autoContinueMaxAttempts).toBe(4);
+  });
+
   it("重连中错误通知默认关闭且可显式开启", () => {
     expect(normalizeCodexErrorHandlingPrefs({}).notifyReconnectErrors).toBe(false);
     expect(normalizeCodexErrorHandlingPrefs({ notifyReconnectErrors: true }).notifyReconnectErrors).toBe(true);

--- a/web/src/lib/codex-error-handling-settings.ts
+++ b/web/src/lib/codex-error-handling-settings.ts
@@ -18,7 +18,6 @@ export type CodexErrorHandlingPrefs = {
 export const CODEX_ERROR_AUTO_CONTINUE_DELAY_MIN_SECONDS = 5;
 export const CODEX_ERROR_AUTO_CONTINUE_DELAY_MAX_SECONDS = 600;
 export const CODEX_ERROR_AUTO_CONTINUE_ATTEMPTS_MIN = 0;
-export const CODEX_ERROR_AUTO_CONTINUE_ATTEMPTS_MAX = 10;
 export const CODEX_AUTO_CONTINUE_ERROR_KINDS_VERSION = 3;
 export const CODEX_AUTO_CONTINUE_ERROR_KINDS: CodexAutoContinueErrorKind[] = [
   "networkStream",
@@ -70,7 +69,7 @@ export const DEFAULT_CODEX_ERROR_HANDLING_PREFS: CodexErrorHandlingPrefs = {
   autoContinueErrorKinds: [...CODEX_DEFAULT_AUTO_CONTINUE_ERROR_KINDS],
   autoContinueErrorKindsVersion: CODEX_AUTO_CONTINUE_ERROR_KINDS_VERSION,
   autoContinueDelaySeconds: 30,
-  autoContinueMaxAttempts: 2,
+  autoContinueMaxAttempts: 5,
 };
 
 /**
@@ -82,13 +81,14 @@ export function isCodexAutoContinueErrorKind(kind: CodexCliErrorKind | undefined
 }
 
 /**
- * 将输入值归一化为指定区间内的整数。
+ * 将输入值归一化为指定下限和可选上限内的整数。
  */
-function normalizeBoundedInteger(value: unknown, fallback: number, min: number, max: number): number {
+function normalizeBoundedInteger(value: unknown, fallback: number, min: number, max?: number): number {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return fallback;
   const rounded = Math.round(numeric);
-  return Math.min(max, Math.max(min, rounded));
+  const lowerBounded = Math.max(min, rounded);
+  return typeof max === "number" ? Math.min(max, lowerBounded) : lowerBounded;
 }
 
 /**
@@ -159,7 +159,6 @@ export function normalizeCodexErrorHandlingPrefs(value: unknown): CodexErrorHand
       raw.autoContinueMaxAttempts,
       DEFAULT_CODEX_ERROR_HANDLING_PREFS.autoContinueMaxAttempts,
       CODEX_ERROR_AUTO_CONTINUE_ATTEMPTS_MIN,
-      CODEX_ERROR_AUTO_CONTINUE_ATTEMPTS_MAX,
     ),
   };
 }


### PR DESCRIPTION
将 Codex 错误自动 continue 的默认最大尝试次数从 2 次提升到 5 次，并移除 10 次上限，使长时间拥塞或服务端间歇性错误场景下的自动恢复更符合用户预期。

主进程与渲染进程的设置归一化逻辑同步改为仅保留非负整数下限，设置面板移除输入框的最大值限制，并补充单测覆盖默认值、无上限与下限归一化行为。