### PR TITLE
perf(git): 优化工作台卡死防护

### DIFF
--- a/web/src/features/git/git-workbench.tsx
+++ b/web/src/features/git/git-workbench.tsx
@@ -987,6 +987,7 @@ const GIT_WORKBENCH_LOCAL_HOT_SESSION_IDLE_TTL_MS = 2 * 60 * 60 * 1000;
 const GIT_WORKBENCH_LOCAL_HOT_SESSION_MAX_KEYS = 8;
 const GIT_WORKBENCH_PUBLISH_SNAPSHOT_EVENT = "cf:git-workbench-publish-snapshot";
 const GIT_WORKBENCH_PUBLISH_SNAPSHOT_DONE_EVENT = "cf:git-workbench-publish-snapshot-done";
+const GIT_WORKBENCH_DRAG_WATCHDOG_MS = 30_000;
 const CONTEXT_MENU_SAFE_GAP = 6;
 const TREE_DEPTH_INDENT = 18;
 const DETAIL_TREE_BASE_PADDING = 12;
@@ -3394,6 +3395,8 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     startWidth: number;
   }>(null);
   const draggingLogColumnIdRef = useRef<GitLogColumnId | null>(null);
+  const dragBodyStyleRef = useRef<null | { userSelect: string; cursor: string; touchAction: string }>(null);
+  const dragWatchdogRef = useRef<number | null>(null);
   const previousCommitChangeGroupsRef = useRef<CommitPanelChangeEntryGroup[]>([]);
   const conflictMergeLoadSeqRef = useRef<number>(0);
   const updateInfoAutoOpenedRequestIdsRef = useRef<Set<number>>(new Set());
@@ -3604,6 +3607,50 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   const detailTreeSpeedSearchRootRef = useRef<HTMLDivElement>(null);
   const detailTreeContainerRef = useRef<HTMLDivElement>(null);
   const [activeSelectionScope, setActiveSelectionScope] = useState<"commit" | "detail" | null>(null);
