### PR TITLE
fix(terminal): 修复 PTY resize 竞态导致的闪退

### DIFF
--- a/electron/pty.test.ts
+++ b/electron/pty.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lydell/node-pty', () => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock('./settings.js', () => ({
+  default: {
+    getSettings: () => ({ terminal: 'pwsh' }),
+  },
+}));
+
+vi.mock('./debugConfig.js', () => ({
+  getDebugConfig: () => ({ terminal: { pty: { debug: false } } }),
+}));
+
+vi.mock('./log.js', () => ({
+  perfLogger: { log: vi.fn() },
+}));
+
+import { PTYManager } from './pty';
+
+describe('PTYManager', () => {
+  /**
+   * 创建带可观察 IPC 发送能力的窗口桩。
+   */
+  function createWindowStub() {
+    const send = vi.fn();
+    return {
+      send,
+      win: {
+        isDestroyed: () => false,
+        webContents: {
+          isDestroyed: () => false,
+          mainFrame: {
+            isDestroyed: () => false,
+            send,
+          },
+        },
+      },
+    };
+  }
+
+  it('resize 遇到底层已退出 PTY 异常时应清理 session、发送尾部输出并通知前端退出', () => {
+    const { send, win } = createWindowStub();
+    const manager = new PTYManager(() => [win as any]);
+    const resize = vi.fn(() => {
+      throw new Error('Cannot resize a pty that has already exited');
+    });
+
+    (manager as any).sessions.set('pty-exited', { resize });
+    (manager as any).backlogs.set('pty-exited', { clear: vi.fn() });
+    (manager as any).ipcPendingById.set('pty-exited', {
+      timer: null,
+      chunks: ['tail output'],
+      totalChars: 'tail output'.length,
+      droppedChars: 0,
+    });
+
+    expect(() => manager.resize('pty-exited', 120, 30)).not.toThrow();
+    expect(resize).toHaveBeenCalledWith(120, 30);
+    expect(manager.hasSession('pty-exited')).toBe(false);
+    expect(manager.getBacklog('pty-exited')).toBe('');
+    expect(send).toHaveBeenNthCalledWith(1, 'pty:data', { id: 'pty-exited', data: 'tail output' });
+    expect(send).toHaveBeenNthCalledWith(2, 'pty:exit', { id: 'pty-exited', exitCode: undefined });
+  });
+
+  it('resize 遇到非已退出异常时只记录失败，不应误删 session', () => {
+    const { send, win } = createWindowStub();
+    const manager = new PTYManager(() => [win as any]);
+    const resize = vi.fn(() => {
+      throw new Error('native resize failed');
+    });
+
+    (manager as any).sessions.set('pty-active', { resize });
+
+    expect(() => manager.resize('pty-active', 100, 24)).not.toThrow();
+    expect(manager.hasSession('pty-active')).toBe(true);
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -308,6 +308,38 @@ export class PTYManager {
   }
 
   /**
+   * 判断异常是否来自“已退出 PTY 的 resize 请求”。
+   *
+   * @param error - 捕获到的异常
+   * @returns 是否为已退出 PTY 的 resize 异常
+   */
+  private isExitedPtyResizeError(error: unknown): boolean {
+    const message = String((error as any)?.message || error || "");
+    return message.includes("Cannot resize a pty that has already exited");
+  }
+
+  /**
+   * 按退出语义清理 PTY 会话，并通知前端解绑旧 PTY。
+   *
+   * @param id - PTY 会话 id
+   * @param exitCode - 退出码，未知时可省略
+   */
+  private cleanupExitedSession(id: string, exitCode?: number): void {
+    const key = String(id || "").trim();
+    if (!key) return;
+    const hadSession = this.sessions.has(key);
+    // 先 flush，避免短命令最后一段输出卡在合并队列中。
+    try { this.flushPtyData(key); } catch {}
+    this.sessions.delete(key);
+    try { this.clearPendingPtyData(key); } catch {}
+    try { this.backlogs.get(key)?.clear(); } catch {}
+    this.backlogs.delete(key);
+    if (hadSession) {
+      this.sendToRenderer('pty:exit', { id: key, exitCode });
+    }
+  }
+
+  /**
    * 获取当前仍处于活跃状态的 PTY 会话数量。
    */
   getActiveSessionCount(): number {
@@ -428,12 +460,7 @@ export class PTYManager {
     });
 
     proc.onExit((evt: { exitCode: number; signal?: number }) => {
-      // 中文说明：在退出前先 flush，避免最后一批输出被合并队列吞掉（例如短命令 < 16ms 即退出）。
-      try { this.flushPtyData(id); } catch {}
-      this.sessions.delete(id);
-      try { this.backlogs.get(id)?.clear(); } catch {}
-      this.backlogs.delete(id);
-      this.sendToRenderer('pty:exit', { id, exitCode: evt?.exitCode });
+      this.cleanupExitedSession(id, evt?.exitCode);
     });
 
     // 关键修复：延迟执行 startupCmd，确保前端有足够时间订阅 'pty:data' 事件
@@ -489,7 +516,16 @@ export class PTYManager {
       const c = Math.max(2, cols);
       const r = Math.max(2, rows);
       dlog(`[pty] resize id=${id} cols=${c} rows=${r}`);
-      p.resize(c, r);
+      try {
+        p.resize(c, r);
+      } catch (e: any) {
+        const message = String(e?.message || e || "");
+        // 终端退出和窗口尺寸变化可能同时发生，resize 失败不应拖垮主进程。
+        try { perfLogger.log(`[pty] resize failed id=${id} cols=${c} rows=${r} error=${message}`); } catch {}
+        if (this.isExitedPtyResizeError(e)) {
+          this.cleanupExitedSession(id);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
resize 与 PTY 退出可能同时发生，node-pty 会抛出
“Cannot resize a pty that has already exited”，此前该异常可能穿透到 主进程并导致应用闪退。

本次调整：
- 捕获 resize 失败并记录日志，避免异常穿透主进程
- 识别已退出 PTY 的 resize 异常后清理会话、pending 输出和 backlog
- 复用退出清理逻辑，保证退出前先 flush 最后一批终端输出
- 补充 PTYManager 单测，覆盖已退出异常与普通 resize 异常