### PR TITLE
fix(terminal): 避免终端自动抢占页面输入焦点

### DIFF
--- a/web/src/adapters/TerminalAdapter.tsx
+++ b/web/src/adapters/TerminalAdapter.tsx
@@ -2863,7 +2863,6 @@ export function createTerminalAdapter(options?: TerminalAdapterOptions): Termina
       // 2) 等字体加载完成后再次精确 fitAndPin 并强制 refresh，消除度量误差引发的光标错位/重叠
       const doFit = () => { try { dlog('[adapter] doFit'); fitAndPin(true); } catch {} };
       doFit();
-      try { term!.focus(); } catch {}
       try {
         if ((document as any).fonts?.ready) {
           (document as any).fonts.ready.then(() => {

--- a/web/src/lib/TerminalManager.ts
+++ b/web/src/lib/TerminalManager.ts
@@ -94,6 +94,18 @@ const TERMINAL_WINDOW_RESIZE_STABLE_SAMPLE_COUNT = 2;
 const TERMINAL_WINDOW_RESIZE_SESSION_IDLE_MS = 1800;
 const TERMINAL_WINDOW_RESIZE_SESSION_MAX_MS = 9000;
 const TERMINAL_HOST_LAYOUT_ANCESTOR_LIMIT = 12;
+const NON_TEXT_INPUT_TYPES = new Set([
+  "button",
+  "checkbox",
+  "color",
+  "file",
+  "hidden",
+  "image",
+  "radio",
+  "range",
+  "reset",
+  "submit",
+]);
 
 /**
  * 渲染进程侧的 PTY 接口抽象，便于将 TerminalManager 从具体的 window.host.pty 解耦以实现复用。
@@ -161,6 +173,65 @@ export default class TerminalManager {
   private logScrollDiagnostic(message: string): void {
     if (!this.dbgEnabled()) return;
     try { void (window as any).host?.utils?.perfLogCritical?.(`[terminal.scroll-debug tm] ${message}`); } catch {}
+  }
+
+  /**
+   * 中文说明：判断当前元素是否是页面侧可编辑控件，用于避免终端自动聚焦抢走输入框光标。
+   */
+  private isPageEditableElement(element: Element | null | undefined): boolean {
+    if (!element || typeof (element as any).closest !== "function") return false;
+    try {
+      if ((element as HTMLElement).closest(".xterm, .cf-terminal-chrome")) return false;
+      const editable = (element as HTMLElement).closest("input, textarea, select, [contenteditable], [role='textbox']");
+      if (!editable) return false;
+      if (editable instanceof HTMLInputElement) {
+        const type = String(editable.type || "text").toLowerCase();
+        return !NON_TEXT_INPUT_TYPES.has(type);
+      }
+      if (editable instanceof HTMLTextAreaElement || editable instanceof HTMLSelectElement) return true;
+      const contentEditable = editable.getAttribute("contenteditable");
+      if (contentEditable !== null) {
+        const normalizedContentEditable = contentEditable.trim().toLowerCase();
+        if (normalizedContentEditable !== "false") return true;
+      }
+      return editable.getAttribute("role") === "textbox";
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * 中文说明：判断是否应保留现有页面输入焦点；若用户正在输入框中编辑，终端刷新/挂载不能抢焦点。
+   */
+  private shouldPreserveCurrentEditableFocus(tabId: string): boolean {
+    try {
+      const active = document.activeElement as HTMLElement | null;
+      if (!active || active === document.body || active === document.documentElement) return false;
+      const container = this.containers[tabId];
+      if (container && container.contains(active)) return false;
+      return this.isPageEditableElement(active);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * 中文说明：在不会打断页面输入框编辑时聚焦终端。
+   */
+  private focusAdapterIfSafe(tabId: string, source: string): boolean {
+    if (this.shouldPreserveCurrentEditableFocus(tabId)) {
+      this.dlog(`focus.skip tab=${tabId} source=${source} reason=editable-active`);
+      this.logScrollDiagnostic(`focus.skip tab=${tabId} source=${source} reason=editable-active`);
+      return false;
+    }
+    try {
+      const adapter = this.adapters[tabId];
+      if (typeof adapter?.focus !== "function") return false;
+      adapter.focus();
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -2769,16 +2840,18 @@ export default class TerminalManager {
     } catch {}
     // 精确度量并立即同步尺寸
     try { this.scheduleResizeSync(tabId, true); } catch {}
-    // 切换后主动聚焦并强制刷新，消解输入法合成/宽字符残影
-    try { this.adapters[tabId]?.focus?.(); } catch {}
+    // 切换后主动聚焦并强制刷新；若用户正在页面输入框中编辑，则保留输入框光标。
+    const focusedTerminal = this.focusAdapterIfSafe(tabId, "activated");
     // 关键：恢复（或对齐修复）滚动位置，避免隐藏/显示后滚动条指示错误
     try { this.restoreScrollSnapshot(tabId, "activated"); } catch {}
     const pid = this.getPtyId(tabId);
     if (pid) {
       try {
         this.hostPty.resume?.(pid);
-        this.hostPty.write(pid, "\u001b[I");
-        this.dlog(`tabActivate.injectFocusGain tab=${tabId} pty=${pid}`);
+        if (focusedTerminal) {
+          this.hostPty.write(pid, "\u001b[I");
+          this.dlog(`tabActivate.injectFocusGain tab=${tabId} pty=${pid}`);
+        }
       } catch (err) {
         this.dlog(`tabActivate.injectFocusGain.error tab=${tabId} pty=${pid} err=${(err as Error)?.message || err}`);
       }
@@ -2830,7 +2903,7 @@ export default class TerminalManager {
     const adapter = this.adapters[tabId];
     if (!adapter) return;
     try { this.scheduleResizeSync(tabId, true); } catch {}
-    try { adapter.focus?.(); } catch {}
+    this.focusAdapterIfSafe(tabId, "attach");
 
     // Install a ResizeObserver on the host element to reliably detect layout changes
     // (e.g. window restore/maximize or side panel toggles) and trigger terminal resize.

--- a/web/src/lib/terminal-manager-scroll.test.ts
+++ b/web/src/lib/terminal-manager-scroll.test.ts
@@ -27,59 +27,11 @@ describe("TerminalManager（终端滚动快照）", () => {
     };
   };
 
-  it("onTabDeactivated 会保存快照，onTabActivated 会恢复", () => {
-    const snapshot = { viewportY: 42, baseY: 80, isAtBottom: false };
-    const adapter: any = {
-      mount: vi.fn(() => ({ cols: 80, rows: 24 })),
-      write: vi.fn(),
-      paste: vi.fn(),
-      onData: vi.fn(() => () => {}),
-      resize: vi.fn(() => ({ cols: 80, rows: 24 })),
-      getScrollSnapshot: vi.fn(() => snapshot),
-      restoreScrollSnapshot: vi.fn(),
-      focus: vi.fn(),
-      blur: vi.fn(),
-      setAppearance: vi.fn(),
-      dispose: vi.fn(),
-    };
-    createTerminalAdapterMock.mockReturnValue(adapter);
-
-    const tm = new TerminalManager(() => undefined, createHostPtyStub() as any, {});
-    tm.ensurePersistentContainer("tab-a");
-    tm.onTabDeactivated("tab-a");
-    tm.onTabActivated("tab-a");
-
-    expect(adapter.getScrollSnapshot).toHaveBeenCalled();
-    expect(adapter.restoreScrollSnapshot).toHaveBeenCalledWith(snapshot);
-    tm.disposeAll(false);
-  });
-
-  it("没有历史快照时，onTabActivated 仍会触发一次对齐修复", () => {
-    const adapter: any = {
-      mount: vi.fn(() => ({ cols: 80, rows: 24 })),
-      write: vi.fn(),
-      paste: vi.fn(),
-      onData: vi.fn(() => () => {}),
-      resize: vi.fn(() => ({ cols: 80, rows: 24 })),
-      getScrollSnapshot: vi.fn(() => null),
-      restoreScrollSnapshot: vi.fn(),
-      focus: vi.fn(),
-      blur: vi.fn(),
-      setAppearance: vi.fn(),
-      dispose: vi.fn(),
-    };
-    createTerminalAdapterMock.mockReturnValue(adapter);
-
-    const tm = new TerminalManager(() => undefined, createHostPtyStub() as any, {});
-    tm.ensurePersistentContainer("tab-b");
-    tm.onTabActivated("tab-b");
-
-    expect(adapter.restoreScrollSnapshot).toHaveBeenCalledWith(null);
-    tm.disposeAll(false);
-  });
-
-  it("scrollToTop 与 scrollToBottom 会透传到适配器", () => {
-    const adapter: any = {
+  /**
+   * 中文说明：创建终端适配器 stub，便于断言焦点、滚动与 resize 调用。
+   */
+  const createAdapterStub = (overrides: Record<string, unknown> = {}) => {
+    return {
       mount: vi.fn(() => ({ cols: 80, rows: 24 })),
       write: vi.fn(),
       paste: vi.fn(),
@@ -93,7 +45,76 @@ describe("TerminalManager（终端滚动快照）", () => {
       scrollToTop: vi.fn(),
       scrollToBottom: vi.fn(),
       dispose: vi.fn(),
+      ...overrides,
     };
+  };
+
+  it("onTabDeactivated 会保存快照，onTabActivated 会恢复", () => {
+    const snapshot = { viewportY: 42, baseY: 80, isAtBottom: false };
+    const adapter: any = createAdapterStub({
+      getScrollSnapshot: vi.fn(() => snapshot),
+    });
+    createTerminalAdapterMock.mockReturnValue(adapter);
+
+    const tm = new TerminalManager(() => undefined, createHostPtyStub() as any, {});
+    tm.ensurePersistentContainer("tab-a");
+    tm.onTabDeactivated("tab-a");
+    tm.onTabActivated("tab-a");
+
+    expect(adapter.getScrollSnapshot).toHaveBeenCalled();
+    expect(adapter.restoreScrollSnapshot).toHaveBeenCalledWith(snapshot);
+    tm.disposeAll(false);
+  });
+
+  it("页面输入框已聚焦时，onTabActivated 不会抢走输入焦点", () => {
+    const adapter: any = createAdapterStub();
+    createTerminalAdapterMock.mockReturnValue(adapter);
+
+    const tm = new TerminalManager(() => undefined, createHostPtyStub() as any, {});
+    tm.ensurePersistentContainer("tab-a");
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    tm.onTabActivated("tab-a");
+
+    expect(adapter.focus).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(input);
+    input.remove();
+    tm.disposeAll(false);
+  });
+
+  it("contenteditable 空属性元素已聚焦时，onTabActivated 不会抢走输入焦点", () => {
+    const adapter: any = createAdapterStub();
+    createTerminalAdapterMock.mockReturnValue(adapter);
+
+    const tm = new TerminalManager(() => undefined, createHostPtyStub() as any, {});
+    tm.ensurePersistentContainer("tab-editable");
+    const editable = document.createElement("div");
+    editable.setAttribute("contenteditable", "");
+    document.body.appendChild(editable);
+    editable.focus();
+    tm.onTabActivated("tab-editable");
+
+    expect(adapter.focus).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(editable);
+    editable.remove();
+    tm.disposeAll(false);
+  });
+
+  it("没有历史快照时，onTabActivated 仍会触发一次对齐修复", () => {
+    const adapter: any = createAdapterStub();
+    createTerminalAdapterMock.mockReturnValue(adapter);
+
+    const tm = new TerminalManager(() => undefined, createHostPtyStub() as any, {});
+    tm.ensurePersistentContainer("tab-b");
+    tm.onTabActivated("tab-b");
+
+    expect(adapter.restoreScrollSnapshot).toHaveBeenCalledWith(null);
+    tm.disposeAll(false);
+  });
+
+  it("scrollToTop 与 scrollToBottom 会透传到适配器", () => {
+    const adapter: any = createAdapterStub();
     createTerminalAdapterMock.mockReturnValue(adapter);
 
     const tm = new TerminalManager(() => undefined, createHostPtyStub() as any, {});
@@ -103,6 +124,26 @@ describe("TerminalManager（终端滚动快照）", () => {
 
     expect(adapter.scrollToTop).toHaveBeenCalledTimes(1);
     expect(adapter.scrollToBottom).toHaveBeenCalledTimes(1);
+    tm.disposeAll(false);
+  });
+
+  it("页面输入框已聚焦时，attachToHost 不会抢走输入焦点", () => {
+    const adapter: any = createAdapterStub();
+    createTerminalAdapterMock.mockReturnValue(adapter);
+
+    const tm = new TerminalManager(() => undefined, createHostPtyStub() as any, {});
+    const host = document.createElement("div");
+    const input = document.createElement("textarea");
+    document.body.appendChild(host);
+    document.body.appendChild(input);
+    input.focus();
+
+    tm.attachToHost("tab-d", host);
+
+    expect(adapter.focus).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(input);
+    host.remove();
+    input.remove();
     tm.disposeAll(false);
   });
 });


### PR DESCRIPTION
- 移除 xterm 挂载阶段的无条件聚焦，避免终端初始化打断页面输入。
- 在 TerminalManager 中集中判断当前页面可编辑控件焦点，终端切换与挂载时仅在安全时聚焦。
- 仅在终端实际获得焦点时向 PTY 注入 focus gain 事件，保持终端应用焦点状态一致。
- 补充滚动快照与焦点保护单测，覆盖 input、textarea 与 contenteditable 场景。