### PR TITLE
fix(codex): 优化重连误判并补充右键 continue 控制

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2934,6 +2934,51 @@ export default function CodexFlowManagerUI() {
   }, [notifyLog]);
 
   /**
+   * 中文说明：当 Codex 后续明确进入 Reconnecting 时，把误落的失败状态恢复为进行中并清理失败残留。
+   */
+  const restoreFailedAgentTurnToReconnecting = useCallback((tabId: string, classification: CodexCliErrorClassification, source: string): void => {
+    const id = String(tabId || "").trim();
+    if (!id) return;
+    const current = agentTurnTimerByTabRef.current[id];
+    if (!current || current.status !== "failed") return;
+
+    clearCodexErrorAutoContinueTimer(id, `restore-reconnecting:${source}`);
+    const restored: AgentTurnTimerState = {
+      status: "working",
+      startedAt: current.startedAt,
+      elapsedMs: 0,
+      reconnectAttempt: classification.reconnectAttempt,
+      reconnectMaxAttempts: classification.reconnectMaxAttempts,
+      reconnectErrorKind: classification.kind,
+      reconnectErrorMessage: classification.matchedText,
+    };
+    const previousHistory = agentTurnHistoryByTabRef.current[id] || [];
+    const nextHistory = previousHistory.filter((item, index) => {
+      if (index > 0) return true;
+      return !(item.status === "failed" && item.startedAt === current.startedAt && item.errorKind === current.errorKind);
+    });
+
+    agentTurnTimerByTabRef.current = {
+      ...agentTurnTimerByTabRef.current,
+      [id]: restored,
+    };
+    agentTurnHistoryByTabRef.current = {
+      ...agentTurnHistoryByTabRef.current,
+      [id]: nextHistory,
+    };
+    setAgentTurnTimerByTab((prev) => ({
+      ...prev,
+      [id]: restored,
+    }));
+    setAgentTurnHistoryByTab((prev) => ({
+      ...prev,
+      [id]: nextHistory,
+    }));
+    clearPendingForTab(id);
+    notifyLog(`agentTimer.failed.restoreReconnecting tab=${id} kind=${classification.kind} source=${source}`);
+  }, [clearCodexErrorAutoContinueTimer, notifyLog]);
+
+  /**
    * 中文说明：将指定标签页的计时标记为“中断”，并保留当前已耗时（用于终端 ESC 中断场景），同时记入历史。
    */
   const interruptAgentTurnTimer = useCallback((tabId: string, source: string) => {
@@ -4116,13 +4161,98 @@ export default function CodexFlowManagerUI() {
     const providerId = resolveTabProviderId(tabId).toLowerCase();
     if (providerId !== "codex") return;
     const timerState = agentTurnTimerByTabRef.current[tabId];
-    if (!timerState || timerState.status !== "working") return;
+    if (!timerState || (timerState.status !== "working" && timerState.status !== "failed")) return;
 
     const cleanedChunk = stripAnsiForCodexErrorScan(chunk);
     if (!cleanedChunk) return;
     const previous = codexErrorScanByTabRef.current[tabId] || { buffer: "", autoContinueAttempts: 0 };
     const now = Date.now();
     const chunkRuntimeStatus = detectCodexCliRuntimeStatusText(cleanedChunk);
+    if (chunkRuntimeStatus?.phase === "idle") {
+      const idleClassification = classifyCodexCliErrorText(cleanedChunk);
+      if (typeof previous.pendingFinalErrorTimerId === "number") {
+        try { window.clearTimeout(previous.pendingFinalErrorTimerId); } catch {}
+      }
+      if (idleClassification?.phase === "final") {
+        const errorKey = buildCodexCliErrorKey(idleClassification);
+        codexErrorScanByTabRef.current[tabId] = {
+          ...previous,
+          buffer: "",
+          lastReconnectErrorKey: undefined,
+          lastReconnectStatusAt: undefined,
+          lastFinalErrorKey: errorKey,
+          pendingFinalErrorKey: undefined,
+          pendingFinalErrorKind: undefined,
+          pendingFinalError: undefined,
+          pendingFinalErrorAt: undefined,
+          pendingFinalErrorTimerId: undefined,
+        };
+        clearAgentTurnReconnecting(tabId, "idle-final-error");
+        if (previous.lastFinalErrorKey !== errorKey)
+          handleCodexCliErrorDetected(tabId, idleClassification, errorKey);
+        notifyLog(`codexError.idle.final tab=${tabId} kind=${idleClassification.kind}`);
+        return;
+      }
+      codexErrorScanByTabRef.current[tabId] = {
+        ...previous,
+        buffer: "",
+        lastReconnectErrorKey: undefined,
+        lastReconnectStatusAt: undefined,
+        pendingFinalErrorKey: undefined,
+        pendingFinalErrorKind: undefined,
+        pendingFinalError: undefined,
+        pendingFinalErrorAt: undefined,
+        pendingFinalErrorTimerId: undefined,
+      };
+      clearAgentTurnReconnecting(tabId, "idle-output");
+      if (timerState.status === "working")
+        interruptAgentTurnTimer(tabId, "codex-idle-output");
+      notifyLog(`codexError.idle tab=${tabId}`);
+      return;
+    }
+    if (timerState.status === "failed") {
+      if (chunkRuntimeStatus?.phase !== "reconnecting") return;
+      const nextBuffer = `${previous.buffer || ""}${cleanedChunk}`.slice(-CODEX_ERROR_SCAN_MAX_BUFFER_LENGTH);
+      const reconnectClassification = classifyCodexCliErrorText(`${cleanedChunk}\n${timerState.errorMessage || ""}`) || {
+        kind: timerState.errorKind || previous.pendingErrorKind || previous.pendingFinalErrorKind || "unknownHttp",
+        severity: "temporary" as const,
+        retryable: true,
+        matchedText: timerState.errorMessage || "Reconnecting",
+        phase: "reconnecting" as const,
+        reconnectAttempt: chunkRuntimeStatus.reconnectAttempt,
+        reconnectMaxAttempts: chunkRuntimeStatus.reconnectMaxAttempts,
+      };
+      const normalizedReconnectClassification: CodexCliErrorClassification = {
+        ...reconnectClassification,
+        phase: "reconnecting",
+        reconnectAttempt: reconnectClassification.reconnectAttempt || chunkRuntimeStatus.reconnectAttempt,
+        reconnectMaxAttempts: reconnectClassification.reconnectMaxAttempts || chunkRuntimeStatus.reconnectMaxAttempts,
+      };
+      const reconnectErrorKey = buildCodexCliErrorKey(normalizedReconnectClassification);
+      restoreFailedAgentTurnToReconnecting(tabId, normalizedReconnectClassification, "pty-runtime-status");
+      const restoredScanState = codexErrorScanByTabRef.current[tabId] || previous;
+      if (typeof restoredScanState.pendingFinalErrorTimerId === "number") {
+        try { window.clearTimeout(restoredScanState.pendingFinalErrorTimerId); } catch {}
+      }
+      codexErrorScanByTabRef.current[tabId] = {
+        ...restoredScanState,
+        buffer: nextBuffer,
+        lastReconnectErrorKey: reconnectErrorKey,
+        lastReconnectStatusAt: now,
+        pendingErrorKey: undefined,
+        pendingErrorKind: undefined,
+        autoContinueTimerId: undefined,
+        pendingFinalErrorKey: undefined,
+        pendingFinalErrorKind: undefined,
+        pendingFinalError: undefined,
+        pendingFinalErrorAt: undefined,
+        pendingFinalErrorTimerId: undefined,
+      };
+      if (previous.lastReconnectErrorKey !== reconnectErrorKey)
+        handleCodexCliReconnectDetected(tabId, normalizedReconnectClassification);
+      notifyLog(`codexError.failed.reconnecting tab=${tabId} kind=${normalizedReconnectClassification.kind}`);
+      return;
+    }
     if (chunkRuntimeStatus?.phase === "working" && typeof previous.pendingFinalErrorTimerId === "number") {
       try { window.clearTimeout(previous.pendingFinalErrorTimerId); } catch {}
       notifyLog(`codexError.pendingFinal.clear tab=${tabId} source=working-output`);
@@ -5578,6 +5708,100 @@ export default function CodexFlowManagerUI() {
     startAgentTurnTimer,
     tm,
   ]);
+
+  /**
+   * 中文说明：用户从右键菜单立即发送 Codex continue，绕过自动 continue 开关但保留发送前环境校验。
+   */
+  const sendCodexManualContinue = useCallback(async (tabId: string): Promise<void> => {
+    const id = String(tabId || "").trim();
+    if (!id) return;
+    const providerId = resolveTabProviderId(id).toLowerCase();
+    if (providerId !== "codex") return;
+    const ptyId = ptyByTabRef.current[id];
+    if (!ptyId) {
+      notifyLog(`codexError.manualContinue.skip tab=${id} reason=missing-pty`);
+      return;
+    }
+
+    const state = codexErrorScanByTabRef.current[id] || { buffer: "", autoContinueAttempts: 0 };
+    if (typeof state.autoContinueTimerId === "number") {
+      try { window.clearTimeout(state.autoContinueTimerId); } catch {}
+    }
+    if (typeof state.pendingFinalErrorTimerId === "number") {
+      try { window.clearTimeout(state.pendingFinalErrorTimerId); } catch {}
+    }
+    const nextAttempts = Math.max(0, Number(state.autoContinueAttempts || 0)) + 1;
+    codexErrorScanByTabRef.current[id] = {
+      ...state,
+      buffer: "",
+      lastReconnectErrorKey: undefined,
+      lastFinalErrorKey: undefined,
+      pendingErrorKey: undefined,
+      pendingErrorKind: undefined,
+      autoContinueTimerId: undefined,
+      autoContinueAttempts: nextAttempts,
+      pendingFinalErrorKey: undefined,
+      pendingFinalErrorKind: undefined,
+      pendingFinalError: undefined,
+      pendingFinalErrorAt: undefined,
+      pendingFinalErrorTimerId: undefined,
+    };
+
+    const tabEnv = getTabExecEnv(id, "codex");
+    notifyLog(`codexError.manualContinue.send tab=${id} attempt=${nextAttempts}`);
+    startAgentTurnTimer(id);
+    try {
+      await tm.sendTextAndEnter(id, "continue", {
+        providerId: "codex",
+        terminalMode: tabEnv.terminal as any,
+        distro: tabEnv.terminal === "wsl" ? tabEnv.distro : undefined,
+      });
+    } catch (error) {
+      notifyLog(`codexError.manualContinue.sendFailed tab=${id} error=${String((error as any)?.message || error)}`);
+      interruptAgentTurnTimer(id, "codex-manual-continue-send-failed");
+    }
+  }, [
+    getTabExecEnv,
+    interruptAgentTurnTimer,
+    notifyLog,
+    resolveTabProviderId,
+    startAgentTurnTimer,
+    tm,
+  ]);
+
+  /**
+   * 中文说明：取消指定标签页已安排的 Codex 自动 continue，同时清除状态条倒计时展示。
+   */
+  const cancelCodexScheduledContinue = useCallback((tabId: string, source: string): void => {
+    const id = String(tabId || "").trim();
+    if (!id) return;
+    clearCodexErrorAutoContinueTimer(id, source);
+    const current = agentTurnTimerByTabRef.current[id];
+    if (current?.status !== "failed") return;
+    const nextState: AgentTurnTimerState = {
+      ...current,
+      autoContinueScheduledAt: undefined,
+      autoContinueAttempt: undefined,
+      autoContinueMaxAttempts: undefined,
+    };
+    agentTurnTimerByTabRef.current = {
+      ...agentTurnTimerByTabRef.current,
+      [id]: nextState,
+    };
+    setAgentTurnTimerByTab((prev) => {
+      if (prev[id]?.status !== "failed") return prev;
+      return {
+        ...prev,
+        [id]: {
+          ...prev[id],
+          autoContinueScheduledAt: undefined,
+          autoContinueAttempt: undefined,
+          autoContinueMaxAttempts: undefined,
+        },
+      };
+    });
+    notifyLog(`codexError.autoContinue.cancel tab=${id} source=${source}`);
+  }, [clearCodexErrorAutoContinueTimer, notifyLog]);
 
   /**
    * 中文说明：按当前设置为可恢复 Codex 错误安排一次自动 continue。
@@ -13179,6 +13403,11 @@ export default function CodexFlowManagerUI() {
             const timerState = tabId ? agentTurnTimerByTab[tabId] : undefined;
             if (!tabId || !timerState) return null;
             const canContinueTimer = timerState.status !== "working";
+            const isCodexFailed = timerState.status === "failed" && resolveTabProviderId(tabId).toLowerCase() === "codex";
+            const hasScheduledCodexContinue = isCodexFailed && (
+              Number(timerState.autoContinueScheduledAt || 0) > Date.now() ||
+              typeof codexErrorScanByTabRef.current[tabId]?.autoContinueTimerId === "number"
+            );
             return (
               <div
                 ref={agentTurnCtxMenuRef}
@@ -13197,6 +13426,30 @@ export default function CodexFlowManagerUI() {
                 >
                   <Play className="h-4 w-4" /> {t("terminal:continueTimer") as string}
                 </button>
+                {isCodexFailed ? (
+                  <>
+                    <button
+                      className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[var(--cf-text-primary)] rounded-apple-sm hover:bg-[var(--cf-surface-hover)] transition-all duration-apple-fast"
+                      onClick={() => {
+                        void sendCodexManualContinue(tabId);
+                        setAgentTurnCtxMenu((m) => ({ ...m, show: false, tabId: null }));
+                      }}
+                    >
+                      <Send className="h-4 w-4" /> {t("terminal:sendContinueNow") as string}
+                    </button>
+                    <button
+                      className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[var(--cf-text-primary)] rounded-apple-sm hover:bg-[var(--cf-surface-hover)] disabled:opacity-40 disabled:pointer-events-none transition-all duration-apple-fast"
+                      disabled={!hasScheduledCodexContinue}
+                      onClick={() => {
+                        if (!hasScheduledCodexContinue) return;
+                        cancelCodexScheduledContinue(tabId, "context-menu");
+                        setAgentTurnCtxMenu((m) => ({ ...m, show: false, tabId: null }));
+                      }}
+                    >
+                      <X className="h-4 w-4" /> {t("terminal:cancelAutoContinue") as string}
+                    </button>
+                  </>
+                ) : null}
                 <button
                   className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[var(--cf-red)] rounded-apple-sm hover:bg-[var(--cf-red-light)] transition-all duration-apple-fast"
                   onClick={() => {

--- a/web/src/lib/codex-cli-error-classifier.test.ts
+++ b/web/src/lib/codex-cli-error-classifier.test.ts
@@ -164,6 +164,34 @@ describe("codex-cli-error-classifier（Codex TUI 错误识别）", () => {
     expect(result?.phase).toBe("final");
   });
 
+  it("Codex 最终历史错误行会压住旧的 Reconnecting 状态", () => {
+    const text = `
+      Reconnecting... 1/5 (4m 09s  esc to interrupt)
+      ■ unexpected status 503 Service Unavailable: upstream_status: HTTP 503
+    `;
+
+    const result = classifyCodexCliErrorText(text);
+    expect(result?.kind).toBe("serviceUnavailable");
+    expect(result?.phase).toBe("final");
+    expect(result?.explicitFinal).toBe(true);
+    expect(shouldDelayCodexCliFinalErrorForReconnect(result)).toBe(false);
+    expect(detectCodexCliRuntimeStatusText(text)?.phase).toBe("idle");
+  });
+
+  it("普通方块项目符号不会被误判为 Codex 最终历史行", () => {
+    const text = `
+      Reconnecting... 1/5 (4m 09s  esc to interrupt)
+      ■ checklist item
+    `;
+
+    const result = classifyCodexCliErrorText(text);
+    const status = detectCodexCliRuntimeStatusText(text);
+    expect(result).toBeNull();
+    expect(status?.phase).toBe("reconnecting");
+    expect(status?.reconnectAttempt).toBe(1);
+    expect(status?.reconnectMaxAttempts).toBe(5);
+  });
+
   it("同一个 Reconnecting 状态后的多条错误详情仍不应被误判为最终失败", () => {
     const text = `
       Reconnecting... 5/5 (8m 53s  esc to interrupt)
@@ -175,6 +203,19 @@ describe("codex-cli-error-classifier（Codex TUI 错误识别）", () => {
     expect(result?.kind).toBe("serviceUnavailable");
     expect(result?.phase).toBe("reconnecting");
     expect(result?.reconnectAttempt).toBe(5);
+    expect(result?.reconnectMaxAttempts).toBe(5);
+  });
+
+  it("同一块重绘输出中错误详情先于 Reconnecting 标题时仍识别为重连", () => {
+    const text = `
+      Unexpected status 502 Bad Gateway: upstream_status: HTTP 502
+      Reconnecting... 2/5 (6m 48s  esc to interrupt)
+    `;
+
+    const result = classifyCodexCliErrorText(text);
+    expect(result?.kind).toBe("badGateway");
+    expect(result?.phase).toBe("reconnecting");
+    expect(result?.reconnectAttempt).toBe(2);
     expect(result?.reconnectMaxAttempts).toBe(5);
   });
 

--- a/web/src/lib/codex-cli-error-classifier.ts
+++ b/web/src/lib/codex-cli-error-classifier.ts
@@ -14,7 +14,7 @@ export type CodexCliErrorKind =
 
 export type CodexCliErrorSeverity = "temporary" | "blocking";
 export type CodexCliErrorPhase = "reconnecting" | "final";
-export type CodexCliRuntimePhase = "working" | "reconnecting";
+export type CodexCliRuntimePhase = "working" | "reconnecting" | "idle";
 
 export type CodexCliErrorClassification = {
   kind: CodexCliErrorKind;
@@ -22,6 +22,7 @@ export type CodexCliErrorClassification = {
   retryable: boolean;
   matchedText: string;
   phase: CodexCliErrorPhase;
+  explicitFinal?: boolean;
   reconnectAttempt?: number;
   reconnectMaxAttempts?: number;
 };
@@ -123,6 +124,9 @@ const CONTROL_CHARS_EXCEPT_WHITESPACE_PATTERN = /[\u0000-\u0008\u000b\u000c\u000
 const MAX_MATCHED_TEXT_LENGTH = 280;
 const RECONNECTING_STATUS_PATTERN = /Reconnecting\.\.\.\s+(\d+)\/(\d+)/gi;
 const WORKING_STATUS_PATTERN = /\bWorking\s*\(/gi;
+const CODEX_HISTORY_LINE_MARKER_PATTERN = /(?:^|\n)[^\S\n]*[■▪]\s+/gu;
+const CODEX_FINAL_HISTORY_LINE_PATTERN =
+  /^(?:unexpected status\s+\d{3}|exceeded retry limit|Conversation interrupted|Goal budget reached|you['’]ve hit your usage limit|usage limit(?:ed)?(?:\s+reached)?|selected model is at capacity|model is at capacity|currently experiencing high demand|400\s+Bad Request|403\s+Forbidden|413\s+(?:Payload Too Large|Request Entity Too Large)|sign in with ChatGPT)\b/i;
 const EXPLICIT_FINAL_ERROR_PATTERN =
   /(?:exceeded retry limit|selected model is at capacity|you['’]ve hit your usage limit|usage limit(?:ed)?(?:\s+reached)?|currently experiencing high demand|400\s+Bad Request|<h1>\s*400\s+Bad Request\s*<\/h1>|unexpected status\s+413\b|413\s+Payload Too Large|413\s+Request Entity Too Large|<h1>\s*413\s+(?:Payload Too Large|Request Entity Too Large)\s*<\/h1>)/i;
 
@@ -159,6 +163,7 @@ export function isCodexCliErrorAutoRetryable(kind: CodexCliErrorKind): boolean {
  */
 export function shouldDelayCodexCliFinalErrorForReconnect(classification: CodexCliErrorClassification | null | undefined): boolean {
   if (!classification || classification.phase !== "final") return false;
+  if (classification.explicitFinal) return false;
   return (
     classification.kind === "rateLimited" ||
     classification.kind === "concurrency" ||
@@ -197,8 +202,18 @@ function clipMatchedText(text: string): string {
   return `${normalized.slice(0, MAX_MATCHED_TEXT_LENGTH - 1)}…`;
 }
 
+/**
+ * 判断 Codex 历史行是否是已停止运行的最终/中断状态，避免把普通方块项目符号当作空闲状态。
+ */
+function isCodexFinalHistoryLine(text: string, contentStartIndex: number): boolean {
+  const index = Math.max(0, Number(contentStartIndex) || 0);
+  const lineEnd = text.indexOf("\n", index);
+  const lineText = text.slice(index, lineEnd === -1 ? text.length : lineEnd).trim();
+  return CODEX_FINAL_HISTORY_LINE_PATTERN.test(lineText);
+}
+
 type CodexStatusMarker = {
-  kind: "reconnecting" | "working";
+  kind: "reconnecting" | "working" | "idle";
   index: number;
   attempt?: number;
   maxAttempts?: number;
@@ -223,6 +238,14 @@ function collectCodexStatusMarkers(text: string): CodexStatusMarker[] {
       index: match.index || 0,
     });
   }
+  for (const match of text.matchAll(CODEX_HISTORY_LINE_MARKER_PATTERN)) {
+    const contentStartIndex = (match.index || 0) + match[0].length;
+    if (!isCodexFinalHistoryLine(text, contentStartIndex)) continue;
+    markers.push({
+      kind: "idle",
+      index: contentStartIndex,
+    });
+  }
   markers.sort((left, right) => left.index - right.index);
   return markers;
 }
@@ -234,6 +257,16 @@ function isExplicitFinalCodexErrorText(matchedText: string): boolean {
   const text = String(matchedText || "").trim();
   if (!text) return false;
   return EXPLICIT_FINAL_ERROR_PATTERN.test(text);
+}
+
+/**
+ * 判断错误匹配是否位于 Codex TUI 最终历史行中，典型形态为红色方块后的错误/中断消息。
+ */
+function hasCodexFinalHistoryMarkerBeforeMatch(text: string, errorIndex: number): boolean {
+  const index = Math.max(0, Number(errorIndex) || 0);
+  const lineStart = Math.max(0, text.lastIndexOf("\n", Math.max(0, index - 1)) + 1);
+  const prefix = text.slice(lineStart, index);
+  return /[■▪]\s*$/u.test(prefix) && isCodexFinalHistoryLine(text, index);
 }
 
 /**
@@ -250,12 +283,23 @@ function resolveCodexCliErrorPhase(text: string, errorIndex: number): {
     if (marker.index > errorIndex) break;
     latestBeforeError = marker;
   }
-  if (latestBeforeError?.kind !== "reconnecting") return { phase: "final" };
-  return {
-    phase: "reconnecting",
-    reconnectAttempt: latestBeforeError.attempt,
-    reconnectMaxAttempts: latestBeforeError.maxAttempts,
-  };
+  if (latestBeforeError?.kind === "reconnecting") {
+    return {
+      phase: "reconnecting",
+      reconnectAttempt: latestBeforeError.attempt,
+      reconnectMaxAttempts: latestBeforeError.maxAttempts,
+    };
+  }
+  const latestMarker = markers[markers.length - 1];
+  if (latestMarker?.kind === "reconnecting" && latestMarker.index > errorIndex) {
+    // Codex TUI 重绘状态行时，PTY 片段里可能先出现错误详情，再出现 Reconnecting 标题。
+    return {
+      phase: "reconnecting",
+      reconnectAttempt: latestMarker.attempt,
+      reconnectMaxAttempts: latestMarker.maxAttempts,
+    };
+  }
+  return { phase: "final" };
 }
 
 /**
@@ -283,6 +327,7 @@ export function detectCodexCliRuntimeStatusText(input: string): CodexCliRuntimeS
   const latest = markers[markers.length - 1];
   if (!latest) return null;
   if (latest.kind === "working") return { phase: "working" };
+  if (latest.kind === "idle") return { phase: "idle" };
   return {
     phase: "reconnecting",
     reconnectAttempt: latest.attempt,
@@ -316,7 +361,8 @@ export function classifyCodexCliErrorText(input: string): CodexCliErrorClassific
     const markers = collectCodexStatusMarkers(text);
     const latestMarker = markers[markers.length - 1];
     if (latestMarker?.kind === "working" && latestMarker.index > (match.index || 0)) return null;
-    const phase = isExplicitFinalCodexErrorText(match[0])
+    const explicitFinal = isExplicitFinalCodexErrorText(match[0]) || hasCodexFinalHistoryMarkerBeforeMatch(text, match.index || 0);
+    const phase = explicitFinal
       ? { phase: "final" as const }
       : resolveCodexCliErrorPhase(text, match.index || 0);
     return {
@@ -324,6 +370,7 @@ export function classifyCodexCliErrorText(input: string): CodexCliErrorClassific
       severity: rule.severity,
       retryable: isCodexCliErrorAutoRetryable(rule.kind),
       matchedText: clipMatchedText(match[0] || text),
+      explicitFinal: explicitFinal || undefined,
       ...phase,
     };
   }

--- a/web/src/locales/en/terminal.json
+++ b/web/src/locales/en/terminal.json
@@ -18,6 +18,8 @@
   "agentFailedAutoContinue": "Failed: {reason} ({elapsed}), auto continue in {seconds}s ({attempt}/{max})",
   "continueTimer": "Continue timer",
   "cancelTimer": "Cancel timer",
+  "sendContinueNow": "Send continue now",
+  "cancelAutoContinue": "Cancel auto continue",
   "timerContextHint": "Right click to manage timer",
   "usageHistory": "Usage History",
   "totalDuration": "Total: {total}",

--- a/web/src/locales/zh/terminal.json
+++ b/web/src/locales/zh/terminal.json
@@ -18,6 +18,8 @@
   "agentFailedAutoContinue": "已报错：{reason}（{elapsed}），{seconds}s 后自动 continue（{attempt}/{max}）",
   "continueTimer": "继续计时",
   "cancelTimer": "取消计时",
+  "sendContinueNow": "立即发送 continue",
+  "cancelAutoContinue": "取消自动 continue",
   "timerContextHint": "右键可管理计时",
   "usageHistory": "历史时长记录",
   "totalDuration": "总计时：{total}",


### PR DESCRIPTION
- 区分 Codex Reconnecting 错误详情与最终失败，避免重连期间提前落失败状态
- 支持失败后检测到重连时恢复进行中计时，并清理错误角标与自动 continue 定时器
- 在 Codex 失败计时右键菜单补充立即发送 continue 与取消自动 continue 操作
- 补充 Codex TUI 历史错误行、重绘顺序和普通项目符号的识别测试