### PR TITLE
fix(history): 历史详情兼容无路径 AGENTS 说明头

### DIFF
--- a/electron/agentSessions/shared/taggedPrefix.test.ts
+++ b/electron/agentSessions/shared/taggedPrefix.test.ts
@@ -40,5 +40,28 @@ describe("extractTaggedPrefix", () => {
     expect(res.picked[0]?.text).toContain("第二行");
     expect(res.picked[0]?.text).not.toContain("\\n");
   });
-});
 
+  it("识别不带 for 后缀的 AGENTS.md instructions 头", () => {
+    const src = "# AGENTS.md instructions\n\n<INSTRUCTIONS>\n规则内容\n</INSTRUCTIONS>";
+    const res = extractTaggedPrefix(src);
+
+    expect(res.rest).toBe("");
+    expect(res.picked).toEqual([{ type: "instructions", text: "\n规则内容\n" }]);
+  });
+
+  it("继续识别带路径的 AGENTS.md instructions 头", () => {
+    const src = "# AGENTS.md instructions for G:\\Projects\\Demo\n\n<INSTRUCTIONS>\n规则内容\n</INSTRUCTIONS>\n剩余内容";
+    const res = extractTaggedPrefix(src);
+
+    expect(res.rest).toBe("剩余内容");
+    expect(res.picked).toEqual([{ type: "instructions", text: "\n规则内容\n" }]);
+  });
+
+  it("不把 AGENTS.md instructions 后的任意标题说明误判为系统说明", () => {
+    const src = "# AGENTS.md instructions draft\n\n普通用户内容";
+    const res = extractTaggedPrefix(src);
+
+    expect(res.rest).toBe(src);
+    expect(res.picked).toEqual([]);
+  });
+});

--- a/electron/agentSessions/shared/taggedPrefix.ts
+++ b/electron/agentSessions/shared/taggedPrefix.ts
@@ -54,7 +54,7 @@ function formatSubagentNotificationText(raw: string): string {
  * - `<permissions instructions>...</permissions instructions>` -> `instructions`
  * - `<environment_context>...</environment_context>` -> `environment_context`
  * - `<subagent_notification>...</subagent_notification>` -> `subagent_notification`
- * - `# AGENTS.md instructions for ...`（含可选 `<instructions>...</instructions>`）-> `instructions`
+ * - `# AGENTS.md instructions`（可选 `for ...`，含可选 `<instructions>...</instructions>`）-> `instructions`
  */
 export function extractTaggedPrefix(source: string): { rest: string; picked: TaggedPrefixPick[] } {
   const src = String(source || "");
@@ -128,8 +128,8 @@ export function extractTaggedPrefix(source: string): { rest: string; picked: Tag
     return { rest: "", picked };
   }
 
-  const agentsPrefix = "# agents.md instructions for";
-  if (lower.startsWith(agentsPrefix)) {
+  const agentsHeaderPattern = /^#[ \t]*agents\.md instructions(?:[ \t]+for\b[^\r\n]*)?[ \t]*(?:\r?\n|$)/i;
+  if (agentsHeaderPattern.test(s2)) {
     const openTag = "<instructions>";
     const closeTag = "</instructions>";
     const openIdx = lower.indexOf(openTag);

--- a/electron/history.test.ts
+++ b/electron/history.test.ts
@@ -310,6 +310,52 @@ describe("electron/history.listHistory", () => {
 });
 
 describe("electron/history.readHistoryFile", () => {
+  it("将不带 for 后缀的 AGENTS.md instructions 解析为说明分类", async () => {
+    const filePath = await createHistoryJsonlFile([
+      {
+        timestamp: "2026-03-06T00:00:00.000Z",
+        type: "session_meta",
+        payload: {
+          id: "session-agents-instructions",
+          cwd: "/workspace/project",
+        },
+      },
+      {
+        timestamp: "2026-03-06T00:00:01.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: "# AGENTS.md instructions\n\n<INSTRUCTIONS>\n规则内容\n</INSTRUCTIONS>",
+            },
+          ],
+        },
+      },
+      {
+        timestamp: "2026-03-06T00:00:02.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "真正的用户问题" }],
+        },
+      },
+    ]);
+
+    const parsed = await readHistoryFile(filePath, { maxLines: 0 });
+    const instructionItem = parsed.messages
+      .flatMap((message) => message.content || [])
+      .find((item) => item.type === "instructions");
+    const allTexts = collectTexts(parsed.messages);
+
+    expect(instructionItem?.text).toBe("\n规则内容\n");
+    expect(allTexts).not.toContain("# AGENTS.md instructions\n\n<INSTRUCTIONS>\n规则内容\n</INSTRUCTIONS>");
+    expect(allTexts).toContain("真正的用户问题");
+  });
+
   it("将 subagent_notification 解析为通知消息并格式化换行", async () => {
     const filePath = await createHistoryJsonlFile([
       {


### PR DESCRIPTION
支持解析 `# AGENTS.md instructions` 这种不带 `for ...` 路径后缀的系统说明头，避免历史详情把注入的 AGENTS 内容当作普通用户消息展示。

同时收紧标题匹配范围，只允许精确标题或 `for ...` 路径标题，避免把普通 Markdown 标题误判为系统说明。