### PR TITLE
fix(worktree): 优化创建工作区进度显示

### DIFF
--- a/electron/git/worktreeCreateTasks.ts
+++ b/electron/git/worktreeCreateTasks.ts
@@ -21,6 +21,8 @@ export type WorktreeCreateTaskItemSnapshot = {
   wtBranch: string;
   index: number;
   status: WorktreeCreateTaskItemStatus;
+  /** 当前正在执行的阶段说明，用于让进度 UI 明确显示慢在哪一步。 */
+  detail?: string;
   updatedAt: number;
   error?: string;
   warnings?: string[];
@@ -204,6 +206,7 @@ export class WorktreeCreateTaskManager {
     wtBranch: string;
     index: number;
     status: WorktreeCreateTaskItemStatus;
+    detail?: string;
     error?: string;
     warnings?: string[];
   }): void {
@@ -223,6 +226,7 @@ export class WorktreeCreateTaskManager {
       wtBranch: String(args.wtBranch || "").trim(),
       index: Math.max(1, Math.floor(Number(args.index) || 1)),
       status: args.status,
+      detail: typeof args.detail === "string" ? String(args.detail || "").trim() || undefined : undefined,
       updatedAt,
       error: typeof args.error === "string" ? String(args.error || "").trim() || undefined : undefined,
       warnings: Array.isArray(args.warnings) ? args.warnings.map((item) => String(item || "").trim()).filter(Boolean) : undefined,
@@ -354,6 +358,17 @@ export class WorktreeCreateTaskManager {
             wtBranch: planned.wtBranch,
             index: Math.max(1, Math.floor(Number(p.index) || 1)),
             status: "creating",
+            detail: "等待开始创建",
+          });
+        },
+        onItemProgress: (p) => {
+          this.upsertWorktreeState(taskId, {
+            providerId: p.providerId,
+            worktreePath: String(p.worktreePath || "").trim(),
+            wtBranch: String(p.wtBranch || "").trim(),
+            index: Math.max(1, Math.floor(Number(p.index) || 1)),
+            status: "creating",
+            detail: String(p.detail || "").trim() || undefined,
           });
         },
       });

--- a/electron/git/worktreeOps.ts
+++ b/electron/git/worktreeOps.ts
@@ -51,6 +51,8 @@ export type CreateWorktreesRequest = {
   }) => void;
   /** 在尝试创建某个 worktree 前回调（用于捕获“中断时的目标目录/分支”）。 */
   onWorktreePlanned?: (args: { providerId: "codex" | "claude" | "gemini"; repoMainPath: string; worktreePath: string; baseBranch: string; wtBranch: string; index: number }) => void;
+  /** 单个 worktree 创建阶段变化回调（用于 UI 展示慢在哪一步）。 */
+  onItemProgress?: (args: { providerId: "codex" | "claude" | "gemini"; repoMainPath: string; worktreePath: string; baseBranch: string; wtBranch: string; index: number; detail: string }) => void;
   /** 创建超时估算完成后回调，供后台任务快照和 UI 等待兜底复用。 */
   onTimeoutEstimated?: (estimate: WorktreeTimeoutEstimate) => void;
 };
@@ -550,7 +552,13 @@ export async function createWorktreesAsync(req: CreateWorktreesRequest): Promise
   /**
    * 在创建 worktree 后应用保留项与初始化命令（非致命）。
    */
