### PR TITLE
fix(git): 避免 Git 视图在大日志场景卡死

### DIFF
--- a/electron/git/exec.ts
+++ b/electron/git/exec.ts
@@ -41,6 +41,8 @@ export type GitExecOptions = {
   stdin?: string | Buffer;
   /** 是否允许超过常规 30 分钟上限；仅用于 worktree 创建/清理等明确的大任务。 */
   allowLongTimeout?: boolean;
+  /** 可选取消信号；触发后会尽快终止子进程并返回 aborted。 */
+  signal?: AbortSignal;
 };
 
 /**
@@ -84,6 +86,7 @@ export async function execGitAsync(opts: GitExecOptions): Promise<GitExecResult>
     envPatch: opts?.envPatch,
     stdin: opts?.stdin,
     allowLongTimeout: opts?.allowLongTimeout,
+    signal: opts?.signal,
   });
 }
 
@@ -92,8 +95,6 @@ export type GitSpawnOptions = GitExecOptions & {
   onStdout?: (chunk: string) => void;
   /** stderr 数据到达时回调（用于流式日志展示）。 */
   onStderr?: (chunk: string) => void;
-  /** 可选取消信号；触发后会尽快终止子进程并返回 aborted。 */
-  signal?: AbortSignal;
 };
 
 export type GitSpawnStdoutToFileOptions = GitExecOptions & {

--- a/electron/git/featureService.diff-open.test.ts
+++ b/electron/git/featureService.diff-open.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it } from "vitest";
 import { execGitAsync } from "./exec";
 import { dispatchGitFeatureAction } from "./featureService";
 
+const GIT_INTEGRATION_TEST_TIMEOUT_MS = 20_000;
+
 type RepoFixture = {
   repo: string;
   userDataPath: string;
@@ -33,8 +35,8 @@ async function createRepoFixture(prefix: string): Promise<RepoFixture> {
     repo,
     userDataPath,
     async cleanup(): Promise<void> {
-      try { await fsp.rm(repo, { recursive: true, force: true }); } catch {}
-      try { await fsp.rm(userDataPath, { recursive: true, force: true }); } catch {}
+      try { await fsp.rm(repo, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }); } catch {}
+      try { await fsp.rm(userDataPath, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }); } catch {}
     },
   };
 }