+
+  /**
+   * 结束 Git 工作台内部拖拽，并恢复拖拽期间临时写入的页面级交互样式。
+   */
+  const endWorkbenchDragInteraction = useCallback((): void => {
+    draggingBottomRef.current = false;
+    draggingLayoutRef.current = null;
+    draggingLogColumnRef.current = null;
+    if (dragWatchdogRef.current !== null) {
+      window.clearTimeout(dragWatchdogRef.current);
+      dragWatchdogRef.current = null;
+    }
+    const prevStyle = dragBodyStyleRef.current;
+    dragBodyStyleRef.current = null;
+    if (prevStyle && typeof document !== "undefined") {
+      document.body.style.userSelect = prevStyle.userSelect;
+      document.body.style.cursor = prevStyle.cursor;
+      document.body.style.touchAction = prevStyle.touchAction;
+    }
+  }, []);
+
+  /**
+   * 开始 Git 工作台拖拽，统一屏蔽文本选择并安装超时兜底，避免丢失 mouseup 后卡住交互。
+   */
+  const beginWorkbenchDragInteraction = useCallback((cursor: "col-resize" | "row-resize"): void => {
+    endWorkbenchDragInteraction();
+    if (typeof document !== "undefined" && !dragBodyStyleRef.current) {
+      dragBodyStyleRef.current = {
+        userSelect: document.body.style.userSelect,
+        cursor: document.body.style.cursor,
+        touchAction: document.body.style.touchAction,
+      };
+    }
+    if (typeof document !== "undefined") {
+      document.body.style.userSelect = "none";
+      document.body.style.cursor = cursor;
+      document.body.style.touchAction = "none";
+    }
+    if (dragWatchdogRef.current !== null)
+      window.clearTimeout(dragWatchdogRef.current);
+    dragWatchdogRef.current = window.setTimeout(() => {
+      endWorkbenchDragInteraction();
+    }, GIT_WORKBENCH_DRAG_WATCHDOG_MS);
+  }, [endWorkbenchDragInteraction]);
 
   /**
    * 把热会话快照应用到当前工作台，只恢复可直接显示的小型状态。
@@ -15072,7 +15119,8 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
       setLogColumnLayout((prev) => resizeGitLogColumn(prev, draggingColumn.columnId, nextWidth));
     };
     const onUp = () => {
-      draggingLogColumnRef.current = null;
+      if (draggingLogColumnRef.current)
+        endWorkbenchDragInteraction();
     };
     window.addEventListener("mousemove", onMove);
     window.addEventListener("mouseup", onUp);
@@ -15080,7 +15128,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
     };
-  }, []);
+  }, [endWorkbenchDragInteraction]);
 
   /**
    * 处理所有分栏拖拽（上方左右、下方左右、底部高度）。
@@ -15160,8 +15208,8 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
       if (next > COLLAPSED_BOTTOM_HEIGHT + 4) setBottomCollapsed(false);
     };
     const onUp = () => {
-      draggingBottomRef.current = false;
-      draggingLayoutRef.current = null;
+      if (draggingBottomRef.current || draggingLayoutRef.current)
+        endWorkbenchDragInteraction();
     };
     window.addEventListener("mousemove", onMove);
     window.addEventListener("mouseup", onUp);
@@ -15169,7 +15217,41 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
     };
-  }, [branchPanelProportion, branchPanelWidth, detailPanelProportion, detailPanelWidth, leftCollapsed]);
+  }, [branchPanelProportion, branchPanelWidth, detailPanelProportion, detailPanelWidth, endWorkbenchDragInteraction, leftCollapsed]);
+
+  /**
+   * 拖拽中遇到窗口失焦、页面隐藏、右键菜单或指针取消时，主动释放交互状态。
+   */
+  useEffect(() => {
+    const release = () => {
+      endWorkbenchDragInteraction();
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== "visible") release();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") release();
+    };
+    window.addEventListener("blur", release);
+    window.addEventListener("mouseup", release, true);
+    window.addEventListener("pointerup", release, true);
+    window.addEventListener("pointercancel", release, true);
+    window.addEventListener("dragend", release, true);
+    window.addEventListener("contextmenu", release, true);
+    window.addEventListener("keydown", onKeyDown, true);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      window.removeEventListener("blur", release);
+      window.removeEventListener("mouseup", release, true);
+      window.removeEventListener("pointerup", release, true);
+      window.removeEventListener("pointercancel", release, true);
+      window.removeEventListener("dragend", release, true);
+      window.removeEventListener("contextmenu", release, true);
+      window.removeEventListener("keydown", onKeyDown, true);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      release();
+    };
+  }, [endWorkbenchDragInteraction]);
 
   /**
    * 渲染 Git 仓库缺失时的空状态，提供初始化与重新检测入口。
@@ -15903,6 +15985,8 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
           className="cf-git-bottom-handle group h-[3px] cursor-row-resize border-b border-[var(--cf-border)] bg-[var(--cf-surface-muted)]"
           onMouseDown={(event) => {
             if (event.button !== 0) return;
+            event.preventDefault();
+            beginWorkbenchDragInteraction("row-resize");
             draggingBottomRef.current = true;
           }}
           onDoubleClick={() => {
@@ -16350,6 +16434,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
                 onMouseDown={(event) => {
                   if (event.button !== 0) return;
                   event.preventDefault();
+                  beginWorkbenchDragInteraction("col-resize");
                   draggingLayoutRef.current = {
                     kind: "bottomLeft",
                     startX: event.clientX,
@@ -16679,6 +16764,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
                               onMouseDown={(event) => {
                                 event.preventDefault();
                                 event.stopPropagation();
+                                beginWorkbenchDragInteraction("col-resize");
                                 draggingLogColumnRef.current = {
                                   columnId,
                                   startX: event.clientX,
@@ -16776,6 +16862,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
                 onMouseDown={(event) => {
                   if (event.button !== 0) return;
                   event.preventDefault();
+                  beginWorkbenchDragInteraction("col-resize");
                   draggingLayoutRef.current = {
                     kind: "bottomRight",
                     startX: event.clientX,
@@ -20313,6 +20400,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
                 onMouseDown={(event) => {
                   if (event.button !== 0) return;
                   event.preventDefault();
+                  beginWorkbenchDragInteraction("col-resize");
                   draggingLayoutRef.current = {
                     kind: "main",
                     startX: event.clientX,

--- a/web/src/lib/monaco-workers.ts
+++ b/web/src/lib/monaco-workers.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+import CssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
+import HtmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
+import TypeScriptWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
+
+type MonacoWorkerEnvironment = {
+  getWorker(moduleId: string, label: string): Worker;
+};
+
+type MonacoWorkerGlobal = typeof globalThis & {
+  MonacoEnvironment?: MonacoWorkerEnvironment;
+};
+
+/**
+ * 根据 Monaco 的语言标签创建对应 worker，避免打包版退回主线程执行语言服务。
+ */
+function createMonacoWorker(label: string): Worker {
+  if (label === "json") return new JsonWorker();
+  if (label === "css" || label === "scss" || label === "less") return new CssWorker();
+  if (label === "html" || label === "handlebars" || label === "razor") return new HtmlWorker();
+  if (label === "typescript" || label === "javascript") return new TypeScriptWorker();
+  return new EditorWorker();
+}
+
+/**
+ * 安装 Monaco worker 工厂；Vite 会把 worker 输出为相对资源，适配 Electron file:// 打包路径。
+ */
+export function installMonacoWorkers(): void {
+  const target = globalThis as MonacoWorkerGlobal;
+  if (target.MonacoEnvironment?.getWorker) return;
+  target.MonacoEnvironment = {
+    getWorker(_moduleId: string, label: string): Worker {
+      return createMonacoWorker(label);
+    },
+  };
+}
+
+installMonacoWorkers();

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
+import '@/lib/monaco-workers';
 import App from './App';
 import { I18nextProvider } from 'react-i18next';
 import i18n, { initI18n } from '@/i18n/setup';

--- a/web/src/types/vite-worker.d.ts
+++ b/web/src/types/vite-worker.d.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+declare module "*?worker" {
+  const WorkerFactory: {
+    new (): Worker;
+  };
+  export default WorkerFactory;
+}


### PR DESCRIPTION
技术变更：
- 为 Git 工作台分栏与日志列宽拖拽增加统一释放入口，覆盖 mouseup、pointerup、窗口失焦、页面隐藏、右键菜单、Escape 与超时兜底，避免拖拽丢失释放事件后页面继续保持禁止选择或错误光标状态。
- 新拖拽开始前主动清理上一次可能残留的拖拽状态，避免旧拖拽状态继续驱动布局计算。
- 为 Monaco 显式注册 editor/json/css/html/typescript worker，让 Vite 打包后生成独立 worker 资源，避免语言服务退回主线程加重渲染负担。
- 增加 Vite worker import 类型声明，保证 TypeScript 能识别 `?worker` 导入。

产品影响：
- Git 工作台调整左右/底部面板和日志列宽时更不容易卡住。
- 打包版代码 diff 与编辑器语言服务在后台 worker 中运行，降低大文件或复杂语言服务导致界面卡顿的风险。