-  const applyPostSetupIfNeeded = async (targetWorktree: string): Promise<string[]> => {
+  const applyPostSetupIfNeeded = async (targetWorktree: string, onProgress?: (detail: string) => void): Promise<string[]> => {
+    const hasPostSetupActions =
+      req.copyRules === true ||
+      (Array.isArray(req.postSetup?.items) && req.postSetup.items.length > 0) ||
+      !!String(req.postSetup?.command || "").trim();
+    if (!hasPostSetupActions) return [];
+
     const res = await applyWorktreePostSetupAsync({
       sourceDir: mainWorktreePath,
       targetDir: targetWorktree,
@@ -558,6 +566,8 @@ export async function createWorktreesAsync(req: CreateWorktreesRequest): Promise
       copyRules: req.copyRules === true,
       gitPath,
       signal,
+      onLog: log,
+      onProgress,
     });
     const warnings = Array.isArray(res.warnings) ? res.warnings.slice() : [];
     if (!res.ok && res.error) warnings.push(res.error);
@@ -704,6 +714,23 @@ export async function createWorktreesAsync(req: CreateWorktreesRequest): Promise
    * 执行单个创建计划，并汇总成功项或失败项。
    */
   const executePlanAsync = async (plan: WorktreeCreatePlan): Promise<void> => {
+    /**
+     * 上报单个 worktree 当前阶段；回调失败不影响创建流程。
+     */
+    const reportProgress = (detail: string): void => {
+      try {
+        req.onItemProgress?.({
+          providerId: plan.providerId,
+          repoMainPath: baseRepoMainPath,
+          worktreePath: plan.targetDir,
+          baseBranch: req.baseBranch,
+          wtBranch: plan.wtBranch,
+          index: plan.index,
+          detail,
+        });
+      } catch {}
+    };
+
     try {
       req.onWorktreePlanned?.({
         providerId: plan.providerId,
@@ -715,6 +742,7 @@ export async function createWorktreesAsync(req: CreateWorktreesRequest): Promise
       });
     } catch {}
 
+    reportProgress("正在执行 git worktree add");
     const addResult = await runWorktreeAddWithRetryAsync(plan);
     if (!addResult.ok) {
       const error = String(addResult.error || "git worktree add failed");
@@ -734,7 +762,9 @@ export async function createWorktreesAsync(req: CreateWorktreesRequest): Promise
       return;
     }
 
-    const warnings = await applyPostSetupIfNeeded(plan.targetDir);
+    reportProgress("正在应用保留项与初始化设置");
+    const warnings = await applyPostSetupIfNeeded(plan.targetDir, reportProgress);
+    reportProgress("正在写入 worktree 元数据");
     const meta: WorktreeMeta = {
       repoMainPath: baseRepoMainPath,
       baseBranch: req.baseBranch,

--- a/electron/git/worktreePostSetup.ts
+++ b/electron/git/worktreePostSetup.ts
@@ -35,6 +35,8 @@ export type WorktreePostSetupApplyResult = {
   error?: string;
 };
 
+type SymlinkPrefixChecker = (targetPath: string) => Promise<void>;
+
 export const WORKTREE_POST_SETUP_BLOCKED_PATHS = new Set([
   ".git",
   "node_modules",
@@ -143,6 +145,44 @@ async function assertNoSymlinkPathPrefixAsync(root: string, target: string): Pro
 }
 
 /**
+ * 创建带缓存的路径前缀符号链接检查器，避免复制大目录时反复检查同一批父目录。
+ */
+function createSymlinkPrefixChecker(root: string): SymlinkPrefixChecker {
+  const rootAbs = path.resolve(root);
+  const checked = new Map<string, Promise<void>>();
+
+  return async (target: string): Promise<void> => {
+    const targetAbs = path.resolve(target);
+    const rel = path.relative(rootAbs, targetAbs);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) throw new Error("path escapes project");
+    if (!rel) return;
+
+    let cursor = rootAbs;
+    for (const part of rel.split(path.sep).filter(Boolean)) {
+      cursor = path.join(cursor, part);
+      const current = cursor;
+      let pending = checked.get(current);
+      if (!pending) {
+        pending = (async () => {
+          try {
+            const st = await fsp.lstat(current);
+            if (st.isSymbolicLink()) {
+              const display = path.relative(rootAbs, current).replace(/\\/g, "/");
+              throw new Error(`${display}: symbolic link is not supported`);
+            }
+          } catch (error: any) {
+            if (String(error?.code || "") === "ENOENT") return;
+            throw error;
+          }
+        })();
+        checked.set(current, pending);
+      }
+      await pending;
+    }
+  };
+}
+
+/**
  * 安全拼接项目内相对路径，越界时返回空串。
  */
 function resolveProjectRelativePath(root: string, relativePath: string): string {
@@ -155,16 +195,19 @@ function resolveProjectRelativePath(root: string, relativePath: string): string 
 /**
  * 递归复制文件或目录；目标已存在时覆盖同名文件并合并目录。
  */
-async function copyPathRecursiveAsync(source: string, target: string, roots: { sourceRoot: string; targetRoot: string }): Promise<void> {
-  await assertNoSymlinkPathPrefixAsync(roots.sourceRoot, source);
-  await assertNoSymlinkPathPrefixAsync(roots.targetRoot, target);
+async function copyPathRecursiveAsync(source: string, target: string, guards: {
+  assertSourcePrefix: SymlinkPrefixChecker;
+  assertTargetPrefix: SymlinkPrefixChecker;
+}): Promise<void> {
+  await guards.assertSourcePrefix(source);
+  await guards.assertTargetPrefix(target);
   const st = await fsp.lstat(source);
   if (st.isSymbolicLink()) throw new Error("symbolic link is not supported");
   if (st.isDirectory()) {
     await fsp.mkdir(target, { recursive: true });
     const entries = await fsp.readdir(source, { withFileTypes: true });
     for (const entry of entries) {
-      await copyPathRecursiveAsync(path.join(source, entry.name), path.join(target, entry.name), roots);
+      await copyPathRecursiveAsync(path.join(source, entry.name), path.join(target, entry.name), guards);
     }
     return;
   }
@@ -184,6 +227,33 @@ function appendLimitedOutput(current: string, chunk: Buffer | string): string {
 }
 
 /**
+ * 格式化后置准备步骤耗时，便于创建日志展示。
+ */
+function formatPostSetupDuration(ms: number): string {
+  const value = Math.max(0, Math.floor(Number(ms) || 0));
+  if (value < 1000) return `${value}ms`;
+  const seconds = Math.round(value / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const rest = seconds % 60;
+  if (minutes <= 0) return `${seconds}s`;
+  return rest > 0 ? `${minutes}m${rest}s` : `${minutes}m`;
+}
+
+/**
+ * 从命令输出块中提取最后一行可读进度，避免初始化命令长时间运行时 UI 看起来不动。
+ */
+function pickLastProgressLineFromChunk(chunk: Buffer | string): string {
+  const text = String(chunk ?? "").replace(/\r/g, "\n");
+  const lines = text
+    .split(/\n+/)
+    .map((line) => line.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "").trim())
+    .filter(Boolean);
+  const last = lines[lines.length - 1] || "";
+  if (!last) return "";
+  return last.length > 80 ? `${last.slice(0, 80)}...` : last;
+}
+
+/**
  * 按当前平台选择执行用户命令的 shell。
  */
 function buildPostSetupShellCommand(command: string): { file: string; args: string[] } {
@@ -194,7 +264,13 @@ function buildPostSetupShellCommand(command: string): { file: string; args: stri
 /**
  * 在目标 worktree 内执行用户配置的初始化命令，并强制设置超时。
  */
-async function runPostSetupCommandAsync(command: string, cwd: string, signal?: AbortSignal): Promise<NonNullable<WorktreePostSetupApplyResult["command"]>> {
+async function runPostSetupCommandAsync(
+  command: string,
+  cwd: string,
+  signal?: AbortSignal,
+  onLog?: (text: string) => void,
+  onProgress?: (detail: string) => void,
+): Promise<NonNullable<WorktreePostSetupApplyResult["command"]>> {
   const trimmed = String(command || "").trim();
   if (!trimmed) return { skipped: true };
   const shell = buildPostSetupShellCommand(trimmed);
@@ -204,6 +280,27 @@ async function runPostSetupCommandAsync(command: string, cwd: string, signal?: A
     let finished = false;
     let child: ReturnType<typeof spawn> | null = null;
     let timer: NodeJS.Timeout | null = null;
+    const startedAt = Date.now();
+    let lastProgressAt = 0;
+
+    /**
+     * 写入后置准备日志；日志失败不影响创建流程。
+     */
+    const log = (text: string): void => {
+      try { onLog?.(String(text ?? "")); } catch {}
+    };
+
+    /**
+     * 将初始化命令的最新输出同步到创建条目状态，并做轻量节流。
+     */
+    const progressFromOutput = (chunk: Buffer | string): void => {
+      const line = pickLastProgressLineFromChunk(chunk);
+      if (!line) return;
+      const now = Date.now();
+      if (now - lastProgressAt < 250) return;
+      lastProgressAt = now;
+      try { onProgress?.(`初始化命令：${line}`); } catch {}
+    };
 
     /**
      * 结束命令执行并清理计时器与 abort 监听。
@@ -216,6 +313,12 @@ async function runPostSetupCommandAsync(command: string, cwd: string, signal?: A
         timer = null;
       }
       try { signal?.removeEventListener("abort", onAbort); } catch {}
+      const durationText = formatPostSetupDuration(Date.now() - startedAt);
+      if (result.skipped !== true) {
+        const error = String(result.error || "").trim();
+        if (error) log(`[后置准备] 初始化命令结束但有警告（${durationText}）：${error}\n`);
+        else log(`[后置准备] 初始化命令完成（${durationText}）\n`);
+      }
       resolve({ command: trimmed, stdout, stderr, ...result });
     };
 
@@ -252,6 +355,7 @@ async function runPostSetupCommandAsync(command: string, cwd: string, signal?: A
         finalize({ exitCode: -1, error: "aborted" });
         return;
       }
+      log("[后置准备] 正在执行初始化命令…\n");
       child = spawn(shell.file, shell.args, {
         cwd,
         windowsHide: true,
@@ -261,8 +365,14 @@ async function runPostSetupCommandAsync(command: string, cwd: string, signal?: A
           CF_WORKTREE_POST_SETUP: "1",
         },
       });
-      child.stdout?.on("data", (chunk) => { stdout = appendLimitedOutput(stdout, chunk); });
-      child.stderr?.on("data", (chunk) => { stderr = appendLimitedOutput(stderr, chunk); });
+      child.stdout?.on("data", (chunk) => {
+        stdout = appendLimitedOutput(stdout, chunk);
+        progressFromOutput(chunk);
+      });
+      child.stderr?.on("data", (chunk) => {
+        stderr = appendLimitedOutput(stderr, chunk);
+        progressFromOutput(chunk);
+      });
       child.on("error", (error: any) => {
         finalize({ exitCode: -1, error: String(error?.message || error) });
       });
@@ -282,6 +392,35 @@ async function runPostSetupCommandAsync(command: string, cwd: string, signal?: A
 }
 
 /**
+ * 批量读取旧版 AI 规则文件中被 Git ignore 的文件名，减少 Windows 下重复启动 Git 的开销。
+ */
+async function listIgnoredLegacyRuleFilesAsync(args: {
+  sourceDir: string;
+  gitPath?: string;
+  names: readonly string[];
+}): Promise<Set<string>> {
+  const existing = args.names.filter((name) => {
+    try { return fs.existsSync(path.join(args.sourceDir, name)); } catch { return false; }
+  });
+  if (existing.length === 0) return new Set();
+
+  const checked = await execGitAsync({
+    gitPath: args.gitPath,
+    argv: ["-C", args.sourceDir, "check-ignore", "--stdin"],
+    stdin: `${existing.join("\n")}\n`,
+    timeoutMs: 4000,
+  });
+  if (!checked.ok && checked.exitCode !== 1) return new Set();
+
+  return new Set(
+    String(checked.stdout || "")
+      .split(/\r?\n/)
+      .map((item) => item.trim().replace(/\\/g, "/"))
+      .filter(Boolean),
+  );
+}
+
+/**
  * 兼容旧版“创建时拷贝 AI 规则文件”开关，只拷贝被 Git 忽略的规则文件。
  */
 async function copyLegacyRuleFilesAsync(args: {
@@ -292,15 +431,17 @@ async function copyLegacyRuleFilesAsync(args: {
   const copied: string[] = [];
   const warnings: string[] = [];
   const names = ["AGENTS.md", "CLAUDE.md", "GEMINI.md"] as const;
+  const ignoredNames = await listIgnoredLegacyRuleFilesAsync({ sourceDir: args.sourceDir, gitPath: args.gitPath, names });
+  const assertSourcePrefix = createSymlinkPrefixChecker(args.sourceDir);
+  const assertTargetPrefix = createSymlinkPrefixChecker(args.targetDir);
   for (const name of names) {
     try {
       const src = path.join(args.sourceDir, name);
       if (!fs.existsSync(src)) continue;
-      const ign = await execGitAsync({ gitPath: args.gitPath, argv: ["-C", args.sourceDir, "check-ignore", "-q", name], timeoutMs: 4000 });
-      if (ign.exitCode !== 0) continue;
+      if (!ignoredNames.has(name)) continue;
       const dst = path.join(args.targetDir, name);
-      await assertNoSymlinkPathPrefixAsync(args.sourceDir, src);
-      await assertNoSymlinkPathPrefixAsync(args.targetDir, dst);
+      await assertSourcePrefix(src);
+      await assertTargetPrefix(dst);
       const st = await fsp.lstat(src);
       if (st.isSymbolicLink()) throw new Error("symbolic link is not supported");
       if (!st.isFile()) continue;
@@ -323,6 +464,8 @@ export async function applyWorktreePostSetupAsync(args: {
   copyRules?: boolean;
   gitPath?: string;
   signal?: AbortSignal;
+  onLog?: (text: string) => void;
+  onProgress?: (detail: string) => void;
 }): Promise<WorktreePostSetupApplyResult> {
   const sourceDir = toFsPathAbs(args.sourceDir);
   const targetDir = toFsPathAbs(args.targetDir);
@@ -338,6 +481,21 @@ export async function applyWorktreePostSetupAsync(args: {
   const config = normalizeWorktreePostSetupConfig(args.config);
   const copied: string[] = [];
   const warnings: string[] = [];
+  const startedAt = Date.now();
+  const hasActions = (config.items?.length || 0) > 0 || args.copyRules === true || !!String(config.command || "").trim();
+  const log = (text: string): void => {
+    try { args.onLog?.(String(text ?? "")); } catch {}
+  };
+  const progress = (detail: string): void => {
+    try { args.onProgress?.(String(detail || "").trim()); } catch {}
+  };
+
+  if (hasActions) {
+    progress("正在应用保留项与初始化设置");
+    log("[后置准备] 开始应用保留项与初始化设置…\n");
+  }
+  const assertSourcePrefix = createSymlinkPrefixChecker(sourceDir);
+  const assertTargetPrefix = createSymlinkPrefixChecker(targetDir);
 
   for (const item of config.items || []) {
     const relativePath = normalizeWorktreePostSetupRelativePath(item.relativePath);
@@ -357,7 +515,12 @@ export async function applyWorktreePostSetupAsync(args: {
       continue;
     }
     try {
-      await copyPathRecursiveAsync(src, dst, { sourceRoot: sourceDir, targetRoot: targetDir });
+      const itemStartedAt = Date.now();
+      progress(`正在复制保留项：${relativePath}`);
+      log(`[后置准备] 正在复制保留项：${relativePath}\n`);
+      await copyPathRecursiveAsync(src, dst, { assertSourcePrefix, assertTargetPrefix });
+      progress(`保留项复制完成：${relativePath}`);
+      log(`[后置准备] 保留项复制完成：${relativePath}（${formatPostSetupDuration(Date.now() - itemStartedAt)}）\n`);
       copied.push(relativePath);
     } catch (error: any) {
       warnings.push(`${relativePath}: ${String(error?.message || error)}`);
@@ -365,13 +528,23 @@ export async function applyWorktreePostSetupAsync(args: {
   }
 
   if (args.copyRules === true) {
+    const ruleStartedAt = Date.now();
+    progress("正在检查并复制 AI 规则文件");
+    log("[后置准备] 正在检查并复制 AI 规则文件…\n");
     const legacy = await copyLegacyRuleFilesAsync({ sourceDir, targetDir, gitPath: args.gitPath });
     copied.push(...legacy.copied.filter((item) => !copied.includes(item)));
     warnings.push(...legacy.warnings);
+    progress("AI 规则文件处理完成");
+    log(`[后置准备] AI 规则文件处理完成（${formatPostSetupDuration(Date.now() - ruleStartedAt)}）\n`);
   }
 
-  const command = await runPostSetupCommandAsync(config.command || "", targetDir, args.signal);
+  if (String(config.command || "").trim()) progress("正在执行初始化命令");
+  const command = await runPostSetupCommandAsync(config.command || "", targetDir, args.signal, args.onLog, args.onProgress);
   if (command.error) warnings.push(`command: ${command.error}`);
+  if (hasActions) {
+    progress("后置准备完成");
+    log(`[后置准备] 完成（${formatPostSetupDuration(Date.now() - startedAt)}）\n`);
+  }
 
   return {
     ok: true,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1326,6 +1326,7 @@ export default function CodexFlowManagerUI() {
     needsForceRemoveWorktree: false,
     needsForceDeleteBranch: false,
     needsForceResetWorktree: false,
+    progress: undefined,
     error: undefined,
   }));
   const [worktreePostRecycleDialog, setWorktreePostRecycleDialog] = useState<WorktreePostRecycleDialogState>(() => ({ open: false, projectId: "", hint: undefined }));
@@ -10442,6 +10443,7 @@ export default function CodexFlowManagerUI() {
 	      needsForceRemoveWorktree: false,
 	      needsForceDeleteBranch: false,
 	      needsForceResetWorktree: false,
+	      progress: undefined,
 	      error: undefined,
 	    });
 	    void loadWorktreeDeleteBranches(project);
@@ -10465,6 +10467,7 @@ export default function CodexFlowManagerUI() {
 	      needsForceRemoveWorktree: false,
 	      needsForceDeleteBranch: false,
 	      needsForceResetWorktree: false,
+	      progress: undefined,
 	      error: undefined,
 	    }));
 	  }, []);
@@ -10503,7 +10506,14 @@ export default function CodexFlowManagerUI() {
 
     setWorktreeDeleteInFlight(project.id, true);
 
-    setWorktreeDeleteDialog((prev) => (prev.open && prev.projectId === pid ? { ...prev, running: true, error: undefined } : prev));
+    setWorktreeDeleteDialog((prev) => (prev.open && prev.projectId === pid ? {
+      ...prev,
+      running: true,
+      progress: dlg.action === "reset"
+        ? (t("projects:worktreeResetProgressResetting", "正在重置到目标分支…") as string)
+        : (t("projects:worktreeDeleteProgressRemoving", "正在移除 worktree…") as string),
+      error: undefined,
+    } : prev));
     try {
       if (dlg.action === "reset") {
         const targetRef = String(dlg.resetTargetBranch || "").trim();
@@ -10520,6 +10530,10 @@ export default function CodexFlowManagerUI() {
           const owner = resolveWorktreePostSetupOwnerProject(project);
           const postSetup = normalizeWorktreePostSetupConfig((owner as any)?.worktreePostSetup);
           if (owner?.winPath && postSetup.applyAfterReset !== false && hasWorktreePostSetupActions(postSetup)) {
+            setWorktreeDeleteDialog((prev) => (prev.open && prev.projectId === pid ? {
+              ...prev,
+              progress: t("projects:worktreeResetProgressPostSetup", "正在重新应用保留项与初始化设置…") as string,
+            } : prev));
             const postRes: any = await (window as any).host?.gitWorktree?.applyPostSetup?.({
               sourceDir: owner.winPath,
               targetDir: project.winPath,
@@ -10537,12 +10551,16 @@ export default function CodexFlowManagerUI() {
               });
             }
           }
+          setWorktreeDeleteDialog((prev) => (prev.open && prev.projectId === pid ? {
+            ...prev,
+            progress: t("projects:worktreeResetProgressRefreshing", "正在刷新项目状态…") as string,
+          } : prev));
           setWorktreeDeleteDialog((prev) => (prev.open && prev.projectId === pid ? { ...prev, open: false, running: false } : prev));
           void refreshGitInfoForProjectIds([project.id]);
           return;
         }
         if (res?.needsForce) {
-          setWorktreeDeleteDialog((prev) => (prev.open && prev.projectId === pid ? { ...prev, running: false, needsForceResetWorktree: true, error: String(res?.error || "") } : prev));
+          setWorktreeDeleteDialog((prev) => (prev.open && prev.projectId === pid ? { ...prev, running: false, progress: undefined, needsForceResetWorktree: true, error: String(res?.error || "") } : prev));
           return;
         }
         throw new Error(res?.error || "reset failed");
@@ -10554,6 +10572,10 @@ export default function CodexFlowManagerUI() {
           forceDeleteBranch: opts?.forceDeleteBranch === true,
         });
         if (res && res.ok) {
+          setWorktreeDeleteDialog((prev) => (prev.open && prev.projectId === pid ? {
+            ...prev,
+            progress: t("projects:worktreeDeleteProgressRefreshing", "正在刷新项目状态…") as string,
+          } : prev));
           setWorktreeDeleteDialog((prev) => (prev.open && prev.projectId === pid ? { ...prev, open: false, running: false } : prev));
           void refreshGitInfoForProjectIds([project.id]);
           try {
@@ -10574,6 +10596,7 @@ export default function CodexFlowManagerUI() {
             ? {
               ...prev,
               running: false,
+              progress: undefined,
               needsForceRemoveWorktree: true,
               needsForceDeleteBranch: res?.needsForceDeleteBranch === true || prev.needsForceDeleteBranch === true,
               error: undefined,
@@ -10586,6 +10609,7 @@ export default function CodexFlowManagerUI() {
             ? {
               ...prev,
               running: false,
+              progress: undefined,
               needsForceRemoveWorktree: res?.needsForceRemoveWorktree === true || prev.needsForceRemoveWorktree === true,
               needsForceDeleteBranch: true,
               error: undefined,
@@ -10596,7 +10620,7 @@ export default function CodexFlowManagerUI() {
         throw new Error(res?.error || "delete failed");
       }
     } catch (e: any) {
-      setWorktreeDeleteDialog((prev) => (prev.open && prev.projectId === pid ? { ...prev, running: false, error: String(e?.message || e) } : prev));
+      setWorktreeDeleteDialog((prev) => (prev.open && prev.projectId === pid ? { ...prev, running: false, progress: undefined, error: String(e?.message || e) } : prev));
       showGitActionErrorDialog({
         title: dlg.action === "reset" ? (t("projects:worktreeResetFailed", "重置失败") as string) : (t("projects:worktreeDeleteFailed", "删除 worktree 失败") as string),
         message: String(e?.message || e),
@@ -14413,6 +14437,9 @@ export default function CodexFlowManagerUI() {
                               </div>
                               <div className="text-[11px] text-slate-500 break-all font-mono">{state.worktreePath}</div>
                               <div className="text-[11px] text-slate-500 break-all font-mono">{state.wtBranch}</div>
+                              {state.detail && createStatus === "creating" ? (
+                                <div className="text-[11px] text-slate-600 dark:text-[var(--cf-text-secondary)]">{state.detail}</div>
+                              ) : null}
                               {state.error ? (
                                 <div className="text-[11px] text-red-700 whitespace-pre-wrap break-words">{state.error}</div>
                               ) : null}
@@ -14464,28 +14491,6 @@ export default function CodexFlowManagerUI() {
                   ) : null}
                   <Button variant="outline" size="sm" className="h-8 text-xs" onClick={() => setWorktreeCreateProgress((prev) => ({ ...prev, open: false }))}>
                     {t("common:close", "关闭") as string}
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    className="h-8 text-xs"
-                    onClick={async () => {
-                      try { if (repo?.winPath) await (window as any).host?.gitWorktree?.openExternalTool?.(repo.winPath); } catch {}
-                    }}
-                    disabled={!repo?.winPath}
-                  >
-                    {t("projects:gitOpenExternalTool", "打开外部 Git 工具") as string}
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    className="h-8 text-xs"
-                    onClick={async () => {
-                      try { if (repo?.winPath) await (window as any).host?.gitWorktree?.openTerminal?.(repo.winPath); } catch {}
-                    }}
-                    disabled={!repo?.winPath}
-                  >
-                    {t("projects:gitOpenTerminal", "在外部终端 / Git Bash 打开") as string}
                   </Button>
                 </div>
               </div>
@@ -15068,6 +15073,7 @@ export default function CodexFlowManagerUI() {
                             needsForceRemoveWorktree: false,
                             needsForceDeleteBranch: false,
                             needsForceResetWorktree: false,
+                            progress: undefined,
                             error: undefined,
                           }));
                         }}
@@ -15122,6 +15128,7 @@ export default function CodexFlowManagerUI() {
                                   ...prev,
                                   resetTargetBranch: e.target.value,
                                   needsForceResetWorktree: false,
+                                  progress: undefined,
                                   error: undefined,
                                 }))
                               }
@@ -15165,13 +15172,19 @@ export default function CodexFlowManagerUI() {
 	                    {worktreeDeleteDialog.afterRecycleHint}
 	                  </div>
 	                ) : null}
-	                {forceHint ? (
+                {forceHint ? (
 	                  <div className="rounded-md border border-amber-200 bg-amber-50 px-2 py-1.5 flex gap-2 items-start">
                     <TriangleAlert className="h-4 w-4 text-amber-600 shrink-0 mt-0.5" />
                     <div className="text-[10px] text-amber-800 leading-normal font-medium">
 	                    {forceHint}
 	                  </div>
 	</div>
+                ) : null}
+                {worktreeDeleteDialog.running && worktreeDeleteDialog.progress ? (
+                  <div className="flex items-center gap-2 rounded-md border border-[var(--cf-border)] bg-[var(--cf-surface-muted)]/75 px-2 py-1.5 text-[10px] leading-snug text-[var(--cf-text-secondary)]">
+                    <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-[var(--cf-accent)]" />
+                    <span className="min-w-0 truncate">{worktreeDeleteDialog.progress}</span>
+                  </div>
                 ) : null}
                 {worktreeDeleteDialog.error ? (
                   <div className="rounded-md border border-red-200 bg-red-50 px-2 py-1.5 text-[10px] font-medium text-red-800 flex items-center gap-2">

--- a/web/src/app/app-shared.tsx
+++ b/web/src/app/app-shared.tsx
@@ -258,6 +258,8 @@ type WorktreeDeleteDialogState = {
   needsForceRemoveWorktree?: boolean;
   needsForceDeleteBranch?: boolean;
   needsForceResetWorktree?: boolean;
+  /** 正在执行删除/重置时展示给用户的当前步骤。 */
+  progress?: string;
   error?: string;
 };
 

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -568,6 +568,8 @@ export type WorktreeCreateTaskItemSnapshot = {
   wtBranch: string;
   index: number;
   status: WorktreeCreateTaskItemStatus;
+  /** 当前正在执行的阶段说明，用于让进度 UI 明确显示慢在哪一步。 */
+  detail?: string;
   updatedAt: number;
   error?: string;
   warnings?: string[];


### PR DESCRIPTION
创建 worktree 时，git worktree add 完成后还会继续执行复制保留项、
复制 AI 规则文件、初始化命令和写入元数据。此前 UI 只显示粗粒度阶段，
用户容易误以为创建已经卡住。

本次调整：
- 为 worktree 创建任务增加单项 detail 进度，展示当前慢在哪一步；
- 在后置准备流程中输出复制、规则文件、初始化命令与耗时日志；
- 将初始化命令的 stdout/stderr 最新行同步为进度提示；
- 优化后置准备复制路径的符号链接检查缓存，减少大目录复制的重复检查；
- 在保留目录并重置流程中增加运行中进度提示。