### PR TITLE
fix(git): 修复 Git 面板语言切换残留文案

### DIFF
--- a/web/src/features/git/changelist-ui.test.ts
+++ b/web/src/features/git/changelist-ui.test.ts
@@ -77,6 +77,14 @@ function createStatusSnapshot(): GitStatusSnapshot {
 describe("changelist ui helpers", () => {
   it("默认列表显示名应兼容历史英文名并输出本地化标签", () => {
     expect(resolveDisplayChangeListName({ id: "default", name: "default" })).toBe("默认");
+    expect(resolveDisplayChangeListName(
+      { id: "default", name: "默认" },
+      () => "Default",
+    )).toBe("Default");
+    expect(buildChangeListSelectOptions(
+      [{ id: "default", name: "默认", fileCount: 0, files: [] }],
+      () => "Default",
+    )).toEqual([{ value: "default", label: "Default" }]);
     expect(buildChangeListSelectOptions([
       { id: "default", name: "default", fileCount: 0, files: [] },
       { id: "feature", name: "功能开发", fileCount: 0, files: [] },

--- a/web/src/features/git/changelist-ui.ts
+++ b/web/src/features/git/changelist-ui.ts
@@ -10,6 +10,7 @@ import type {
 import { resolveGitText } from "./git-i18n";
 
 const DEFAULT_CHANGE_LIST_ID = "default";
+type GitChangeListTextResolver = (key: string, fallback: string, values?: Record<string, unknown>) => string;
 
 /**
  * 统一归一化 changelist 相关路径，避免不同分隔符导致映射键不一致。
@@ -19,23 +20,29 @@ function normalizeChangeListPath(pathText: string): string {
 }
 
 /**
- * 返回 changelist 的最终显示名；默认列表会兼容历史英文名并统一显示为中文标签。
+ * 返回 changelist 的最终显示名；默认列表会兼容内置中英文名并按当前语言显示。
  */
-export function resolveDisplayChangeListName(list: Pick<GitChangeList, "id" | "name">): string {
+export function resolveDisplayChangeListName(
+  list: Pick<GitChangeList, "id" | "name">,
+  resolveText: GitChangeListTextResolver = resolveGitText,
+): string {
   const id = String(list.id || "").trim();
   const name = String(list.name || "").trim();
-  if (id === DEFAULT_CHANGE_LIST_ID && (!name || /^default$/i.test(name)))
-    return resolveGitText("changelist.defaultName", "默认");
+  if (id === DEFAULT_CHANGE_LIST_ID && (!name || /^default$/i.test(name) || name === "默认"))
+    return resolveText("changelist.defaultName", "默认");
   return name || id;
 }
 
 /**
  * 构建目标 changelist 下拉项；显示层只暴露名称，值层始终绑定稳定 id。
  */
-export function buildChangeListSelectOptions(lists: GitChangeList[]): Array<{ value: string; label: string }> {
+export function buildChangeListSelectOptions(
+  lists: GitChangeList[],
+  resolveText: GitChangeListTextResolver = resolveGitText,
+): Array<{ value: string; label: string }> {
   return lists.map((list) => ({
     value: list.id,
-    label: resolveDisplayChangeListName(list),
+    label: resolveDisplayChangeListName(list, resolveText),
   }));
 }
 

--- a/web/src/features/git/commit-panel/changes-tree-view-model.test.ts
+++ b/web/src/features/git/commit-panel/changes-tree-view-model.test.ts
@@ -379,6 +379,33 @@ describe("commit panel tree view model", () => {
     expect(formatCommitTreeGroupSummary(summary, translate)).toBe("2 个目录，4 个文件");
   });
 
+  it("分组渲染摘要应使用传入翻译函数，避免英文界面残留中文数量单位", () => {
+    const translate = (key: string, fallback: string, values?: Record<string, unknown>): string => {
+      if (key === "commitTree.summary.zeroFiles") return "0 files";
+      if (key === "commitTree.summary.directoriesAndFiles")
+        return `${String(values?.directoryCount || 0)} directories, ${String(values?.fileCount || 0)} files`;
+      return resolveGitTextWith(
+        (_innerKey, options) => String(options.defaultValue || ""),
+        key,
+        fallback,
+        values,
+      );
+    };
+    const groups = buildChangeEntryGroups({
+      entries: [
+        { path: "src/a.ts", x: "?", y: "?", staged: false, unstaged: true, untracked: true, ignored: false, renamed: false, deleted: false, statusText: "Untracked", changeListId: "default" },
+        { path: "src/b.ts", x: "?", y: "?", staged: false, unstaged: true, untracked: true, ignored: false, renamed: false, deleted: false, statusText: "Untracked", changeListId: "default" },
+      ],
+      ignoredEntries: [],
+      changeLists: [{ id: "default", name: "Default" }],
+      options: { stagingAreaEnabled: false, changeListsEnabled: true },
+      translate,
+    });
+
+    expect(groups.find((group) => group.kind === "changelist")?.renderPayload?.countText).toBe("0 files");
+    expect(groups.find((group) => group.kind === "unversioned")?.renderPayload?.countText).toBe("1 directories, 2 files");
+  });
+
   it("helper node 状态应统一进入 view model，而不是由 UI 零散拼接", () => {
     expect(buildCommitTreeGroupState({
       updating: true,

--- a/web/src/features/git/commit-panel/changes-tree-view-model.ts
+++ b/web/src/features/git/commit-panel/changes-tree-view-model.ts
@@ -102,8 +102,8 @@ function resolveGroupSortWeight(group: Pick<ChangeEntryGroup, "kind" | "changeLi
 /**
  * 统一构建 group renderer/search/copy 共用的显示载荷。
  */
-function buildGroupRenderPayload(group: ChangeEntryGroup): CommitTreeRenderPayload {
-  const countText = group.summary ? formatCommitTreeGroupSummary(group.summary) : undefined;
+function buildGroupRenderPayload(group: ChangeEntryGroup, translate?: GitTranslate): CommitTreeRenderPayload {
+  const countText = group.summary ? formatCommitTreeGroupSummary(group.summary, translate) : undefined;
   return {
     textPresentation: group.label,
     countText,
@@ -164,6 +164,8 @@ export function formatCommitTreeGroupSummary(summary: CommitTreeGroupSummary | u
   if (!summary) return translate ? translate("commitTree.summary.zeroFiles", "0 个文件") : "0 个文件";
   const directoryCount = Math.max(0, Math.floor(summary.directoryCount));
   const fileCount = Math.max(0, Math.floor(summary.fileCount));
+  if (directoryCount <= 0 && fileCount <= 0)
+    return translate ? translate("commitTree.summary.zeroFiles", "0 个文件") : "0 个文件";
   if (directoryCount > 0 && fileCount > 0) {
     return translate
       ? translate("commitTree.summary.directoriesAndFiles", "{{directoryCount}} 个目录，{{fileCount}} 个文件", { directoryCount, fileCount })
@@ -231,7 +233,7 @@ export function buildChangeEntryGroups(args: BuildChangeEntryGroupsArgs): Change
       sortWeight: resolveGroupSortWeight(withSummary),
       stableId: withSummary.key,
       selectionFlags: buildGroupSelectionFlags(withSummary),
-      renderPayload: buildGroupRenderPayload(withSummary),
+      renderPayload: buildGroupRenderPayload(withSummary, gt),
       sourceKind: withSummary.sourceKind || "status",
       sourceId: withSummary.sourceId || withSummary.key,
       actionGroupId: withSummary.actionGroupId || COMMIT_TREE_ACTION_GROUPS.mainPopup,

--- a/web/src/features/git/commit-panel/checks.test.ts
+++ b/web/src/features/git/commit-panel/checks.test.ts
@@ -43,6 +43,24 @@ describe("commit checks", () => {
     ]);
   });
 
+  it("传入当前界面翻译函数时默认作者提示应使用对应语言", () => {
+    const checks = runBeforeCommitChecks({
+      message: "feat: test",
+      cleanupMessage: false,
+      explicitAuthor: "",
+      defaultAuthor: "Alice <alice@example.com>",
+      authorDate: "",
+      resolveText: (_key, _fallback, values) => `Default author: ${String(values?.author || "")}`,
+    });
+
+    expect(checks).toEqual([
+      expect.objectContaining({
+        id: "author-default",
+        message: "Default author: Alice <alice@example.com>",
+      }),
+    ]);
+  });
+
   it("可按调用场景隐藏空提交信息错误，仅保留其余检查结果", () => {
     const checks = runBeforeCommitChecks({
       message: "   ",

--- a/web/src/features/git/commit-panel/checks.ts
+++ b/web/src/features/git/commit-panel/checks.ts
@@ -6,6 +6,8 @@ import type { GitPostCommitPushResult } from "../types";
 import type { GitCommitIntent } from "./commit-workflow";
 import { resolveGitText } from "../git-i18n";
 
+type GitCommitCheckTextResolver = (key: string, fallback: string, values?: Record<string, unknown>) => string;
+
 export type GitCommitCheckLevel = "error" | "warning" | "info";
 
 export type GitCommitCheck = {
@@ -23,6 +25,7 @@ export type GitCommitBeforeCheckArgs = {
   defaultAuthor: string;
   authorDate: string;
   showEmptyMessageError?: boolean;
+  resolveText?: GitCommitCheckTextResolver;
 };
 
 export type GitCommitPostCheckArgs = {
@@ -48,6 +51,7 @@ export function normalizeCommitMessageForPolicy(message: string, cleanupMessage:
  */
 export function runBeforeCommitChecks(args: GitCommitBeforeCheckArgs): GitCommitCheck[] {
   const checks: GitCommitCheck[] = [];
+  const resolveText = args.resolveText || resolveGitText;
   const normalizedMessage = normalizeCommitMessageForPolicy(args.message, args.cleanupMessage);
   const explicitAuthor = String(args.explicitAuthor || "").trim();
   const defaultAuthor = String(args.defaultAuthor || "").trim();
@@ -59,8 +63,8 @@ export function runBeforeCommitChecks(args: GitCommitBeforeCheckArgs): GitCommit
       level: "error",
       blocking: true,
       message: args.cleanupMessage
-        ? resolveGitText("commit.checks.emptyAfterCleanup", "清理提交消息后内容为空，请输入有效的提交信息。")
-        : resolveGitText("commit.checks.emptyMessage", "提交信息不能为空。"),
+        ? resolveText("commit.checks.emptyAfterCleanup", "清理提交消息后内容为空，请输入有效的提交信息。")
+        : resolveText("commit.checks.emptyMessage", "提交信息不能为空。"),
     });
   }
 
@@ -69,7 +73,7 @@ export function runBeforeCommitChecks(args: GitCommitBeforeCheckArgs): GitCommit
       id: "author-date-invalid",
       level: "error",
       blocking: true,
-      message: resolveGitText("commit.checks.authorDateInvalid", "作者时间格式无效，请使用有效的日期时间。"),
+      message: resolveText("commit.checks.authorDateInvalid", "作者时间格式无效，请使用有效的日期时间。"),
     });
   }
 
@@ -78,14 +82,14 @@ export function runBeforeCommitChecks(args: GitCommitBeforeCheckArgs): GitCommit
       id: "author-missing",
       level: "error",
       blocking: true,
-      message: resolveGitText("commit.checks.authorMissing", "未配置默认作者，请先设置 Git user.name / user.email，或在提交选项里填写作者。"),
+      message: resolveText("commit.checks.authorMissing", "未配置默认作者，请先设置 Git user.name / user.email，或在提交选项里填写作者。"),
     });
   } else if (!explicitAuthor && defaultAuthor) {
     checks.push({
       id: "author-default",
       level: "info",
       blocking: false,
-      message: resolveGitText("commit.checks.defaultAuthor", "默认作者：{{author}}", { author: defaultAuthor }),
+      message: resolveText("commit.checks.defaultAuthor", "默认作者：{{author}}", { author: defaultAuthor }),
     });
   }
 

--- a/web/src/features/git/commit-panel/workflow-handler.ts
+++ b/web/src/features/git/commit-panel/workflow-handler.ts
@@ -8,6 +8,8 @@ import type { CommitWorkflowPayload, GitCommitIntent } from "./commit-workflow";
 import { buildPostCommitChecks, findBlockingCommitCheck, runBeforeCommitChecks, type GitCommitCheck } from "./checks";
 import { shouldPersistLastCommitMessage } from "./message-policy";
 
+type GitCommitWorkflowTextResolver = (key: string, fallback: string, values?: Record<string, unknown>) => string;
+
 export type PrepareGitCommitWorkflowArgs = {
   message: string;
   intent: GitCommitIntent;
@@ -16,6 +18,7 @@ export type PrepareGitCommitWorkflowArgs = {
   defaultAuthor: string;
   authorDate: string;
   entries?: GitStatusEntry[];
+  resolveText?: GitCommitWorkflowTextResolver;
   resolvePayloadAsync: (args: {
     message: string;
     intent: GitCommitIntent;
@@ -45,6 +48,7 @@ export async function prepareGitCommitWorkflowAsync(
     explicitAuthor: args.explicitAuthor,
     defaultAuthor: args.defaultAuthor,
     authorDate: args.authorDate,
+    resolveText: args.resolveText,
   });
   const blockingCheck = findBlockingCommitCheck(checks);
   if (blockingCheck) {
@@ -73,7 +77,7 @@ export async function prepareGitCommitWorkflowAsync(
   if (!String(payloadRes.payload.message || "").trim()) {
     return {
       ok: false,
-      error: resolveGitText("commit.checks.emptyMessage", "提交信息不能为空。"),
+      error: (args.resolveText || resolveGitText)("commit.checks.emptyMessage", "提交信息不能为空。"),
       checks,
       blockingCheck: null,
     };

--- a/web/src/features/git/git-workbench.tsx
+++ b/web/src/features/git/git-workbench.tsx
@@ -3856,8 +3856,9 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
       defaultAuthor: defaultCommitAuthor,
       authorDate: sanitized.authorDate,
       showEmptyMessageError: false,
+      resolveText: gt,
     });
-  }, [commitAdvancedOptionsState, commitMessage, defaultCommitAuthor]);
+  }, [commitAdvancedOptionsState, commitMessage, defaultCommitAuthor, gt]);
   const blockingCommitCheck = useMemo<GitCommitCheck | null>(() => {
     return findBlockingCommitCheck(commitChecks);
   }, [commitChecks]);
@@ -4809,9 +4810,9 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   const displayChangeLists = useMemo(() => {
     return (status?.changeLists?.lists || []).map((one) => ({
       ...one,
-      name: resolveDisplayChangeListName(one),
+      name: resolveDisplayChangeListName(one, gt),
     }));
-  }, [status?.changeLists?.lists]);
+  }, [gt, status?.changeLists?.lists]);
   const activeChangeListId = useMemo<string>(() => {
     return String(status?.changeLists?.activeListId || "").trim();
   }, [status?.changeLists?.activeListId]);
@@ -11873,6 +11874,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
       defaultAuthor: defaultCommitAuthor,
       authorDate: sanitizedOptions.authorDate,
       entries: args.entries,
+      resolveText: gt,
       resolvePayloadAsync: resolveCommitWorkflowPayloadAsync,
     });
     if (!workflowRes.ok) {
@@ -11981,6 +11983,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     defaultCommitAuthor,
     ensureMergePrecheckConfirmedAsync,
     finalizeGitNotice,
+    gt,
     openConflictResolverDialog,
     openPushAfterCommitAsync,
     refreshAllAsync,
@@ -12629,7 +12632,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
       if (action === "move") {
         if (!selectedEntryPaths.length) return;
         const lists = resolveMoveDialogLists(displayChangeLists, actionSelectedEntries);
-        const options = buildChangeListSelectOptions(lists);
+        const options = buildChangeListSelectOptions(lists, gt);
         const form = await openActionDialogAsync({
           title: gt("actionDialogs.moveToChangelist.title", "移动到变更列表"),
           description: gt("actionDialogs.moveToChangelist.description", "选择目标变更列表"),
@@ -12914,7 +12917,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
               key: "targetListId",
               label: gt("actionDialogs.deleteChangeList.targetLabel", "目标列表"),
               type: "select",
-              options: buildChangeListSelectOptions(candidates),
+              options: buildChangeListSelectOptions(candidates, gt),
               required: true,
             }],
             defaults: { targetListId: candidates[0]?.id || "" },

--- a/web/src/locales/en/git.json
+++ b/web/src/locales/en/git.json
@@ -2695,6 +2695,12 @@
       "frozen": "Frozen",
       "outdatedFiles": "{{count}} outdated files"
     },
+    "summary": {
+      "zeroFiles": "0 files",
+      "directoriesAndFiles": "{{directoryCount}} directories, {{fileCount}} files",
+      "directoriesOnly": "{{directoryCount}} directories",
+      "filesOnly": "{{fileCount}} files"
+    },
     "conflictActions": {
       "unstage": {
         "icon": "Reset",

--- a/web/src/locales/zh/git.json
+++ b/web/src/locales/zh/git.json
@@ -2578,6 +2578,12 @@
       "frozen": "冻结",
       "outdatedFiles": "{{count}} 个过期文件"
     },
+    "summary": {
+      "zeroFiles": "0 个文件",
+      "directoriesAndFiles": "{{directoryCount}} 个目录，{{fileCount}} 个文件",
+      "directoriesOnly": "{{directoryCount}} 个目录",
+      "filesOnly": "{{fileCount}} 个文件"
+    },
     "conflictActions": {
       "unstage": {
         "icon": "重置",


### PR DESCRIPTION
将 Git 提交面板中提前缓存的显示文案改为使用当前界面的翻译函数，
避免切换到英文界面后仍残留中文默认列表名、作者提示和数量单位。

- changelist 默认名称和下拉选项统一按当前语言生成
- 提交检查与提交工作流错误提示支持传入当前翻译函数
- 提交树目录/文件数量摘要接入 i18n 文案并补齐中英文键
- 补充相关单测覆盖语言切换后的显示结果