@@ -79,7 +81,7 @@ describe("featureService diff.openPath", () => {
     } finally {
       await fixture.cleanup();
     }
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("revisionToWorking 模式应直接返回当前工作区文件路径", async () => {
     const fixture = await createRepoFixture("codexflow-diff-open-working");
@@ -106,7 +108,7 @@ describe("featureService diff.openPath", () => {
     } finally {
       await fixture.cleanup();
     }
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("revisionToRevision 模式在右侧版本缺失时应回退到左侧修订文件", async () => {
     const fixture = await createRepoFixture("codexflow-diff-open-revision-fallback");
@@ -140,5 +142,5 @@ describe("featureService diff.openPath", () => {
     } finally {
       await fixture.cleanup();
     }
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 });

--- a/electron/git/featureService.ts
+++ b/electron/git/featureService.ts
@@ -562,6 +562,7 @@ async function runGitExecAsync(
     argv: normalizedArgv,
     timeoutMs,
     envPatch,
+    signal: ctx.abortSignal,
   });
   gitConsoleStore.appendCompletedEntry({
     cwd,
@@ -662,6 +663,7 @@ async function runGitExecQuietAsync(
     argv: buildNormalizedGitArgv(argv),
     timeoutMs,
     envPatch,
+    signal: ctx.abortSignal,
   });
 }
 

--- a/electron/git/shelf/manager.test.ts
+++ b/electron/git/shelf/manager.test.ts
@@ -8,6 +8,7 @@ import { ShelveChangesManager } from "./manager";
 import type { GitShelfManagerRuntime } from "./types";
 import { VcsShelveChangesSaver } from "./vcsShelveChangesSaver";
 
+const GIT_INTEGRATION_TEST_TIMEOUT_MS = 20_000;
 const cleanupTargets = new Set<string>();
 
 /**
@@ -94,7 +95,7 @@ afterEach(async () => {
   await Promise.all(
     Array.from(cleanupTargets.values()).map(async (target) => {
       try {
-        await fsp.rm(target, { recursive: true, force: true });
+        await fsp.rm(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       } catch {}
       cleanupTargets.delete(target);
     }),
@@ -125,7 +126,7 @@ describe("统一搁置平台", () => {
     expect(restoreRes.ok).toBe(true);
     expect(await fsp.readFile(path.join(ctx.repoRoot, "tracked.txt"), "utf8")).toContain("manual");
     expect(await manager.listShelvedChangeListsAsync()).toHaveLength(0);
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("system shelf 应支持未跟踪目录的保存与恢复，避免把目录误当文件复制", async () => {
     const ctx = await initRepoAsync("untracked-directory");
@@ -146,7 +147,7 @@ describe("统一搁置平台", () => {
 
     await saver.load();
     expect(await fsp.readFile(untrackedFilePath, "utf8")).toBe("demo\n");
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("手动搁置与系统搁置应共用同一平台层存储，并可按 source 区分读取", async () => {
     const ctx = await initRepoAsync("shared-platform");
@@ -167,7 +168,7 @@ describe("统一搁置平台", () => {
     expect(await manager.listShelvedChangeListsAsync({ source: "manual" })).toHaveLength(1);
     expect(await manager.listShelvedChangeListsAsync({ source: "system" })).toHaveLength(1);
     expect(manager.getShelfResourcesDirectory()).toContain(path.join("git", "shelves"));
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("手动搁置应只处理当前选择或当前更改列表，而不是整仓改动", async () => {
     const ctx = await initRepoAsync("manual-selection");
@@ -231,7 +232,7 @@ describe("统一搁置平台", () => {
     expect((await fsp.readFile(path.join(ctx.repoRoot, "feature.txt"), "utf8")).replace(/\r\n/g, "\n")).toContain("feature bugfix");
     expect(changeListManager.getAffectedLists([{ path: "tracked.txt" }])[0]?.getId()).toBe(featureList.getId());
     expect(changeListManager.getAffectedLists([{ path: "feature.txt" }])[0]?.getId()).toBe(bugfixList.getId());
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("应按 changelist 维度生成 system shelf，并在 rollback / unshelve 后恢复文件归属", async () => {
     const ctx = await initRepoAsync("changelist-flow");
@@ -269,7 +270,7 @@ describe("统一搁置平台", () => {
     expect(await fsp.readFile(path.join(ctx.repoRoot, "feature.txt"), "utf8")).toContain("feature bugfix");
     expect(changeListManager.getAffectedLists([{ path: "tracked.txt" }])[0]?.getId()).toBe(featureList.getId());
     expect(changeListManager.getAffectedLists([{ path: "feature.txt" }])[0]?.getId()).toBe(bugfixList.getId());
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("partial unshelve 应只恢复选中文件，并在 remove-applied 策略下保留剩余 shelf 内容", async () => {
     const ctx = await initRepoAsync("partial-unshelve");
@@ -334,7 +335,7 @@ describe("统一搁置平台", () => {
     expect(restoreRemainingRes.ok).toBe(true);
     expect((await fsp.readFile(path.join(ctx.repoRoot, "feature.txt"), "utf8")).replace(/\r\n/g, "\n")).toContain("feature partial");
     expect(await manager.listShelvedChangeListsAsync({ source: "manual" })).toHaveLength(0);
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("应支持重命名、回收、恢复归档与彻底删除，并通过 includeHidden 暴露隐藏状态", async () => {
     const ctx = await initRepoAsync("archive-flow");
@@ -398,7 +399,7 @@ describe("统一搁置平台", () => {
       "removed",
     ]);
     expect(events.at(-1)).toEqual(expect.objectContaining({ ref, type: "removed" }));
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("应支持导入外部 patch 文件，并在统一 shelf 平台中恢复", async () => {
     const ctx = await initRepoAsync("import-patch");
@@ -424,5 +425,5 @@ describe("统一搁置平台", () => {
     expect(restoreRes.ok).toBe(true);
     expect((await fsp.readFile(path.join(ctx.repoRoot, "tracked.txt"), "utf8")).replace(/\r\n/g, "\n")).toBe("base\nimported line\n");
     expect(await manager.listShelvedChangeListsAsync({ source: "manual" })).toHaveLength(0);
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 });

--- a/electron/git/update/changeSaver.test.ts
+++ b/electron/git/update/changeSaver.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { execGitAsync, spawnGitStdoutToFileAsync, type GitExecResult } from "../exec";
 import { createWorkspaceChangesSaver } from "./preservingProcess";
 
+const GIT_INTEGRATION_TEST_TIMEOUT_MS = 20_000;
 const cleanupTargets = new Set<string>();
 
 /**
@@ -53,7 +54,7 @@ afterEach(async () => {
   await Promise.all(
     Array.from(cleanupTargets.values()).map(async (target) => {
       try {
-        await fsp.rm(target, { recursive: true, force: true });
+        await fsp.rm(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       } catch {}
       cleanupTargets.delete(target);
     }),
@@ -126,7 +127,7 @@ describe("git change saver", () => {
     expect(await readFileAsync(repoB, "untracked-b.txt")).toContain("untracked b");
     expect((await gitMustAsync(repoA, ["stash", "list"])).trim()).toBe("");
     expect((await gitMustAsync(repoB, ["stash", "list"])).trim()).toBe("");
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("shelve saver 应通过 shelf view manager 暴露查看动作，并保留 system shelf 语义", async () => {
     const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "codexflow-change-saver-shelve-"));
@@ -183,5 +184,5 @@ describe("git change saver", () => {
         label: "查看搁置记录",
       }),
     }));
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 });

--- a/electron/git/update/config.test.ts
+++ b/electron/git/update/config.test.ts
@@ -12,6 +12,7 @@ type ConfigTestContext = {
   cleanupPaths: string[];
 };
 
+const GIT_INTEGRATION_TEST_TIMEOUT_MS = 25_000;
 const cleanupQueue = new Set<string>();
 
 /**
@@ -76,7 +77,7 @@ afterEach(async () => {
   const cleanupPaths = Array.from(cleanupQueue);
   cleanupQueue.clear();
   await Promise.all(cleanupPaths.map(async (target) => {
-    await fsp.rm(target, { recursive: true, force: true });
+    await fsp.rm(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   }));
 });
 
@@ -103,7 +104,7 @@ describe("update config options", () => {
     expect(snapshot.methodResolution.saveChangesPolicy).toBe("shelve");
     expect(snapshot.scopePreview.roots).toHaveLength(1);
     expect(snapshot.scopePreview.roots[0]?.source).toBe("current");
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("历史 reset 配置在读取时应降级并回写为 Merge", async () => {
     const ctx = await createConfigTestContextAsync("legacy-reset");
@@ -135,7 +136,7 @@ describe("update config options", () => {
       mode: "merge",
       options: [],
     });
-  }, 10_000);
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("历史 branch-default 配置在读取时应降级并回写为 Merge", async () => {
     const ctx = await createConfigTestContextAsync("legacy-branch-default");
@@ -162,7 +163,7 @@ describe("update config options", () => {
       mode: "merge",
       options: [],
     });
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("多仓默认范围应返回关联仓、嵌套仓与默认跳过结果预览", async () => {
     const ctx = await createConfigTestContextAsync("scope-preview");
@@ -222,5 +223,5 @@ describe("update config options", () => {
     expect(snapshot.scopePreview.roots.some((root) => root.repoRoot === linkedRepo && root.source === "linked" && !root.included)).toBe(true);
     expect(snapshot.scopePreview.roots.some((root) => root.repoRoot === nestedRepo && root.source === "nested" && root.included)).toBe(true);
     expect(snapshot.scopePreview.skippedRoots.some((root) => root.repoRoot === linkedRepo && root.reasonCode === "requested")).toBe(true);
-  }, 10_000);
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 });

--- a/electron/git/update/shelf-store.test.ts
+++ b/electron/git/update/shelf-store.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../shelf/system";
 import type { GitShelfManagerRuntime } from "../shelf/types";
 
+const GIT_INTEGRATION_TEST_TIMEOUT_MS = 20_000;
 const cleanupTargets = new Set<string>();
 
 /**
@@ -156,7 +157,7 @@ afterEach(async () => {
   await Promise.all(
     Array.from(cleanupTargets.values()).map(async (target) => {
       try {
-        await fsp.rm(target, { recursive: true, force: true });
+        await fsp.rm(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       } catch {}
       cleanupTargets.delete(target);
     }),
@@ -189,7 +190,7 @@ describe("system shelf 平台", () => {
     expect(await fsp.readFile(path.join(firstRepo.repoRoot, "tracked.txt"), "utf8")).toContain("first");
     expect(await listSystemShelvesAsync(firstRuntime)).toHaveLength(0);
     expect(await listSystemShelvesAsync(secondRuntime)).toHaveLength(1);
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("删除记录时只应删除目标 ref 对应目录", async () => {
     const ctx = await initRepoAsync("delete-one");
@@ -210,7 +211,7 @@ describe("system shelf 平台", () => {
     const remaining = await listSystemShelvesAsync(runtime);
     expect(remaining).toHaveLength(1);
     expect(remaining[0]!.ref).toBe(items[1]!.ref);
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("大补丁场景应通过流式写文件完成搁置，而不是触发 maxBuffer", async () => {
     const ctx = await initRepoAsync("large-patch");
@@ -232,7 +233,7 @@ describe("system shelf 平台", () => {
     expect(items).toHaveLength(1);
     expect(items[0]?.hasIndexPatch).toBe(true);
     expect(items[0]?.hasWorktreePatch).toBe(true);
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("不应再调用整仓 clean；即使注入 clean 失败，保存仍应按新平台语义成功", async () => {
     const ctx = await initRepoAsync("orphaned-clean");
@@ -250,7 +251,7 @@ describe("system shelf 平台", () => {
     const hiddenItems = await listSystemShelvesAsync(runtime, { includeHidden: true });
     expect(hiddenItems).toHaveLength(1);
     expect(hiddenItems[0]?.state).toBe("saved");
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("恢复 index 成功但 worktree 失败时应标记 restore-failed，并允许后续重试", async () => {
     const ctx = await initRepoAsync("retry");
@@ -280,7 +281,7 @@ describe("system shelf 平台", () => {
     expect(retryRes.ok).toBe(true);
     expect(await fsp.readFile(path.join(ctx.repoRoot, "tracked.txt"), "utf8")).toContain("unstaged");
     expect(await listSystemShelvesAsync(saveRuntime)).toHaveLength(0);
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("恢复后应还原原始 changelist 映射", async () => {
     const ctx = await initRepoAsync("changelist-restore");
@@ -316,7 +317,7 @@ describe("system shelf 平台", () => {
     expect(restoredRepo.activeListId).toBe("feature-list");
     expect(restoredRepo.fileToList["tracked.txt"]).toBe("feature-list");
     expect(restoredRepo.lists.some((item) => item.id === "feature-list" && item.name === "功能列表")).toBe(true);
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("恢复未跟踪文件时，若目标路径已存在且内容一致，应视为已恢复成功", async () => {
     const ctx = await initRepoAsync("untracked-same-content");
@@ -337,7 +338,7 @@ describe("system shelf 平台", () => {
     expect(restoreRes.ok).toBe(true);
     expect(await fsp.readFile(path.join(ctx.repoRoot, "same.txt"), "utf8")).toBe("same content\n");
     expect(await listSystemShelvesAsync(runtime)).toHaveLength(0);
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 
   it("恢复未跟踪文件时，若目标路径已存在且内容不同，应继续保留 restore-failed", async () => {
     const ctx = await initRepoAsync("untracked-different-content");
@@ -361,5 +362,5 @@ describe("system shelf 平台", () => {
     const hiddenItems = await listSystemShelvesAsync(runtime, { includeHidden: true });
     expect(hiddenItems).toHaveLength(1);
     expect(hiddenItems[0]?.state).toBe("restore-failed");
-  });
+  }, GIT_INTEGRATION_TEST_TIMEOUT_MS);
 });

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -286,6 +286,7 @@ type RendererRecoveryState = {
   unresponsiveTimer: ReturnType<typeof setTimeout> | null;
   recoverInFlight: boolean;
 };
+type MainTaskPriority = "ui" | "git-read" | "git-write" | "background";
 
 const TAB_DRAG_PREVIEW_MIN_WIDTH = 144;
 const TAB_DRAG_PREVIEW_MAX_WIDTH = 228;
@@ -296,11 +297,137 @@ const GIT_WORKBENCH_SNAPSHOT_MAX_ENTRIES = 3;
 const GIT_WORKBENCH_SNAPSHOT_IDLE_TTL_MS = 2 * 60 * 60 * 1000;
 const GIT_WORKBENCH_SNAPSHOT_TRIM_INTERVAL_MS = 5 * 60 * 1000;
 const GIT_WORKBENCH_SNAPSHOT_DELETE_TOMBSTONE_MS = 30 * 1000;
+const GIT_FEATURE_READ_CONCURRENCY = 3;
+const GIT_FEATURE_READ_QUEUE_LIMIT = 24;
+const GIT_FEATURE_READ_QUEUE_TIMEOUT_MS = 15_000;
 const tabDragPreviewWindowsById = new Map<string, TabDragPreviewWindowEntry>();
 const tabDragPreviewWindowIdByOwner = new Map<string, string>();
 const gitWorkbenchSnapshotsByKey = new Map<string, GitWorkbenchSnapshotEntry>();
 const gitWorkbenchSnapshotDeletedTabIds = new Map<string, number>();
+const gitFeatureReadActions = new Set<string>([
+  "branch.popup",
+  "changes.conflictMerge.get",
+  "changes.conflictResolver.get",
+  "changes.ignoreTargets",
+  "console.get",
+  "diff.get",
+  "diff.openPath",
+  "diff.patch",
+  "log.availability",
+  "log.details",
+  "log.details.availability",
+  "log.get",
+  "log.messageDraft",
+  "log.rebasePlan.get",
+  "log.resolveFileHistoryPath",
+  "push.preview",
+  "repo.detect",
+  "shelf.list",
+  "stash.list",
+  "status.get",
+  "status.getIgnored",
+  "update.options.get",
+  "update.trackedBranchPreview",
+  "worktree.list",
+]);
+let gitFeatureReadRunning = 0;
+const gitFeatureReadQueue: Array<{
+  action: string;
+  requestId: number;
+  enqueuedAt: number;
+  timeout: ReturnType<typeof setTimeout>;
+  reject: (error: Error) => void;
+  run: () => void;
+}> = [];
 let cachedAppBrandIconDataUrl: string | null | undefined;
+
+/**
+ * 判定 Git 动作所属任务优先级，用于把高频读取限制在后台队列里。
+ */
+function resolveGitFeatureTaskPriority(action: string): MainTaskPriority {
+  return gitFeatureReadActions.has(action) ? "git-read" : "git-write";
+}
+
+/**
+ * 调度排队中的 Git 读取任务，限制并发，避免快速切换页面时堆出大量 Git 子进程。
+ */
+function pumpGitFeatureReadQueue(): void {
+  while (gitFeatureReadRunning < GIT_FEATURE_READ_CONCURRENCY && gitFeatureReadQueue.length > 0) {
+    const item = gitFeatureReadQueue.shift();
+    if (!item) continue;
+    gitFeatureReadRunning += 1;
+    item.run();
+  }
+}
+
+/**
+ * 取消尚未开始的 Git 读取任务，避免过期请求稍后才启动。
+ */
+function cancelQueuedGitFeatureReadRequest(requestId: number, reason?: string): boolean {
+  const normalizedRequestId = Math.max(0, Math.floor(Number(requestId) || 0));
+  if (!normalizedRequestId) return false;
+  const index = gitFeatureReadQueue.findIndex((item) => item.requestId === normalizedRequestId);
+  if (index < 0) return false;
+  const [item] = gitFeatureReadQueue.splice(index, 1);
+  if (!item) return false;
+  try { clearTimeout(item.timeout); } catch {}
+  item.reject(new Error(String(reason || "").trim() || "Git 读取请求已取消"));
+  return true;
+}
+
+/**
+ * 在主进程侧限制 Git 读取请求并发；写操作不排队，保证提交/推送等用户命令不被读任务拖住。
+ */
+async function runGitFeatureWithScheduler<T>(action: string, requestId: number, task: () => Promise<T>): Promise<T> {
+  if (resolveGitFeatureTaskPriority(action) !== "git-read")
+    return await task();
+  if (gitFeatureReadRunning < GIT_FEATURE_READ_CONCURRENCY) {
+    gitFeatureReadRunning += 1;
+    try {
+      return await task();
+    } finally {
+      gitFeatureReadRunning = Math.max(0, gitFeatureReadRunning - 1);
+      pumpGitFeatureReadQueue();
+    }
+  }
+  if (gitFeatureReadQueue.length >= GIT_FEATURE_READ_QUEUE_LIMIT) {
+    const dropped = gitFeatureReadQueue.shift();
+    if (dropped) {
+      try { clearTimeout(dropped.timeout); } catch {}
+      dropped.reject(new Error("Git 读取请求已被更新的请求替换"));
+    }
+    logWhiteScreenDiagnostic(`[git.scheduler] drop stale read action=${clampLogValue(dropped?.action || "", 80)} queue=${gitFeatureReadQueue.length}`);
+  }
+  return await new Promise<T>((resolve, reject) => {
+    let started = false;
+    const timeout = setTimeout(() => {
+      if (started) return;
+      const index = gitFeatureReadQueue.findIndex((item) => item.run === run);
+      if (index >= 0) gitFeatureReadQueue.splice(index, 1);
+      reject(new Error("Git 读取请求排队超时，请稍后重试"));
+    }, GIT_FEATURE_READ_QUEUE_TIMEOUT_MS);
+    try { (timeout as any).unref?.(); } catch {}
+    const run = () => {
+      started = true;
+      clearTimeout(timeout);
+      void task()
+        .then(resolve, reject)
+        .finally(() => {
+          gitFeatureReadRunning = Math.max(0, gitFeatureReadRunning - 1);
+          pumpGitFeatureReadQueue();
+        });
+    };
+    gitFeatureReadQueue.push({
+      action,
+      requestId: Math.max(0, Math.floor(Number(requestId) || 0)),
+      enqueuedAt: Date.now(),
+      timeout,
+      reject,
+      run,
+    });
+    pumpGitFeatureReadQueue();
+  });
+}
 
 /**
  * 构造 Git 工作台热会话缓存键，按 tab 与仓库根隔离跨窗口快照。
@@ -695,8 +822,9 @@ type GpuRecoverySnapshot = {
 
 const RENDERER_RECOVERY_WINDOW_MS = 120_000;
 const RENDERER_RECOVERY_MAX_RELOADS = 2;
-const RENDERER_UNRESPONSIVE_TIMEOUT_MS = 12_000;
+const RENDERER_UNRESPONSIVE_TIMEOUT_MS = 7_000;
 const RENDERER_RECOVERY_IN_FLIGHT_TIMEOUT_MS = 15_000;
+const RENDERER_LIGHT_MODE_DURATION_MS = 60_000;
 
 const GPU_RECOVERY_FILE = "gpu-recovery.json";
 const GPU_RECOVERY_WINDOW_MS = 30 * 60_000;
@@ -1679,6 +1807,21 @@ function clearRendererRecoveryState(win: BrowserWindow): void {
 }
 
 /**
+ * 通知渲染层短时降级重任务，先尝试让页面恢复响应，再进入 reload/recreate 兜底。
+ */
+function requestRendererLightMode(win: BrowserWindow, reason: string): void {
+  try {
+    if (win.isDestroyed()) return;
+    const wc = win.webContents;
+    if (!wc || wc.isDestroyed()) return;
+    wc.send("renderer.lightMode", {
+      reason: clampLogValue(reason, 160),
+      durationMs: RENDERER_LIGHT_MODE_DURATION_MS,
+    });
+  } catch {}
+}
+
+/**
  * 中文说明：裁剪恢复尝试记录，仅保留最近时间窗内的数据。
  */
 function pruneRendererRecoveryAttempts(state: RendererRecoveryState, now: number): void {
@@ -1800,6 +1943,7 @@ function installMainWindowSelfHealHooks(win: BrowserWindow): void {
     });
     wc.on("unresponsive", () => {
       logWhiteScreenDiagnostic("[WC] unresponsive");
+      requestRendererLightMode(win, "webContents.unresponsive");
       const state = getRendererRecoveryState(win);
       if (state.unresponsiveTimer) return;
       state.unresponsiveTimer = setTimeout(() => {
@@ -3507,17 +3651,33 @@ ipcMain.handle("gitFeature.call", async (event, args: { action: string; payload?
     if (!action) return { ok: false, error: "missing action" };
     const cfg = settings.getSettings() as any;
     const gitPath = String(cfg?.gitWorktree?.gitPath || "").trim() || "git";
-    return await dispatchGitFeatureAction({
-      action,
-      payload: args?.payload,
-      gitPath,
-      userDataPath: app.getPath("userData"),
-      requestId: Math.max(0, Math.floor(Number(args?.requestId) || 0)),
-      emitProgress: (payload) => {
-        try {
-          event.sender.send("gitFeature.progress", payload);
-        } catch {}
-      },
+    const requestId = Math.max(0, Math.floor(Number(args?.requestId) || 0));
+    if (action === "request.cancel") {
+      const targetRequestId = Math.max(0, Math.floor(Number(args?.payload?.targetRequestId ?? args?.payload?.requestId) || 0));
+      const queuedCancelled = cancelQueuedGitFeatureReadRequest(targetRequestId, String(args?.payload?.reason || "").trim());
+      if (queuedCancelled) {
+        return {
+          ok: true,
+          data: {
+            targetRequestId,
+            cancelled: true,
+          },
+        };
+      }
+    }
+    return await runGitFeatureWithScheduler(action, requestId, async () => {
+      return await dispatchGitFeatureAction({
+        action,
+        payload: args?.payload,
+        gitPath,
+        userDataPath: app.getPath("userData"),
+        requestId,
+        emitProgress: (payload) => {
+          try {
+            event.sender.send("gitFeature.progress", payload);
+          } catch {}
+        },
+      });
     });
   } catch (e: any) {
     return { ok: false, error: String(e?.message || e) };

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -12,6 +12,8 @@ type PtyDataPayload = { id: string; data: string };
 type PtyExitPayload = { id: string; exitCode?: number };
 
 const PRELOAD_SLOW_INVOKE_WARN_MS = 700;
+const RENDERER_LIGHT_MODE_DOM_EVENT = "cf:renderer-light-mode";
+const SYM_RENDERER_LIGHT_MODE_LISTENER = Symbol.for("codexflow:rendererLightModeListener");
 
 /**
  * 读取单调时间，用于计算渲染侧 IPC 等待耗时。
@@ -59,6 +61,30 @@ function installInvokeTimingDiagnostics(): void {
 }
 
 installInvokeTimingDiagnostics();
+
+/**
+ * 安装渲染轻量模式桥接器，把主进程恢复策略转为页面内事件。
+ */
+function ensureRendererLightModeBridge(): void {
+  try {
+    const g: any = process as any;
+    if (g[SYM_RENDERER_LIGHT_MODE_LISTENER]) return;
+    const listener = (_: unknown, payload: { reason?: string; durationMs?: number }) => {
+      try {
+        window.dispatchEvent(new CustomEvent(RENDERER_LIGHT_MODE_DOM_EVENT, {
+          detail: {
+            reason: String(payload?.reason || "").trim(),
+            durationMs: Math.max(5_000, Math.min(120_000, Number(payload?.durationMs) || 60_000)),
+          },
+        }));
+      } catch {}
+    };
+    g[SYM_RENDERER_LIGHT_MODE_LISTENER] = listener;
+    ipcRenderer.on("renderer.lightMode", listener);
+  } catch {}
+}
+
+ensureRendererLightModeBridge();
 
 // ---- PTY 事件分发（关键性能修复）----
 //

--- a/electron/projects.fast.ts
+++ b/electron/projects.fast.ts
@@ -216,13 +216,10 @@ function hasCustomDirRecord(p: Project | null | undefined): boolean {
 
 // 防抖：短时间内的并发调用合并为一次
 let __scanPromise: Promise<Project[]> | null = null;
-let __scanStamp = 0;
 export async function scanProjectsAsync(_roots?: string[], verbose = false): Promise<Project[]> {
-  const now = Date.now();
-  if (__scanPromise && (now - __scanStamp) < 1500) {
+  if (__scanPromise) {
     return __scanPromise;
   }
-  __scanStamp = now;
   __scanPromise = (async () => {
   const store = loadStore();
   const logPath = path.join(app.getPath('userData'), 'scan-log.txt');
@@ -607,7 +604,12 @@ export async function scanProjectsAsync(_roots?: string[], verbose = false): Pro
   if (cleaned.length !== store.length) { try { await saveStoreAsync(cleaned); } catch {} }
   return cleaned;
   })();
-  try { const res = await __scanPromise; return res; } finally { /* 保持 window 期内复用 */ }
+  try {
+    const res = await __scanPromise;
+    return res;
+  } finally {
+    __scanPromise = null;
+  }
 }
 
 export type AddProjectOptions = {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6904,6 +6904,7 @@ export default function CodexFlowManagerUI() {
 
   // Load settings and projects on mount
   useEffect(() => {
+    let cancelled = false;
     (async () => {
       try {
         const s = await window.host.settings.get();
@@ -6989,27 +6990,32 @@ export default function CodexFlowManagerUI() {
       try {
         const res: any = await window.host.projects.list();
         if (res && res.ok && Array.isArray(res.projects)) {
-          setProjects(res.projects);
-          setSelectedProjectId((prev) => (res.projects.some((p: any) => p.id === prev) ? prev : ""));
+          if (!cancelled) {
+            setProjects(res.projects);
+            setSelectedProjectId((prev) => (res.projects.some((p: any) => p.id === prev) ? prev : ""));
+          }
         } else {
           console.warn('projects.list returned', res);
         }
       } catch (e) {
         console.warn('projects.list failed', e);
-      }
-      try {
-        const res: any = await window.host.projects.scan();
-        if (res && res.ok && Array.isArray(res.projects)) {
-          setProjects(res.projects);
-          setSelectedProjectId((prev) => (res.projects.some((p: any) => p.id === prev) ? prev : ""));
-        } else {
-          console.warn('projects.scan returned', res);
-        }
-      } catch (e) {
-        console.warn('projects.scan failed', e);
       } finally {
-        setProjectsHydrated(true);
+        if (!cancelled) setProjectsHydrated(true);
       }
+      void (async () => {
+        try {
+          const res: any = await window.host.projects.scan();
+          if (cancelled) return;
+          if (res && res.ok && Array.isArray(res.projects)) {
+            setProjects(res.projects);
+            setSelectedProjectId((prev) => (res.projects.some((p: any) => p.id === prev) ? prev : ""));
+          } else {
+            console.warn('projects.scan returned', res);
+          }
+        } catch (e) {
+          if (!cancelled) console.warn('projects.scan failed', e);
+        }
+      })();
       // 启动静默检查更新（仅提示）
       try {
         const cur = await window.host.app.getVersion();
@@ -7036,6 +7042,9 @@ export default function CodexFlowManagerUI() {
         setStartupChecksComplete(true);
       }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, [uiLog]);
 
   // 监听主进程语言变更事件，保持本地 locale 状态同步（用于设置面板默认值等）

--- a/web/src/features/git/api.test.ts
+++ b/web/src/features/git/api.test.ts
@@ -2,10 +2,22 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import * as api from "./api";
 
 afterEach(() => {
+  api.__resetGitFeatureApiForTests();
   delete (globalThis as any).window;
 });
 
 describe("git api alignment", () => {
+  /**
+   * 构造可手动释放的 Promise，用于模拟仍在进行中的 IPC 请求。
+   */
+  function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((next) => {
+      resolve = next;
+    });
+    return { promise, resolve };
+  }
+
   it("不应再导出 update 专用 shelf API", () => {
     expect("getUpdateShelvesAsync" in api).toBe(false);
     expect("restoreUpdateShelveAsync" in api).toBe(false);
@@ -122,6 +134,84 @@ describe("git api alignment", () => {
         repoPath: "/repo",
         commitAndPush: { previewProtectedOnly: true },
       }),
+    }));
+  });
+
+  it("连续 Git 读请求应取消同键旧请求，避免后台读取堆积", async () => {
+    const firstStatus = createDeferred<{ ok: boolean }>();
+    let firstStatusRequestId = 0;
+    const call = vi.fn(async (args: any) => {
+      if (args?.action === "status.get" && !firstStatusRequestId) {
+        firstStatusRequestId = Number(args.requestId || 0);
+        return await firstStatus.promise;
+      }
+      return { ok: true };
+    });
+    (globalThis as any).window = {
+      host: {
+        gitFeature: { call },
+      },
+    };
+
+    const first = api.getStatusAsync("/repo");
+    await Promise.resolve();
+    const second = api.getStatusAsync("/repo");
+    await Promise.resolve();
+
+    expect(call).toHaveBeenCalledWith(expect.objectContaining({
+      action: "request.cancel",
+      payload: expect.objectContaining({
+        targetRequestId: firstStatusRequestId,
+      }),
+      requestId: 0,
+    }));
+    firstStatus.resolve({ ok: true });
+    await Promise.all([first, second]);
+  });
+
+  it("Git 写请求不应触发旧请求取消，避免误伤提交/暂存等真实操作", async () => {
+    const call = vi.fn(async () => ({ ok: true }));
+    (globalThis as any).window = {
+      host: {
+        gitFeature: { call },
+      },
+    };
+
+    await api.stageFilesAsync("/repo", ["a.txt"]);
+    await api.stageFilesAsync("/repo", ["b.txt"]);
+
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(call).not.toHaveBeenCalledWith(expect.objectContaining({
+      action: "request.cancel",
+    }));
+  });
+
+  it("日志分页读取应按 cursor 区分取消键，避免加载更多时取消首屏或相邻页", async () => {
+    const call = vi.fn(async () => ({ ok: true }));
+    const filters = {
+      text: "",
+      caseSensitive: false,
+      matchMode: "fuzzy" as const,
+      branch: "",
+      author: "",
+      dateFrom: "",
+      dateTo: "",
+      path: "",
+      revision: "",
+      followRenames: false,
+    };
+    (globalThis as any).window = {
+      host: {
+        gitFeature: { call },
+      },
+    };
+
+    await api.getLogAsync("/repo", 0, 200, filters);
+    await api.getLogAsync("/repo", 200, 200, filters);
+
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(call).not.toHaveBeenCalledWith(expect.objectContaining({
+      action: "request.cancel",
     }));
   });
 });

--- a/web/src/features/git/api.ts
+++ b/web/src/features/git/api.ts
@@ -89,8 +89,26 @@ const SILENT_GIT_ACTIVITY_ACTIONS = new Set<string>([
   "update.options.get",
   "update.options.set",
 ]);
+const STALE_CANCEL_GIT_ACTIONS = new Set<string>([
+  "branch.popup",
+  "console.get",
+  "diff.get",
+  "diff.openPath",
+  "diff.patch",
+  "log.availability",
+  "log.details",
+  "log.details.availability",
+  "log.get",
+  "push.preview",
+  "shelf.list",
+  "stash.list",
+  "status.get",
+  "status.getIgnored",
+  "worktree.list",
+]);
 
 let gitFeatureActivitySeq = 0;
+const latestGitRequestByKey = new Map<string, number>();
 const gitFeatureProgressBridgeState: {
   installed: boolean;
 } = (globalThis as any).__cf_git_feature_progress_bridge_state__ || ((globalThis as any).__cf_git_feature_progress_bridge_state__ = {
@@ -145,6 +163,61 @@ function isConsoleAction(action: string): boolean {
  */
 function shouldEmitGitFeatureActivity(action: string): boolean {
   return !SILENT_GIT_ACTIVITY_ACTIONS.has(action);
+}
+
+/**
+ * 生成可取消读请求的稳定键，同一仓库同一类刷新只保留最新请求。
+ */
+function buildStaleCancelableGitRequestKey(action: string, payload?: any): string {
+  if (!STALE_CANCEL_GIT_ACTIONS.has(action)) return "";
+  const repoPath = String(payload?.repoPath || payload?.repoRoot || "").trim().replace(/\\/g, "/").toLowerCase();
+  const path = String(payload?.path || "").trim();
+  const mode = String(payload?.mode || "").trim();
+  const cursor = action === "log.get" ? Math.max(0, Math.floor(Number(payload?.cursor) || 0)) : "";
+  const filters = action === "log.get" ? JSON.stringify(payload?.filters || {}) : "";
+  const hash = String(payload?.hash || "").trim();
+  const hashes = Array.isArray(payload?.hashes) ? payload.hashes.map((one: unknown) => String(one || "").trim()).filter(Boolean).join(",") : "";
+  const shelfRef = String(payload?.shelfRef || "").trim();
+  return [action, repoPath, path, mode, cursor, filters, hash, hashes, shelfRef].join("|");
+}
+
+/**
+ * 取消同键旧请求，避免快速切换提交、筛选或页面时后台 Git 读任务堆积。
+ */
+function cancelPreviousStaleGitRequest(requestKey: string, nextRequestId: number): void {
+  if (!requestKey) return;
+  const previousRequestId = latestGitRequestByKey.get(requestKey) || 0;
+  latestGitRequestByKey.set(requestKey, nextRequestId);
+  if (!previousRequestId || previousRequestId === nextRequestId) return;
+  try {
+    void window.host.gitFeature?.call({
+      action: "request.cancel",
+      payload: {
+        targetRequestId: previousRequestId,
+        reason: "已有更新的 Git 读取请求",
+      },
+      requestId: 0,
+    });
+  } catch {}
+}
+
+/**
+ * 清理已完成请求的最新标记，避免映射长期增长。
+ */
+function clearLatestGitRequestMarker(requestKey: string, requestId: number): void {
+  if (!requestKey) return;
+  if (latestGitRequestByKey.get(requestKey) === requestId)
+    latestGitRequestByKey.delete(requestKey);
+}
+
+/**
+ * 重置 Git API 模块内部状态，仅用于隔离单元测试之间的模块级缓存。
+ */
+export function __resetGitFeatureApiForTests(): void {
+  gitFeatureActivitySeq = 0;
+  latestGitRequestByKey.clear();
+  gitFeatureActivityListeners.clear();
+  gitFeatureProgressBridgeState.installed = false;
 }
 
 /**
@@ -332,6 +405,8 @@ export async function callGitFeatureAsync<T>(action: string, payload?: any): Pro
   const normalizedAction = String(action || "").trim();
   const requestId = gitFeatureActivitySeq + 1;
   gitFeatureActivitySeq = requestId;
+  const staleRequestKey = buildStaleCancelableGitRequestKey(normalizedAction, payload);
+  cancelPreviousStaleGitRequest(staleRequestKey, requestId);
   const message = resolveGitFeatureActivityMessage(normalizedAction, payload);
   const emitActivity = shouldEmitGitFeatureActivity(normalizedAction);
   const consoleAction = isConsoleAction(normalizedAction);
@@ -364,6 +439,7 @@ export async function callGitFeatureAsync<T>(action: string, payload?: any): Pro
         ok: normalizedResponse.ok,
       });
     }
+    clearLatestGitRequestMarker(staleRequestKey, requestId);
     return normalizedResponse;
   } catch (e: any) {
     if (emitActivity) {
@@ -376,6 +452,7 @@ export async function callGitFeatureAsync<T>(action: string, payload?: any): Pro
         ok: false,
       });
     }
+    clearLatestGitRequestMarker(staleRequestKey, requestId);
     return { ok: false, error: String(e?.message || e), meta: { requestId } };
   }
 }

--- a/web/src/features/git/git-workbench.tsx
+++ b/web/src/features/git/git-workbench.tsx
@@ -190,11 +190,11 @@ import { GitLogGraphCell } from "./log-graph/cell";
 import type { GitGraphCell } from "./log-graph/model";
 import {
   buildGitLogBranchesDashboard,
-  buildGitLogVisiblePack,
   loadGitLogBranchesDashboardState,
   saveGitLogBranchesDashboardState,
   type GitLogBranchesDashboardState,
 } from "./log-graph/visible-pack";
+import { useGitLogVisiblePack } from "./log-graph/use-visible-pack";
 import {
   buildCommitPatchPathspecs,
   buildCommitDetailsRequestKey,
@@ -5890,6 +5890,10 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   const gitActivityCountRef = useRef<number>(0);
   const gitConsoleRefreshTimerRef = useRef<number | null>(null);
   const gitConsoleLiveRefreshTimerRef = useRef<number | null>(null);
+  const logDecorationPillCacheRef = useRef<{
+    contextKey: string;
+    map: Map<string, { decorations: string; pills: GitDecorationPill[] }>;
+  }>({ contextKey: "", map: new Map() });
   const logHeaderScrollRef = useRef<HTMLDivElement>(null);
   const logScrollSyncLockRef = useRef<boolean>(false);
   const logVirtual = useVirtualWindow(logItems.length, LOG_ROW_HEIGHT, VIRTUAL_OVERSCAN, `${bottomTab}:${bottomCollapsed ? 1 : 0}:${diffFullscreen ? 1 : 0}`);
@@ -6151,13 +6155,11 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
       : selectedCommitHashes;
     return buildCommitSelectionSignature(requestHashes);
   }, [orderedSelectedCommitHashesNewestFirst, selectedCommitHashes]);
-  const logVisiblePack = useMemo(() => {
-    return buildGitLogVisiblePack({
-      items: logItems,
-      graphItems: logGraphItems,
-      fileHistoryMode: isFileHistoryMode,
-    });
-  }, [isFileHistoryMode, logGraphItems, logItems]);
+  const logVisiblePack = useGitLogVisiblePack({
+    items: logItems,
+    graphItems: logGraphItems,
+    fileHistoryMode: isFileHistoryMode,
+  });
   const logBranchesDashboard = useMemo(
     () => buildGitLogBranchesDashboard(branchPopup, logBranchesDashboardState),
     [branchPopup, logBranchesDashboardState],
@@ -6363,16 +6365,33 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     selectedDetailNodeKeys,
   ]);
 
+  const logDecorationContextKey = useMemo<string>(() => {
+    return `${String(repoBranch || "").trim()}\n${JSON.stringify(branchPopup?.repositories || [])}\n${JSON.stringify(branchPopup?.groups || {})}`;
+  }, [branchPopup?.groups, branchPopup?.repositories, repoBranch]);
   const logDecorationPillsByHash = useMemo<Map<string, GitDecorationPill[]>>(() => {
-    const map = new Map<string, GitDecorationPill[]>();
-    for (const item of logItems) {
-      map.set(
-        item.hash,
-        buildLogDecorationPills(String(item.decorations || ""), branchPopup, String(repoBranch || "")),
-      );
+    const cache = logDecorationPillCacheRef.current;
+    if (cache.contextKey !== logDecorationContextKey) {
+      cache.contextKey = logDecorationContextKey;
+      cache.map = new Map();
     }
-    return map;
-  }, [branchPopup, logItems, repoBranch]);
+    const nextMap = new Map<string, { decorations: string; pills: GitDecorationPill[] }>();
+    for (const item of logItems) {
+      const hash = String(item.hash || "").trim();
+      if (!hash) continue;
+      const decorations = String(item.decorations || "");
+      const cached = cache.map.get(hash);
+      if (cached && cached.decorations === decorations) {
+        nextMap.set(hash, cached);
+        continue;
+      }
+      nextMap.set(hash, {
+        decorations,
+        pills: buildLogDecorationPills(decorations, branchPopup, String(repoBranch || "")),
+      });
+    }
+    cache.map = nextMap;
+    return new Map(Array.from(nextMap, ([hash, entry]) => [hash, entry.pills]));
+  }, [branchPopup, logDecorationContextKey, logItems, repoBranch]);
 
   /**
    * 基于当前日志内容估算短列最佳宽度，减少作者/时间/哈希/引用列的无效留白。

--- a/web/src/features/git/log-graph/use-visible-pack.ts
+++ b/web/src/features/git/log-graph/use-visible-pack.ts
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import { useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
+import type { GitLogItem } from "../types";
+import {
+  buildGitLogVisiblePack,
+  buildGitLogVisiblePlaceholderPack,
+  type GitLogVisiblePack,
+} from "./visible-pack";
+
+const GIT_LOG_GRAPH_WORKER_TIMEOUT_MS = 2500;
+const GIT_LOG_GRAPH_SYNC_BUILD_LIMIT = 80;
+const GIT_LOG_GRAPH_LIGHT_MODE_TTL_MS = 60_000;
+const GIT_LOG_GRAPH_WORKER_FAILURE_RETRY_MS = 10_000;
+const GIT_LOG_GRAPH_LIGHT_MODE_EVENT = "cf:renderer-light-mode";
+
+type GitLogVisiblePackWorkerResponse = {
+  ok: boolean;
+  requestId: number;
+  pack?: GitLogVisiblePack;
+  error?: string;
+  durationMs?: number;
+};
+
+type RendererLightModeEvent = CustomEvent<{ reason?: string; durationMs?: number }>;
+
+/**
+ * 为图谱输入生成轻量签名，用于避免无意义地重建 Worker 任务。
+ */
+function buildGitLogVisiblePackSignature(
+  items: GitLogItem[],
+  graphItems: GitLogItem[] | undefined,
+  fileHistoryMode: boolean,
+): string {
+  const visibleHead = items.slice(0, 3).map((item) => item.hash).join(",");
+  const visibleTail = items.slice(-3).map((item) => item.hash).join(",");
+  const graphHead = (graphItems || []).slice(0, 3).map((item) => item.hash).join(",");
+  const graphTail = (graphItems || []).slice(-3).map((item) => item.hash).join(",");
+  return [
+    fileHistoryMode ? "file" : "log",
+    items.length,
+    visibleHead,
+    visibleTail,
+    graphItems?.length || 0,
+    graphHead,
+    graphTail,
+  ].join("|");
+}
+
+/**
+ * 创建 Git 图谱 Worker；失败时返回 null，由调用方回落到同步小任务或占位图谱。
+ */
+function createGitLogVisiblePackWorker(): Worker | null {
+  try {
+    return new Worker(new URL("./visible-pack-worker.ts", import.meta.url), { type: "module" });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 判断当前是否应使用轻量模式，长任务刚发生时暂停重图谱计算一小段时间。
+ */
+function isGitLogGraphLightModeActive(untilRef: MutableRefObject<number>): boolean {
+  return Date.now() < untilRef.current;
+}
+
+/**
+ * 异步构建 Git 日志可见图谱包，避免大仓库日志在 React render 阶段同步阻塞 UI。
+ */
+export function useGitLogVisiblePack(args: {
+  items: GitLogItem[];
+  graphItems?: GitLogItem[];
+  fileHistoryMode: boolean;
+}): GitLogVisiblePack {
+  const items = Array.isArray(args.items) ? args.items : [];
+  const graphItems = Array.isArray(args.graphItems) ? args.graphItems : undefined;
+  const signature = useMemo(
+    () => buildGitLogVisiblePackSignature(items, graphItems, args.fileHistoryMode),
+    [args.fileHistoryMode, graphItems, items],
+  );
+  const workerRef = useRef<Worker | null>(null);
+  const requestSeqRef = useRef(0);
+  const lightModeUntilRef = useRef(0);
+  const lightModeRetryTimerRef = useRef<number | null>(null);
+  const [retrySeq, setRetrySeq] = useState(0);
+  const [pack, setPack] = useState<GitLogVisiblePack>(() => {
+    if (items.length <= GIT_LOG_GRAPH_SYNC_BUILD_LIMIT) {
+      return buildGitLogVisiblePack({
+        items,
+        graphItems,
+        fileHistoryMode: args.fileHistoryMode,
+      });
+    }
+    return buildGitLogVisiblePlaceholderPack(items, { pending: true });
+  });
+
+  /**
+   * 安排轻量模式结束后的重试，让简化图谱自动恢复为完整拓扑。
+   */
+  const scheduleLightModeRetry = (delayMs: number): void => {
+    if (lightModeRetryTimerRef.current != null)
+      window.clearTimeout(lightModeRetryTimerRef.current);
+    const safeDelayMs = Math.max(500, Math.min(120_000, Math.floor(Number(delayMs) || 0)));
+    lightModeRetryTimerRef.current = window.setTimeout(() => {
+      lightModeRetryTimerRef.current = null;
+      setRetrySeq((prev) => prev + 1);
+    }, safeDelayMs);
+  };
+
+  useEffect(() => {
+    /**
+     * 记录轻量模式截止时间，避免长任务后立刻继续启动重计算。
+     */
+    const onLightMode = (event: Event): void => {
+      const custom = event as RendererLightModeEvent;
+      const durationMs = Math.max(5_000, Math.min(120_000, Number(custom.detail?.durationMs) || GIT_LOG_GRAPH_LIGHT_MODE_TTL_MS));
+      lightModeUntilRef.current = Math.max(lightModeUntilRef.current, Date.now() + durationMs);
+      setPack(buildGitLogVisiblePlaceholderPack(items, { degraded: true }));
+      scheduleLightModeRetry(durationMs + 50);
+    };
+    window.addEventListener(GIT_LOG_GRAPH_LIGHT_MODE_EVENT, onLightMode as EventListener);
+    return () => {
+      window.removeEventListener(GIT_LOG_GRAPH_LIGHT_MODE_EVENT, onLightMode as EventListener);
+    };
+  }, [items]);
+
+  useEffect(() => {
+    const requestId = requestSeqRef.current + 1;
+    requestSeqRef.current = requestId;
+
+    if (items.length <= GIT_LOG_GRAPH_SYNC_BUILD_LIMIT && !isGitLogGraphLightModeActive(lightModeUntilRef)) {
+      setPack(buildGitLogVisiblePack({
+        items,
+        graphItems,
+        fileHistoryMode: args.fileHistoryMode,
+      }));
+      return;
+    }
+
+    const placeholder = buildGitLogVisiblePlaceholderPack(items, {
+      pending: !isGitLogGraphLightModeActive(lightModeUntilRef),
+      degraded: isGitLogGraphLightModeActive(lightModeUntilRef),
+    });
+    setPack(placeholder);
+    if (isGitLogGraphLightModeActive(lightModeUntilRef)) return;
+
+    const worker = createGitLogVisiblePackWorker();
+    if (!worker) {
+      setPack(buildGitLogVisiblePlaceholderPack(items, { degraded: true }));
+      scheduleLightModeRetry(GIT_LOG_GRAPH_WORKER_FAILURE_RETRY_MS);
+      return;
+    }
+    workerRef.current?.terminate();
+    workerRef.current = worker;
+
+    let settled = false;
+    const timeout = window.setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try { worker.terminate(); } catch {}
+      if (workerRef.current === worker) workerRef.current = null;
+      lightModeUntilRef.current = Math.max(lightModeUntilRef.current, Date.now() + GIT_LOG_GRAPH_LIGHT_MODE_TTL_MS);
+      setPack(buildGitLogVisiblePlaceholderPack(items, { degraded: true }));
+      scheduleLightModeRetry(GIT_LOG_GRAPH_LIGHT_MODE_TTL_MS + 50);
+      try { void window.host?.utils?.perfLog?.(`[git.graph.worker.timeout] items=${items.length} graphItems=${graphItems?.length || 0}`); } catch {}
+    }, GIT_LOG_GRAPH_WORKER_TIMEOUT_MS);
+
+    worker.onmessage = (event: MessageEvent<GitLogVisiblePackWorkerResponse>) => {
+      if (settled) return;
+      const response = event.data;
+      if (Math.max(0, Math.floor(Number(response?.requestId) || 0)) !== requestId) return;
+      settled = true;
+      window.clearTimeout(timeout);
+      try { worker.terminate(); } catch {}
+      if (workerRef.current === worker) workerRef.current = null;
+      if (response?.ok && response.pack) {
+        setPack(response.pack);
+        return;
+      }
+      setPack(buildGitLogVisiblePlaceholderPack(items, { degraded: true }));
+      scheduleLightModeRetry(GIT_LOG_GRAPH_WORKER_FAILURE_RETRY_MS);
+      try { void window.host?.utils?.perfLog?.(`[git.graph.worker.failed] items=${items.length} error=${String(response?.error || "")}`); } catch {}
+    };
+    worker.onerror = (event) => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timeout);
+      try { worker.terminate(); } catch {}
+      if (workerRef.current === worker) workerRef.current = null;
+      setPack(buildGitLogVisiblePlaceholderPack(items, { degraded: true }));
+      scheduleLightModeRetry(GIT_LOG_GRAPH_WORKER_FAILURE_RETRY_MS);
+      try { void window.host?.utils?.perfLog?.(`[git.graph.worker.error] items=${items.length} error=${String(event?.message || "")}`); } catch {}
+    };
+    worker.postMessage({
+      requestId,
+      items,
+      graphItems,
+      fileHistoryMode: args.fileHistoryMode,
+    });
+
+    return () => {
+      settled = true;
+      window.clearTimeout(timeout);
+      try { worker.terminate(); } catch {}
+      if (workerRef.current === worker) workerRef.current = null;
+    };
+  }, [args.fileHistoryMode, graphItems, items, retrySeq, signature]);
+
+  useEffect(() => {
+    return () => {
+      if (lightModeRetryTimerRef.current != null)
+        window.clearTimeout(lightModeRetryTimerRef.current);
+      lightModeRetryTimerRef.current = null;
+      try { workerRef.current?.terminate(); } catch {}
+      workerRef.current = null;
+    };
+  }, []);
+
+  return pack;
+}

--- a/web/src/features/git/log-graph/visible-pack-worker.ts
+++ b/web/src/features/git/log-graph/visible-pack-worker.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import type { GitLogItem } from "../types";
+import { buildGitLogVisiblePack } from "./visible-pack";
+
+type GitLogVisiblePackWorkerRequest = {
+  requestId: number;
+  items: GitLogItem[];
+  graphItems?: GitLogItem[];
+  fileHistoryMode: boolean;
+};
+
+type GitLogVisiblePackWorkerResponse =
+  | {
+      ok: true;
+      requestId: number;
+      pack: ReturnType<typeof buildGitLogVisiblePack>;
+      durationMs: number;
+    }
+  | {
+      ok: false;
+      requestId: number;
+      error: string;
+      durationMs: number;
+    };
+
+/**
+ * 在 Worker 线程构建 Git 日志图谱，避免 React 渲染线程被大列表同步计算堵住。
+ */
+self.onmessage = (event: MessageEvent<GitLogVisiblePackWorkerRequest>) => {
+  const request = event.data;
+  const startedAt = Date.now();
+  try {
+    const pack = buildGitLogVisiblePack({
+      items: Array.isArray(request.items) ? request.items : [],
+      graphItems: Array.isArray(request.graphItems) ? request.graphItems : undefined,
+      fileHistoryMode: request.fileHistoryMode === true,
+      emitRuntimeProbe: false,
+    });
+    const response: GitLogVisiblePackWorkerResponse = {
+      ok: true,
+      requestId: Math.max(0, Math.floor(Number(request.requestId) || 0)),
+      pack,
+      durationMs: Date.now() - startedAt,
+    };
+    self.postMessage(response);
+  } catch (error: any) {
+    const response: GitLogVisiblePackWorkerResponse = {
+      ok: false,
+      requestId: Math.max(0, Math.floor(Number(request.requestId) || 0)),
+      error: String(error?.message || error),
+      durationMs: Date.now() - startedAt,
+    };
+    self.postMessage(response);
+  }
+};

--- a/web/src/features/git/log-graph/visible-pack.test.ts
+++ b/web/src/features/git/log-graph/visible-pack.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildGitLogBranchesDashboard,
+  buildGitLogVisiblePlaceholderPack,
   buildGitLogVisiblePack,
   createDefaultGitLogBranchesDashboardState,
   loadGitLogBranchesDashboardState,
@@ -148,6 +149,21 @@ describe("git log visible pack", () => {
       expect.objectContaining({ from: 0, to: 0, style: "solid" }),
     ]);
     expect(pack.graphCells[1]?.incomingFromLane).toBe(0);
+  });
+
+  it("占位图谱应保持列表行数并退化为单轨，保证完整图谱计算前列表可交互", () => {
+    const items = [
+      createLogItem({ hash: "head", parents: ["mid"] }),
+      createLogItem({ hash: "mid", parents: ["base"] }),
+      createLogItem({ hash: "base", parents: [] }),
+    ];
+    const pack = buildGitLogVisiblePlaceholderPack(items, { pending: true });
+
+    expect(pack.items).toBe(items);
+    expect(pack.pending).toBe(true);
+    expect(pack.graphCells).toHaveLength(items.length);
+    expect(pack.graphCells.every((cell) => cell.lane === 0 && cell.maxLane === 0)).toBe(true);
+    expect(pack.graphColumnWidth).toBeCloseTo(resolveLogGraphWidth(0), 4);
   });
 
   it("branches dashboard 应只暴露日志真正需要的最小仓库上下文", () => {

--- a/web/src/features/git/log-graph/visible-pack.ts
+++ b/web/src/features/git/log-graph/visible-pack.ts
@@ -14,6 +14,8 @@ export type GitLogVisiblePack = {
   graphCells: GitGraphCell[];
   maxLane: number;
   graphColumnWidth: number;
+  pending?: boolean;
+  degraded?: boolean;
 };
 
 export type GitLogBranchesDashboardSelectionAction = "filter" | "navigate";
@@ -58,6 +60,32 @@ export type GitLogBranchesDashboard = {
 };
 
 const GIT_LOG_BRANCHES_DASHBOARD_STORAGE_KEY = "cf.gitWorkbench.logBranchesDashboard.v1";
+
+/**
+ * 构建单行占位图谱单元，只保留最小字段，避免轻量模式还同步跑完整文件历史图谱。
+ */
+function createPlaceholderGraphCell(item: GitLogItem, index: number, total: number): GitGraphCell {
+  const hash = String(item.hash || "").trim();
+  return {
+    lane: 0,
+    color: "var(--cf-text-muted)",
+    tracks: [],
+    edges: index + 1 < total
+      ? [{
+          from: 0,
+          to: 0,
+          color: "var(--cf-text-muted)",
+          style: "solid",
+          targetHash: String(item.parents?.[0] || ""),
+        }]
+      : [],
+    incomingFromLane: index > 0 ? 0 : null,
+    incomingFromLanes: index > 0 ? [0] : [],
+    nodeKind: "default",
+    maxLane: 0,
+    commitHash: hash,
+  };
+}
 
 /**
  * 构建日志分支 dashboard 默认设置，首次进入默认不显示概览，但仍保留“选择即筛选”作为默认交互语义。
@@ -227,11 +255,13 @@ export function buildGitLogVisiblePack(args: {
   items: GitLogItem[];
   graphItems?: GitLogItem[];
   fileHistoryMode: boolean;
+  emitRuntimeProbe?: boolean;
 }): GitLogVisiblePack {
   const items = Array.isArray(args.items) ? args.items : [];
   const graphItems = Array.isArray(args.graphItems) ? args.graphItems : items;
   const graphCells = args.fileHistoryMode ? buildFileHistoryGraphCells(items) : buildLogGraphCells(items, graphItems);
-  emitGitLogGraphRuntimeProbe(items, graphItems, graphCells, args.fileHistoryMode);
+  if (args.emitRuntimeProbe !== false)
+    emitGitLogGraphRuntimeProbe(items, graphItems, graphCells, args.fileHistoryMode);
   let maxLane = 1;
   for (const cell of graphCells) {
     const lane = Number(cell?.maxLane ?? 0);
@@ -243,6 +273,27 @@ export function buildGitLogVisiblePack(args: {
     graphCells,
     maxLane,
     graphColumnWidth: resolveLogGraphWidth(maxLane),
+  };
+}
+
+/**
+ * 快速构建日志图谱占位数据，只保留单列节点与上下连接线，让列表先可交互。
+ */
+export function buildGitLogVisiblePlaceholderPack(
+  itemsInput: GitLogItem[],
+  options?: {
+    pending?: boolean;
+    degraded?: boolean;
+  },
+): GitLogVisiblePack {
+  const items = Array.isArray(itemsInput) ? itemsInput : [];
+  return {
+    items,
+    graphCells: items.map((item, index) => createPlaceholderGraphCell(item, index, items.length)),
+    maxLane: 0,
+    graphColumnWidth: resolveLogGraphWidth(0),
+    pending: options?.pending === true,
+    degraded: options?.degraded === true,
   };
 }
 

--- a/web/src/features/git/use-virtual-window.test.tsx
+++ b/web/src/features/git/use-virtual-window.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import React, { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useVirtualWindow, type VirtualWindowState } from "./use-virtual-window";
+
+type VirtualWindowHarnessProps = {
+  itemCount: number;
+  rowHeight: number;
+  overscan: number;
+  onState: (state: VirtualWindowState) => void;
+};
+
+/**
+ * 挂载虚拟列表 hook，便于在 jsdom 中验证首帧和测量后的窗口范围。
+ */
+function VirtualWindowHarness(props: VirtualWindowHarnessProps): JSX.Element {
+  const virtual = useVirtualWindow(props.itemCount, props.rowHeight, props.overscan);
+  useEffect(() => {
+    props.onState(virtual.windowState);
+  }, [props, virtual.windowState]);
+  return <div ref={virtual.containerRef} data-testid="scroll-container" />;
+}
+
+/**
+ * 等待 React effect 完成，避免断言跑在状态更新前。
+ */
+async function flushAsync(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("useVirtualWindow", () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root?.unmount();
+      await flushAsync();
+    });
+    root = null;
+    container?.remove();
+    container = null;
+    delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it("首帧不应在容器尺寸未知时渲染全部项目", async () => {
+    const states: VirtualWindowState[] = [];
+
+    await act(async () => {
+      root!.render(
+        <VirtualWindowHarness
+          itemCount={1000}
+          rowHeight={32}
+          overscan={8}
+          onState={(state) => states.push(state)}
+        />,
+      );
+      await flushAsync();
+    });
+
+    expect(states[0]).toMatchObject({
+      start: 0,
+      end: 52,
+    });
+    expect(states.some((state) => state.end === 1000)).toBe(false);
+  });
+
+  it("容器完成测量后应按视口高度计算可见窗口", async () => {
+    const states: VirtualWindowState[] = [];
+
+    await act(async () => {
+      root!.render(
+        <VirtualWindowHarness
+          itemCount={1000}
+          rowHeight={32}
+          overscan={4}
+          onState={(state) => states.push(state)}
+        />,
+      );
+      await flushAsync();
+    });
+
+    const scrollContainer = container!.querySelector("[data-testid='scroll-container']") as HTMLDivElement;
+    Object.defineProperty(scrollContainer, "clientHeight", {
+      configurable: true,
+      value: 320,
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event("resize"));
+      await flushAsync();
+    });
+
+    expect(states[states.length - 1]).toMatchObject({
+      start: 0,
+      end: 18,
+      top: 0,
+      bottom: (1000 - 18) * 32,
+    });
+  });
+});

--- a/web/src/features/git/use-virtual-window.ts
+++ b/web/src/features/git/use-virtual-window.ts
@@ -11,6 +11,16 @@ export type VirtualWindowState = {
 };
 
 /**
+ * 估算首帧可渲染行数，避免容器尺寸尚未测量时一次性渲染全部项目。
+ */
+function resolveInitialVirtualEnd(itemCount: number, overscan: number): number {
+  const safeCount = Math.max(0, Math.floor(Number(itemCount) || 0));
+  if (safeCount <= 0) return 0;
+  const initialRows = Math.max(12, Math.floor(Number(overscan) || 0) * 2 + 36);
+  return Math.min(safeCount, initialRows);
+}
+
+/**
  * 根据滚动容器尺寸计算虚拟列表窗口，避免一次渲染全部行。
  */
 export function useVirtualWindow(
@@ -29,7 +39,7 @@ export function useVirtualWindow(
   const containerNode = containerRef.current;
   const [windowState, setWindowState] = useState<VirtualWindowState>({
     start: 0,
-    end: Math.max(0, itemCount),
+    end: resolveInitialVirtualEnd(itemCount, overscan),
     top: 0,
     bottom: 0,
   });
@@ -82,8 +92,8 @@ export function useVirtualWindow(
 
   useEffect(() => {
     setWindowState((prev) => {
-      if (prev.start < itemCount) return prev;
-      const end = Math.min(itemCount, Math.max(1, overscan * 2));
+      if (prev.start < itemCount && prev.end > prev.start) return prev;
+      const end = resolveInitialVirtualEnd(itemCount, overscan);
       return {
         start: 0,
         end,

--- a/web/src/lib/runtime-diagnostics.ts
+++ b/web/src/lib/runtime-diagnostics.ts
@@ -7,6 +7,8 @@ const RENDERER_HEARTBEAT_WARN_DRIFT_MS = 700;
 const RENDERER_HEARTBEAT_MIN_LOG_GAP_MS = 3000;
 const RENDERER_LONG_TASK_WARN_MS = 200;
 const RENDERER_LONG_TASK_MIN_LOG_GAP_MS = 1500;
+const RENDERER_LIGHT_MODE_EVENT = "cf:renderer-light-mode";
+const RENDERER_LIGHT_MODE_DURATION_MS = 60_000;
 
 let rendererDiagnosticsEnabled = false;
 
@@ -34,6 +36,20 @@ function logRendererDiagnostic(message: string): void {
 }
 
 /**
+ * 通知页面进入短时轻量模式，让 Git 图谱等重任务主动降级，避免卡死扩大。
+ */
+function requestRendererLightMode(reason: string): void {
+  try {
+    window.dispatchEvent(new CustomEvent(RENDERER_LIGHT_MODE_EVENT, {
+      detail: {
+        reason: clampLogValue(reason, 120),
+        durationMs: RENDERER_LIGHT_MODE_DURATION_MS,
+      },
+    }));
+  } catch {}
+}
+
+/**
  * 从主进程调试配置同步诊断开关。
  */
 async function refreshRendererDiagnosticsEnabled(): Promise<void> {
@@ -57,6 +73,7 @@ function installHeartbeatProbe(): void {
       const driftMs = now - expectedAt;
       expectedAt = now + RENDERER_HEARTBEAT_INTERVAL_MS;
       if (driftMs < RENDERER_HEARTBEAT_WARN_DRIFT_MS) return;
+      requestRendererLightMode(`eventLoop.blocked driftMs=${Math.round(driftMs)}`);
       if (now - lastLoggedAt < RENDERER_HEARTBEAT_MIN_LOG_GAP_MS) return;
       lastLoggedAt = now;
       logRendererDiagnostic(`eventLoop.blocked driftMs=${Math.round(driftMs)} intervalMs=${RENDERER_HEARTBEAT_INTERVAL_MS} visibility=${document.visibilityState}`);
@@ -80,6 +97,7 @@ function installLongTaskProbe(): void {
         for (const entry of list.getEntries()) {
           const durationMs = Number(entry.duration || 0);
           if (durationMs < RENDERER_LONG_TASK_WARN_MS) continue;
+          requestRendererLightMode(`longTask durationMs=${Math.round(durationMs)}`);
           const now = nowMs();
           if (now - lastLoggedAt < RENDERER_LONG_TASK_MIN_LOG_GAP_MS) continue;
           lastLoggedAt = now;


### PR DESCRIPTION
解决 Git 工作台在大仓库日志、文件历史和快速切换提交时可能出现的界面卡死问题。

限制主进程 Git 读取请求并发，并为重复读请求补充取消链路，避免过期读取继续占用后台 Git 子进程。

将日志图谱可见包迁移到 Worker 异步计算，长任务或 Worker 失败时先显示轻量占位图谱，并在冷却后自动恢复完整拓扑。

优化虚拟列表首帧窗口和项目扫描启动流程，避免容器未测量或冷启动扫描时一次性阻塞界面。

产品变化：
- Git 工作台遇到大日志或文件历史时不再长时间卡死。
- 快速切换提交、筛选条件或页面时，过期读取会被取消，不再拖慢后续操作。
- 渲染线程卡顿后会临时降级日志图谱，优先保证列表可以滚动和选择。