### PR TITLE
fix(codex): 收紧错误去重范围，避免回放误伤新报错

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,5 +160,6 @@
       "en-US",
       "zh-CN"
     ]
-  }
+  },
+  "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48"
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -73,6 +73,7 @@ import { collectRetainedAgentTurnTabIds, pruneAgentTurnHistory, pruneAgentTurnTi
 import {
   classifyCodexCliErrorText,
   detectCodexCliRuntimeStatusText,
+  buildCodexCliErrorNotificationKey,
   getCodexCliErrorKindLabel,
   shouldDelayCodexCliFinalErrorForReconnect,
   stripAnsiForCodexErrorScan,
@@ -426,8 +427,7 @@ type AgentTurnTimerState = {
 
 type CodexErrorScanState = {
   buffer: string;
-  lastReconnectErrorKey?: string;
-  lastFinalErrorKey?: string;
+  notifiedErrorKeys?: string[];
   lastReconnectStatusAt?: number;
   pendingErrorKey?: string;
   pendingErrorKind?: CodexCliErrorKind;
@@ -443,6 +443,7 @@ type CodexErrorScanState = {
 const CODEX_ERROR_SCAN_MAX_BUFFER_LENGTH = 16 * 1024;
 const CODEX_RECONNECT_DETAIL_GRACE_MS = 10_000;
 const CODEX_RECONNECT_AFTER_ERROR_GRACE_MS = 10_000;
+const CODEX_ERROR_SCAN_NOTIFIED_KEYS_LIMIT = 64;
 
 /**
  * 中文说明：生成 Codex 错误去重键，避免同一段终端输出反复触发处理。
@@ -450,6 +451,44 @@ const CODEX_RECONNECT_AFTER_ERROR_GRACE_MS = 10_000;
 function buildCodexCliErrorKey(classification: CodexCliErrorClassification): string {
   const attempt = classification.reconnectAttempt ? `:${classification.reconnectAttempt}/${classification.reconnectMaxAttempts || "?"}` : "";
   return `${classification.phase}:${classification.kind}${attempt}:${classification.matchedText}`;
+}
+
+/**
+ * 中文说明：判断某个 Codex 错误键是否已经在本轮里通知过。
+ */
+function hasNotifiedCodexErrorKey(state: CodexErrorScanState | undefined, errorKey: string): boolean {
+  if (!state || !errorKey) return false;
+  return (
+    Array.isArray(state.notifiedErrorKeys) && state.notifiedErrorKeys.includes(errorKey)
+  );
+}
+/**
+ * 中文说明：记录已经通知过的 Codex 错误键，并限制保存长度。
+ */
+function pushNotifiedCodexErrorKey(state: CodexErrorScanState, errorKey: string): string[] {
+  const current = Array.isArray(state.notifiedErrorKeys) ? state.notifiedErrorKeys.filter((key) => key && key !== errorKey) : [];
+  current.push(errorKey);
+  return current.length > CODEX_ERROR_SCAN_NOTIFIED_KEYS_LIMIT
+    ? current.slice(-CODEX_ERROR_SCAN_NOTIFIED_KEYS_LIMIT)
+    : current;
+}
+
+/**
+ * 中文说明：记录一次已经对用户可见的 Codex 错误，避免同一错误在重绘/回放后再次弹出。
+ */
+function rememberCodexErrorNotification(
+  scanByTabRef: React.MutableRefObject<Record<string, CodexErrorScanState>>,
+  tabId: string,
+  errorKey: string,
+): void {
+  const id = String(tabId || "").trim();
+  if (!id || !errorKey) return;
+  const state = scanByTabRef.current[id];
+  if (!state) return;
+  scanByTabRef.current[id] = {
+    ...state,
+    notifiedErrorKeys: pushNotifiedCodexErrorKey(state, errorKey),
+  };
 }
 
 type CompletionEventSource = "osc" | "external" | "manual" | "unknown";
@@ -2809,6 +2848,7 @@ export default function CodexFlowManagerUI() {
     const id = String(tabId || "").trim();
     if (!id) return;
     const state = codexErrorScanByTabRef.current[id];
+    const shouldClearNotifiedErrorKeys = source === "user-send";
     if (state && typeof state.autoContinueTimerId === "number") {
       try { window.clearTimeout(state.autoContinueTimerId); } catch {}
       notifyLog(`codexError.scan.resetTimer tab=${id} source=${source}`);
@@ -2819,8 +2859,27 @@ export default function CodexFlowManagerUI() {
     }
     if (options?.keepAttempts && state) {
       codexErrorScanByTabRef.current[id] = {
+        ...state,
         buffer: "",
         autoContinueAttempts: state.autoContinueAttempts || 0,
+        notifiedErrorKeys: state.notifiedErrorKeys,
+        lastReconnectStatusAt: undefined,
+        pendingErrorKey: undefined,
+        pendingErrorKind: undefined,
+        autoContinueTimerId: undefined,
+        pendingFinalErrorKey: undefined,
+        pendingFinalErrorKind: undefined,
+        pendingFinalError: undefined,
+        pendingFinalErrorAt: undefined,
+        pendingFinalErrorTimerId: undefined,
+      };
+      return;
+    }
+    if (state) {
+      codexErrorScanByTabRef.current[id] = {
+        buffer: "",
+        autoContinueAttempts: 0,
+        notifiedErrorKeys: shouldClearNotifiedErrorKeys ? undefined : state.notifiedErrorKeys,
       };
       return;
     }
@@ -4169,6 +4228,7 @@ export default function CodexFlowManagerUI() {
       applyPending({ ...current, [id]: (current[id] ?? 0) + 1 });
     }
     showCompletionNotification(id, notificationBody);
+    rememberCodexErrorNotification(codexErrorScanByTabRef, id, errorKey);
     if (foreground && activeMatch)
       acknowledgeAgentTurnFailure(id, "visible-final-error");
     notifyLog(`codexError.detected tab=${id} kind=${classification.kind} retryable=${classification.retryable ? "1" : "0"} auto=${autoContinue ? "1" : "0"}`);
@@ -4212,7 +4272,7 @@ export default function CodexFlowManagerUI() {
     }
     const bufferedStatus = detectCodexCliRuntimeStatusText(state.buffer || "");
     const bufferedClassification = classifyCodexCliErrorText(state.buffer || "");
-    const bufferedErrorKey = bufferedClassification ? buildCodexCliErrorKey(bufferedClassification) : "";
+    const bufferedErrorKey = bufferedClassification ? buildCodexCliErrorNotificationKey(bufferedClassification) : "";
     if (
       bufferedStatus?.phase === "working" ||
       bufferedStatus?.phase === "reconnecting" ||
@@ -4242,7 +4302,6 @@ export default function CodexFlowManagerUI() {
       pendingFinalError: undefined,
       pendingFinalErrorAt: undefined,
       pendingFinalErrorTimerId: undefined,
-      lastFinalErrorKey: errorKey,
     };
     const timerState = agentTurnTimerByTabRef.current[id];
     if (!timerState || timerState.status !== "working") {
@@ -4279,13 +4338,11 @@ export default function CodexFlowManagerUI() {
         try { window.clearTimeout(previous.pendingFinalErrorTimerId); } catch {}
       }
       if (idleClassification?.phase === "final") {
-        const errorKey = buildCodexCliErrorKey(idleClassification);
+        const errorKey = buildCodexCliErrorNotificationKey(idleClassification);
         codexErrorScanByTabRef.current[tabId] = {
           ...previous,
           buffer: "",
-          lastReconnectErrorKey: undefined,
           lastReconnectStatusAt: undefined,
-          lastFinalErrorKey: errorKey,
           pendingFinalErrorKey: undefined,
           pendingFinalErrorKind: undefined,
           pendingFinalError: undefined,
@@ -4293,7 +4350,7 @@ export default function CodexFlowManagerUI() {
           pendingFinalErrorTimerId: undefined,
         };
         clearAgentTurnReconnecting(tabId, "idle-final-error");
-        if (previous.lastFinalErrorKey !== errorKey)
+        if (!hasNotifiedCodexErrorKey(previous, errorKey))
           handleCodexCliErrorDetected(tabId, idleClassification, errorKey);
         notifyLog(`codexError.idle.final tab=${tabId} kind=${idleClassification.kind}`);
         return;
@@ -4301,7 +4358,6 @@ export default function CodexFlowManagerUI() {
       codexErrorScanByTabRef.current[tabId] = {
         ...previous,
         buffer: "",
-        lastReconnectErrorKey: undefined,
         lastReconnectStatusAt: undefined,
         pendingFinalErrorKey: undefined,
         pendingFinalErrorKind: undefined,
@@ -4325,8 +4381,6 @@ export default function CodexFlowManagerUI() {
         codexErrorScanByTabRef.current[tabId] = {
           ...restoredScanState,
           buffer: cleanedChunk.slice(-CODEX_ERROR_SCAN_MAX_BUFFER_LENGTH),
-          lastReconnectErrorKey: undefined,
-          lastFinalErrorKey: undefined,
           lastReconnectStatusAt: undefined,
           pendingErrorKey: undefined,
           pendingErrorKind: undefined,
@@ -4357,7 +4411,7 @@ export default function CodexFlowManagerUI() {
         reconnectAttempt: reconnectClassification.reconnectAttempt || chunkRuntimeStatus.reconnectAttempt,
         reconnectMaxAttempts: reconnectClassification.reconnectMaxAttempts || chunkRuntimeStatus.reconnectMaxAttempts,
       };
-      const reconnectErrorKey = buildCodexCliErrorKey(normalizedReconnectClassification);
+      const reconnectErrorKey = buildCodexCliErrorNotificationKey(normalizedReconnectClassification);
       restoreFailedAgentTurnToReconnecting(tabId, normalizedReconnectClassification, "pty-runtime-status");
       const restoredScanState = codexErrorScanByTabRef.current[tabId] || previous;
       if (typeof restoredScanState.pendingFinalErrorTimerId === "number") {
@@ -4366,7 +4420,6 @@ export default function CodexFlowManagerUI() {
       codexErrorScanByTabRef.current[tabId] = {
         ...restoredScanState,
         buffer: nextBuffer,
-        lastReconnectErrorKey: reconnectErrorKey,
         lastReconnectStatusAt: now,
         pendingErrorKey: undefined,
         pendingErrorKind: undefined,
@@ -4377,7 +4430,7 @@ export default function CodexFlowManagerUI() {
         pendingFinalErrorAt: undefined,
         pendingFinalErrorTimerId: undefined,
       };
-      if (previous.lastReconnectErrorKey !== reconnectErrorKey)
+      if (!hasNotifiedCodexErrorKey(previous, reconnectErrorKey))
         handleCodexCliReconnectDetected(tabId, normalizedReconnectClassification);
       notifyLog(`codexError.failed.reconnecting tab=${tabId} kind=${normalizedReconnectClassification.kind}`);
       return;
@@ -4390,8 +4443,6 @@ export default function CodexFlowManagerUI() {
       ? {
         ...previous,
         buffer: "",
-        lastReconnectErrorKey: undefined,
-        lastReconnectStatusAt: undefined,
         pendingFinalErrorKey: undefined,
         pendingFinalErrorKind: undefined,
         pendingFinalError: undefined,
@@ -4417,7 +4468,7 @@ export default function CodexFlowManagerUI() {
           reconnectAttempt: chunkRuntimeStatus.reconnectAttempt,
           reconnectMaxAttempts: chunkRuntimeStatus.reconnectMaxAttempts,
         };
-        const reconnectErrorKey = buildCodexCliErrorKey(reconnectClassification);
+        const reconnectErrorKey = buildCodexCliErrorNotificationKey(reconnectClassification);
         codexErrorScanByTabRef.current[tabId] = {
           ...latestScanState,
           buffer: nextBuffer,
@@ -4426,9 +4477,9 @@ export default function CodexFlowManagerUI() {
           pendingFinalError: undefined,
           pendingFinalErrorAt: undefined,
           pendingFinalErrorTimerId: undefined,
-          lastReconnectErrorKey: reconnectErrorKey,
+          notifiedErrorKeys: pushNotifiedCodexErrorKey(latestScanState, reconnectErrorKey),
         };
-        if (previous.lastReconnectErrorKey !== reconnectErrorKey)
+        if (!hasNotifiedCodexErrorKey(previous, reconnectErrorKey))
           handleCodexCliReconnectDetected(tabId, reconnectClassification);
         notifyLog(`codexError.pendingFinal.reconnecting tab=${tabId} kind=${reconnectClassification.kind} ageMs=${pendingAgeMs}`);
         return;
@@ -4452,7 +4503,7 @@ export default function CodexFlowManagerUI() {
       return;
     }
 
-    const errorKey = buildCodexCliErrorKey(classification);
+    const errorKey = buildCodexCliErrorNotificationKey(classification);
     if (classification.phase === "reconnecting") {
       if (typeof previous.pendingFinalErrorTimerId === "number") {
         try { window.clearTimeout(previous.pendingFinalErrorTimerId); } catch {}
@@ -4460,14 +4511,14 @@ export default function CodexFlowManagerUI() {
       codexErrorScanByTabRef.current[tabId] = {
         ...latestScanState,
         buffer: nextBuffer,
-        lastReconnectErrorKey: errorKey,
         pendingFinalErrorKey: undefined,
         pendingFinalErrorKind: undefined,
         pendingFinalError: undefined,
         pendingFinalErrorAt: undefined,
         pendingFinalErrorTimerId: undefined,
+        notifiedErrorKeys: pushNotifiedCodexErrorKey(latestScanState, errorKey),
       };
-      if (previous.lastReconnectErrorKey === errorKey) return;
+      if (hasNotifiedCodexErrorKey(previous, errorKey)) return;
       handleCodexCliReconnectDetected(tabId, classification);
       return;
     }
@@ -4498,9 +4549,9 @@ export default function CodexFlowManagerUI() {
     codexErrorScanByTabRef.current[tabId] = {
       ...latestScanState,
       buffer: nextBuffer,
-      lastFinalErrorKey: errorKey,
+      notifiedErrorKeys: pushNotifiedCodexErrorKey(latestScanState, errorKey),
     };
-    if (previous.lastFinalErrorKey === errorKey) return;
+    if (hasNotifiedCodexErrorKey(previous, errorKey)) return;
     handleCodexCliErrorDetected(tabId, classification, errorKey);
   }
 
@@ -5893,8 +5944,6 @@ export default function CodexFlowManagerUI() {
     codexErrorScanByTabRef.current[id] = {
       ...state,
       buffer: "",
-      lastReconnectErrorKey: undefined,
-      lastFinalErrorKey: undefined,
       pendingErrorKey: undefined,
       pendingErrorKind: undefined,
       autoContinueTimerId: undefined,
@@ -5950,8 +5999,6 @@ export default function CodexFlowManagerUI() {
     codexErrorScanByTabRef.current[id] = {
       ...state,
       buffer: "",
-      lastReconnectErrorKey: undefined,
-      lastFinalErrorKey: undefined,
       pendingErrorKey: undefined,
       pendingErrorKind: undefined,
       autoContinueTimerId: undefined,

--- a/web/src/lib/codex-cli-error-classifier.test.ts
+++ b/web/src/lib/codex-cli-error-classifier.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   classifyCodexCliErrorText,
+  buildCodexCliErrorNotificationKey,
   detectCodexCliRuntimeStatusText,
   getCodexCliErrorKindLabel,
   isCodexCliErrorAutoRetryable,
@@ -193,6 +194,20 @@ describe("codex-cli-error-classifier（Codex TUI 错误识别）", () => {
     const result = classifyCodexCliErrorText(text);
     expect(result?.kind).toBe("serviceUnavailable");
     expect(result?.phase).toBe("final");
+  });
+
+  it("同一错误在 final 和 reconnecting 阶段会生成相同的通知键", () => {
+    const finalResult = classifyCodexCliErrorText(
+      "unexpected status 503 Service Unavailable: openai_error, url: http://example.test/v1/responses",
+    );
+    const reconnectingResult = classifyCodexCliErrorText(`
+      Reconnecting... 1/5 (4m 18s  esc to interrupt)
+        unexpected status 503 Service Unavailable: openai_error, url: http://example.test/v1/responses
+    `);
+
+    expect(finalResult?.phase).toBe("final");
+    expect(reconnectingResult?.phase).toBe("reconnecting");
+    expect(buildCodexCliErrorNotificationKey(finalResult!)).toBe(buildCodexCliErrorNotificationKey(reconnectingResult!));
   });
 
   it("Codex 最终历史错误行会压住旧的 Reconnecting 状态", () => {

--- a/web/src/lib/codex-cli-error-classifier.ts
+++ b/web/src/lib/codex-cli-error-classifier.ts
@@ -178,6 +178,16 @@ export function shouldDelayCodexCliFinalErrorForReconnect(classification: CodexC
 }
 
 /**
+ * 生成 Codex 错误通知去重键。
+ * 说明：只保留错误类别和错误文本本身，忽略 phase 与重连次数，避免同一条错误在重绘或回放时重复弹出。
+ */
+export function buildCodexCliErrorNotificationKey(classification: Pick<CodexCliErrorClassification, "kind" | "matchedText">): string {
+  const kind = String(classification?.kind || "").trim();
+  const text = normalizeCodexCliErrorText(String(classification?.matchedText || "")).toLowerCase();
+  return `${kind}:${text}`;
+}
+
+/**
  * 返回 Codex 错误类别对应的英文识别文本，用于设置面板与状态展示。
  */
 export function getCodexCliErrorKindLabel(kind: CodexCliErrorKind | undefined): string {


### PR DESCRIPTION
审查 323436e 的 Codex CLI 错误处理后，发现原先的回放保护窗会在
PTY 输出入口整体跳过错误扫描，可能把保护期内出现的真实新报错一并吞掉。

本次修复：
- 移除按标签页计时的错误回放保护窗，恢复对 PTY 输出的持续扫描。
- 用户发起新一轮输入时清空已通知错误键，避免旧轮次的同类错误压住新错误。
- 计时启动和同轮自动继续仍保留已通知错误键，维持同一轮内的重复通知抑制。