### PR TITLE
feat(worktree): 支持批量选择保留项

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -6403,20 +6403,21 @@ ipcMain.handle('app.getEnvMeta', async () => {
   }
 });
 
-// 打开选择目录对话并返回选中的 Windows 路径（若取消则返回 canceled）
-ipcMain.handle('utils.chooseFolder', async (_e, args?: { title?: string; defaultPath?: string }) => {
+// 打开选择目录对话并返回首个 Windows 路径与完整路径列表（若取消则返回 canceled）
+ipcMain.handle('utils.chooseFolder', async (_e, args?: { title?: string; defaultPath?: string; multiSelections?: boolean }) => {
   try {
     const win = BrowserWindow.getFocusedWindow();
     const title = String(args?.title || "").trim();
     const defaultPath = String(args?.defaultPath || "").trim();
+    const multiSelections = args?.multiSelections === true;
     const opts = {
-      properties: ['openDirectory'],
+      properties: ['openDirectory', ...(multiSelections ? ['multiSelections'] : [])],
       ...(title ? { title } : {}),
       ...(defaultPath ? { defaultPath } : {}),
     } as any;
     const ret = win ? await dialog.showOpenDialog(win, opts) : await dialog.showOpenDialog(opts);
     if (!ret || ret.canceled || !Array.isArray(ret.filePaths) || ret.filePaths.length === 0) return { ok: false, canceled: true };
-    return { ok: true, path: ret.filePaths[0] };
+    return { ok: true, path: ret.filePaths[0], paths: ret.filePaths };
   } catch (e: any) {
     return { ok: false, error: String(e) };
   }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -898,7 +898,7 @@ contextBridge.exposeInMainWorld('host', {
     , getHomeDir: async () => {
       return await ipcRenderer.invoke('utils.getHomeDir');
     }
-    , chooseFolder: async (args?: { title?: string; defaultPath?: string }) => {
+    , chooseFolder: async (args?: { title?: string; defaultPath?: string; multiSelections?: boolean }) => {
       return await ipcRenderer.invoke('utils.chooseFolder', args || {});
     }
     , chooseFiles: async (args?: { title?: string; defaultPath?: string; multiSelections?: boolean; filters?: Array<{ name: string; extensions: string[] }> }) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8444,23 +8444,47 @@ export default function CodexFlowManagerUI() {
     if (!project) return;
     try {
       const picked = kind === "folder"
-        ? await window.host.utils.chooseFolder({ title: t("projects:worktreePostSetupPickFolder", "选择要保留的文件夹") as string, defaultPath: project.winPath })
-        : await window.host.utils.chooseFiles({ title: t("projects:worktreePostSetupPickFile", "选择要保留的文件") as string, defaultPath: project.winPath, multiSelections: false });
+        ? await window.host.utils.chooseFolder({ title: t("projects:worktreePostSetupPickFolder", "选择要保留的文件夹") as string, defaultPath: project.winPath, multiSelections: true })
+        : await window.host.utils.chooseFiles({ title: t("projects:worktreePostSetupPickFile", "选择要保留的文件") as string, defaultPath: project.winPath, multiSelections: true });
       if (!picked || picked.canceled) return;
-      const rawPath = kind === "folder" ? String((picked as any).path || "") : String((picked as any).paths?.[0] || "");
-      const relativePath = toProjectRelativeWorktreePostSetupPath(project.winPath, rawPath);
-      if (!relativePath) {
+      const pickedPaths = (Array.isArray((picked as any).paths) ? (picked as any).paths : [(picked as any).path])
+        .map((item: any) => String(item || "").trim())
+        .filter(Boolean);
+      const relativePaths: string[] = [];
+      const seen = new Set<string>();
+      let outsidePath = "";
+      let blockedPath = "";
+      for (const rawPath of pickedPaths) {
+        const relativePath = toProjectRelativeWorktreePostSetupPath(project.winPath, rawPath);
+        if (!relativePath) {
+          outsidePath = rawPath;
+          break;
+        }
+        if (isBlockedWorktreePostSetupRelativePath(relativePath)) {
+          blockedPath = relativePath;
+          break;
+        }
+        const key = relativePath.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        relativePaths.push(relativePath);
+      }
+      if (outsidePath) {
         setWorktreePostSetupDialog((prev) => ({ ...prev, error: t("projects:worktreePostSetupOutsideProject", "只能选择当前项目目录内的文件或文件夹。") as string }));
         return;
       }
-      if (isBlockedWorktreePostSetupRelativePath(relativePath)) {
-        setWorktreePostSetupDialog((prev) => ({ ...prev, error: t("projects:worktreePostSetupBlockedPath", "该路径不适合复制：{path}", { path: relativePath }) as string }));
+      if (blockedPath) {
+        setWorktreePostSetupDialog((prev) => ({ ...prev, error: t("projects:worktreePostSetupBlockedPath", "该路径不适合复制：{path}", { path: blockedPath }) as string }));
+        return;
+      }
+      if (relativePaths.length <= 0) {
         return;
       }
       setWorktreePostSetupDialog((prev) => {
         const items = parseWorktreePostSetupItemsDraft(prev.itemsDraft);
-        const exists = items.some((item) => item.relativePath.toLowerCase() === relativePath.toLowerCase());
-        const nextLines = exists ? items.map((item) => item.relativePath) : [...items.map((item) => item.relativePath), relativePath];
+        const existingKeys = new Set(items.map((item) => item.relativePath.toLowerCase()));
+        const appendLines = relativePaths.filter((relativePath) => !existingKeys.has(relativePath.toLowerCase()));
+        const nextLines = [...items.map((item) => item.relativePath), ...appendLines];
         return { ...prev, itemsDraft: nextLines.join("\n"), error: undefined };
       });
     } catch (e: any) {

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -1073,7 +1073,11 @@ export interface UtilsAPI {
   pathExists(p: string, dirOnly?: boolean): Promise<{ ok: boolean; exists?: boolean; isDirectory?: boolean; isFile?: boolean; error?: string }>;
   /** 获取当前用户主目录路径（轻量）。 */
   getHomeDir(): Promise<{ ok: boolean; homeDir?: string; error?: string }>;
-  chooseFolder(args?: { title?: string; defaultPath?: string }): Promise<{ ok: boolean; path?: string; canceled?: boolean; error?: string }>;
+  chooseFolder(args?: {
+    title?: string;
+    defaultPath?: string;
+    multiSelections?: boolean;
+  }): Promise<{ ok: boolean; path?: string; paths?: string[]; canceled?: boolean; error?: string }>;
   chooseFiles(args?: {
     title?: string;
     defaultPath?: string;


### PR DESCRIPTION
从产品层面，这次改动优化了 worktree 创建后的保留设置体验：
用户在配置保留文件和文件夹时，可以一次选择多个目标，并且子 worktree 入口会回溯到管理父项目读取和保存配置，保证同一组 worktree 共用一份保留设置。

从技术层面：
- 扩展 utils.chooseFolder IPC，支持 multiSelections 并保留兼容的首个 path 返回值
- 后置设置对话框按管理父项目解析配置归属
- 文件和文件夹选择支持批量追加，并继续执行项目内路径校验、去重和危险路径拦截
- 同步 preload 暴露类型与渲染层 host 类型声明