### PR TITLE
fix(git): 修复控制台复制与文本选区复制链路

### DIFF
--- a/electron/git/consoleStore.test.ts
+++ b/electron/git/consoleStore.test.ts
@@ -8,21 +8,25 @@ describe("GitConsoleStore", () => {
     const repoRoot = "/repo";
     const longStdout = `header\n${"0123456789".repeat(8_500)}`;
 
-    store.appendCompletedEntry({
-      cwd: repoRoot,
-      gitPath: "git",
-      argv: ["log", "--oneline"],
-      result: {
-        ok: true,
-        stdout: longStdout,
-        stderr: "",
-        exitCode: 0,
-      },
-      durationMs: 12,
-    });
+    for (let index = 0; index < 25; index += 1) {
+      store.appendCompletedEntry({
+        cwd: repoRoot,
+        gitPath: "git",
+        argv: ["log", "--oneline", String(index)],
+        result: {
+          ok: true,
+          stdout: longStdout,
+          stderr: "",
+          exitCode: 0,
+        },
+        durationMs: 12 + index,
+      });
+    }
 
     const viewEntry = store.listEntries(repoRoot, 20, "view")[0];
     const copyEntry = store.listEntries(repoRoot, 20, "copy")[0];
+    const cappedEntries = store.listEntries(repoRoot, 20, "copy");
+    const fullEntries = store.listEntries(repoRoot, 0, "copy");
 
     expect(viewEntry).toBeTruthy();
     expect(copyEntry).toBeTruthy();
@@ -30,5 +34,58 @@ describe("GitConsoleStore", () => {
     expect(viewEntry?.stdout.endsWith("…")).toBe(true);
     expect(copyEntry?.stdout).toBe(longStdout);
     expect(copyEntry?.stdout.length).toBeGreaterThan(viewEntry?.stdout.length || 0);
+    expect(cappedEntries).toHaveLength(20);
+    expect(fullEntries).toHaveLength(25);
+  });
+
+  it("按仓库读取日志时应包含仓库子目录里执行的记录", () => {
+    const store = new GitConsoleStore();
+    const repoRoot = "/repo";
+    const subdir = "/repo/packages/app";
+    const siblingRepo = "/repo-other";
+
+    store.appendCompletedEntry({
+      cwd: repoRoot,
+      gitPath: "git",
+      argv: ["status"],
+      result: {
+        ok: true,
+        stdout: "root",
+        stderr: "",
+        exitCode: 0,
+      },
+      durationMs: 10,
+    });
+    store.appendCompletedEntry({
+      cwd: subdir,
+      gitPath: "git",
+      argv: ["log"],
+      result: {
+        ok: true,
+        stdout: "subdir",
+        stderr: "",
+        exitCode: 0,
+      },
+      durationMs: 11,
+    });
+    store.appendCompletedEntry({
+      cwd: siblingRepo,
+      gitPath: "git",
+      argv: ["status"],
+      result: {
+        ok: true,
+        stdout: "sibling",
+        stderr: "",
+        exitCode: 0,
+      },
+      durationMs: 12,
+    });
+
+    const entries = store.listEntries(repoRoot, 0, "copy");
+    expect(entries.map((entry) => entry.stdout)).toEqual(["root", "subdir"]);
+
+    const cleared = store.clearEntries(repoRoot);
+    expect(cleared).toBe(2);
+    expect(store.listEntries("", 0, "copy").map((entry) => entry.stdout)).toEqual(["sibling"]);
   });
 });

--- a/electron/git/consoleStore.ts
+++ b/electron/git/consoleStore.ts
@@ -53,6 +53,18 @@ function formatGitCommandForConsole(gitPath: string, argv: string[]): string {
 }
 
 /**
+ * 判断控制台记录是否归属于指定仓库路径，兼容以仓库子目录作为 cwd 的 Git 命令。
+ */
+function isEntryInRepoScope(entry: GitConsoleEntry, repoRootAbs: string, repoRootKey: string): boolean {
+  if (!repoRootKey) return true;
+  if (entry.repoRootKey === repoRootKey) return true;
+  const entryKey = entry.repoRootKey || toFsPathKey(entry.cwd);
+  if (entryKey === repoRootKey) return true;
+  if (entryKey.startsWith(`${repoRootKey}/`)) return true;
+  return !!repoRootAbs && !entry.repoRootKey && entry.cwd === repoRootAbs;
+}
+
+/**
  * 管理 Git 控制台内存记录。
  * - 存储层保留较长文本，保证“复制日志”尽量拿到完整输出；
  * - 列表层默认再做一次轻量裁剪，避免大文本直接进入渲染树。
@@ -154,14 +166,14 @@ export class GitConsoleStore {
    * 按仓库读取控制台记录；默认返回适合 UI 展示的短文本。
    */
   listEntries(repoRootOrPath: string, limitInput: number, mode: GitConsoleListMode = "view"): GitConsoleEntry[] {
-    const limit = Math.max(20, Math.min(500, Math.floor(Number(limitInput) || 200)));
+    const normalizedLimit = Number(limitInput);
+    const rawLimit = Number.isFinite(normalizedLimit) ? Math.floor(normalizedLimit) : 200;
+    const limit = rawLimit <= 0 ? 0 : Math.max(20, Math.min(500, rawLimit));
     const abs = toFsPathAbs(String(repoRootOrPath || "").trim());
     const key = toFsPathKey(abs);
-    const source = key
-      ? this.entries.filter((entry) => entry.repoRootKey === key || (!entry.repoRootKey && entry.cwd === abs))
-      : this.entries;
-    const start = Math.max(0, source.length - limit);
-    return source.slice(start).map((entry) => this.cloneEntryForMode(entry, mode));
+    const source = key ? this.entries.filter((entry) => isEntryInRepoScope(entry, abs, key)) : this.entries;
+    const sliced = limit > 0 ? source.slice(Math.max(0, source.length - limit)) : source;
+    return sliced.map((entry) => this.cloneEntryForMode(entry, mode));
   }
 
   /**
@@ -179,7 +191,7 @@ export class GitConsoleStore {
     let removed = 0;
     for (let idx = this.entries.length - 1; idx >= 0; idx -= 1) {
       const hit = this.entries[idx];
-      if (hit.repoRootKey === key || (!hit.repoRootKey && hit.cwd === abs)) {
+      if (isEntryInRepoScope(hit, abs, key)) {
         this.entries.splice(idx, 1);
         removed += 1;
       }

--- a/electron/git/featureService.operation.test.ts
+++ b/electron/git/featureService.operation.test.ts
@@ -159,12 +159,12 @@ async function getStatusSnapshotAsync(userDataPath: string, repo: string): Promi
 /**
  * 读取指定仓库的 Git 控制台记录，便于验证 Pull 是否真的走了独立命令链。
  */
-async function listConsoleEntriesAsync(userDataPath: string, repo: string): Promise<GitConsoleEntry[]> {
+async function listConsoleEntriesAsync(userDataPath: string, repo: string, limit: number = 200): Promise<GitConsoleEntry[]> {
   const res = await dispatchGitFeatureAction({
     action: "console.get",
     payload: {
       repoPath: repo,
-      limit: 200,
+      limit,
       includeLongText: true,
     },
     userDataPath,

--- a/electron/git/featureService.ts
+++ b/electron/git/featureService.ts
@@ -11123,7 +11123,10 @@ export async function dispatchGitFeatureAction(args: GitFeatureActionArgs): Prom
 
     if (action === "console.get") {
       const repoPath = String(args.payload?.repoPath || "").trim();
-      const limit = Math.max(20, Math.min(500, Math.floor(Number(args.payload?.limit) || 200)));
+      const normalizedLimit = Number(args.payload?.limit);
+      const limit = Number.isFinite(normalizedLimit)
+        ? (Math.floor(normalizedLimit) <= 0 ? 0 : Math.max(20, Math.min(500, Math.floor(normalizedLimit))))
+        : 200;
       const mode = args.payload?.includeLongText === true ? "copy" : "view";
       const repoRoot = repoPath ? resolveConsoleRepoPath(repoPath) : "";
       return {

--- a/package.json
+++ b/package.json
@@ -160,6 +160,5 @@
       "en-US",
       "zh-CN"
     ]
-  },
-  "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48"
+  }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -73,7 +73,6 @@ import { collectRetainedAgentTurnTabIds, pruneAgentTurnHistory, pruneAgentTurnTi
 import {
   classifyCodexCliErrorText,
   detectCodexCliRuntimeStatusText,
-  buildCodexCliErrorNotificationKey,
   getCodexCliErrorKindLabel,
   shouldDelayCodexCliFinalErrorForReconnect,
   stripAnsiForCodexErrorScan,
@@ -427,7 +426,8 @@ type AgentTurnTimerState = {
 
 type CodexErrorScanState = {
   buffer: string;
-  notifiedErrorKeys?: string[];
+  lastReconnectErrorKey?: string;
+  lastFinalErrorKey?: string;
   lastReconnectStatusAt?: number;
   pendingErrorKey?: string;
   pendingErrorKind?: CodexCliErrorKind;
@@ -443,7 +443,6 @@ type CodexErrorScanState = {
 const CODEX_ERROR_SCAN_MAX_BUFFER_LENGTH = 16 * 1024;
 const CODEX_RECONNECT_DETAIL_GRACE_MS = 10_000;
 const CODEX_RECONNECT_AFTER_ERROR_GRACE_MS = 10_000;
-const CODEX_ERROR_SCAN_NOTIFIED_KEYS_LIMIT = 64;
 
 /**
  * 中文说明：生成 Codex 错误去重键，避免同一段终端输出反复触发处理。
@@ -451,44 +450,6 @@ const CODEX_ERROR_SCAN_NOTIFIED_KEYS_LIMIT = 64;
 function buildCodexCliErrorKey(classification: CodexCliErrorClassification): string {
   const attempt = classification.reconnectAttempt ? `:${classification.reconnectAttempt}/${classification.reconnectMaxAttempts || "?"}` : "";
   return `${classification.phase}:${classification.kind}${attempt}:${classification.matchedText}`;
-}
-
-/**
- * 中文说明：判断某个 Codex 错误键是否已经在本轮里通知过。
- */
-function hasNotifiedCodexErrorKey(state: CodexErrorScanState | undefined, errorKey: string): boolean {
-  if (!state || !errorKey) return false;
-  return (
-    Array.isArray(state.notifiedErrorKeys) && state.notifiedErrorKeys.includes(errorKey)
-  );
-}
-/**
- * 中文说明：记录已经通知过的 Codex 错误键，并限制保存长度。
- */
-function pushNotifiedCodexErrorKey(state: CodexErrorScanState, errorKey: string): string[] {
-  const current = Array.isArray(state.notifiedErrorKeys) ? state.notifiedErrorKeys.filter((key) => key && key !== errorKey) : [];
-  current.push(errorKey);
-  return current.length > CODEX_ERROR_SCAN_NOTIFIED_KEYS_LIMIT
-    ? current.slice(-CODEX_ERROR_SCAN_NOTIFIED_KEYS_LIMIT)
-    : current;
-}
-
-/**
- * 中文说明：记录一次已经对用户可见的 Codex 错误，避免同一错误在重绘/回放后再次弹出。
- */
-function rememberCodexErrorNotification(
-  scanByTabRef: React.MutableRefObject<Record<string, CodexErrorScanState>>,
-  tabId: string,
-  errorKey: string,
-): void {
-  const id = String(tabId || "").trim();
-  if (!id || !errorKey) return;
-  const state = scanByTabRef.current[id];
-  if (!state) return;
-  scanByTabRef.current[id] = {
-    ...state,
-    notifiedErrorKeys: pushNotifiedCodexErrorKey(state, errorKey),
-  };
 }
 
 type CompletionEventSource = "osc" | "external" | "manual" | "unknown";
@@ -2848,7 +2809,6 @@ export default function CodexFlowManagerUI() {
     const id = String(tabId || "").trim();
     if (!id) return;
     const state = codexErrorScanByTabRef.current[id];
-    const shouldClearNotifiedErrorKeys = source === "user-send";
     if (state && typeof state.autoContinueTimerId === "number") {
       try { window.clearTimeout(state.autoContinueTimerId); } catch {}
       notifyLog(`codexError.scan.resetTimer tab=${id} source=${source}`);
@@ -2859,27 +2819,8 @@ export default function CodexFlowManagerUI() {
     }
     if (options?.keepAttempts && state) {
       codexErrorScanByTabRef.current[id] = {
-        ...state,
         buffer: "",
         autoContinueAttempts: state.autoContinueAttempts || 0,
-        notifiedErrorKeys: state.notifiedErrorKeys,
-        lastReconnectStatusAt: undefined,
-        pendingErrorKey: undefined,
-        pendingErrorKind: undefined,
-        autoContinueTimerId: undefined,
-        pendingFinalErrorKey: undefined,
-        pendingFinalErrorKind: undefined,
-        pendingFinalError: undefined,
-        pendingFinalErrorAt: undefined,
-        pendingFinalErrorTimerId: undefined,
-      };
-      return;
-    }
-    if (state) {
-      codexErrorScanByTabRef.current[id] = {
-        buffer: "",
-        autoContinueAttempts: 0,
-        notifiedErrorKeys: shouldClearNotifiedErrorKeys ? undefined : state.notifiedErrorKeys,
       };
       return;
     }
@@ -4228,7 +4169,6 @@ export default function CodexFlowManagerUI() {
       applyPending({ ...current, [id]: (current[id] ?? 0) + 1 });
     }
     showCompletionNotification(id, notificationBody);
-    rememberCodexErrorNotification(codexErrorScanByTabRef, id, errorKey);
     if (foreground && activeMatch)
       acknowledgeAgentTurnFailure(id, "visible-final-error");
     notifyLog(`codexError.detected tab=${id} kind=${classification.kind} retryable=${classification.retryable ? "1" : "0"} auto=${autoContinue ? "1" : "0"}`);
@@ -4272,7 +4212,7 @@ export default function CodexFlowManagerUI() {
     }
     const bufferedStatus = detectCodexCliRuntimeStatusText(state.buffer || "");
     const bufferedClassification = classifyCodexCliErrorText(state.buffer || "");
-    const bufferedErrorKey = bufferedClassification ? buildCodexCliErrorNotificationKey(bufferedClassification) : "";
+    const bufferedErrorKey = bufferedClassification ? buildCodexCliErrorKey(bufferedClassification) : "";
     if (
       bufferedStatus?.phase === "working" ||
       bufferedStatus?.phase === "reconnecting" ||
@@ -4302,6 +4242,7 @@ export default function CodexFlowManagerUI() {
       pendingFinalError: undefined,
       pendingFinalErrorAt: undefined,
       pendingFinalErrorTimerId: undefined,
+      lastFinalErrorKey: errorKey,
     };
     const timerState = agentTurnTimerByTabRef.current[id];
     if (!timerState || timerState.status !== "working") {
@@ -4338,11 +4279,13 @@ export default function CodexFlowManagerUI() {
         try { window.clearTimeout(previous.pendingFinalErrorTimerId); } catch {}
       }
       if (idleClassification?.phase === "final") {
-        const errorKey = buildCodexCliErrorNotificationKey(idleClassification);
+        const errorKey = buildCodexCliErrorKey(idleClassification);
         codexErrorScanByTabRef.current[tabId] = {
           ...previous,
           buffer: "",
+          lastReconnectErrorKey: undefined,
           lastReconnectStatusAt: undefined,
+          lastFinalErrorKey: errorKey,
           pendingFinalErrorKey: undefined,
           pendingFinalErrorKind: undefined,
           pendingFinalError: undefined,
@@ -4350,7 +4293,7 @@ export default function CodexFlowManagerUI() {
           pendingFinalErrorTimerId: undefined,
         };
         clearAgentTurnReconnecting(tabId, "idle-final-error");
-        if (!hasNotifiedCodexErrorKey(previous, errorKey))
+        if (previous.lastFinalErrorKey !== errorKey)
           handleCodexCliErrorDetected(tabId, idleClassification, errorKey);
         notifyLog(`codexError.idle.final tab=${tabId} kind=${idleClassification.kind}`);
         return;
@@ -4358,6 +4301,7 @@ export default function CodexFlowManagerUI() {
       codexErrorScanByTabRef.current[tabId] = {
         ...previous,
         buffer: "",
+        lastReconnectErrorKey: undefined,
         lastReconnectStatusAt: undefined,
         pendingFinalErrorKey: undefined,
         pendingFinalErrorKind: undefined,
@@ -4381,6 +4325,8 @@ export default function CodexFlowManagerUI() {
         codexErrorScanByTabRef.current[tabId] = {
           ...restoredScanState,
           buffer: cleanedChunk.slice(-CODEX_ERROR_SCAN_MAX_BUFFER_LENGTH),
+          lastReconnectErrorKey: undefined,
+          lastFinalErrorKey: undefined,
           lastReconnectStatusAt: undefined,
           pendingErrorKey: undefined,
           pendingErrorKind: undefined,
@@ -4411,7 +4357,7 @@ export default function CodexFlowManagerUI() {
         reconnectAttempt: reconnectClassification.reconnectAttempt || chunkRuntimeStatus.reconnectAttempt,
         reconnectMaxAttempts: reconnectClassification.reconnectMaxAttempts || chunkRuntimeStatus.reconnectMaxAttempts,
       };
-      const reconnectErrorKey = buildCodexCliErrorNotificationKey(normalizedReconnectClassification);
+      const reconnectErrorKey = buildCodexCliErrorKey(normalizedReconnectClassification);
       restoreFailedAgentTurnToReconnecting(tabId, normalizedReconnectClassification, "pty-runtime-status");
       const restoredScanState = codexErrorScanByTabRef.current[tabId] || previous;
       if (typeof restoredScanState.pendingFinalErrorTimerId === "number") {
@@ -4420,6 +4366,7 @@ export default function CodexFlowManagerUI() {
       codexErrorScanByTabRef.current[tabId] = {
         ...restoredScanState,
         buffer: nextBuffer,
+        lastReconnectErrorKey: reconnectErrorKey,
         lastReconnectStatusAt: now,
         pendingErrorKey: undefined,
         pendingErrorKind: undefined,
@@ -4430,7 +4377,7 @@ export default function CodexFlowManagerUI() {
         pendingFinalErrorAt: undefined,
         pendingFinalErrorTimerId: undefined,
       };
-      if (!hasNotifiedCodexErrorKey(previous, reconnectErrorKey))
+      if (previous.lastReconnectErrorKey !== reconnectErrorKey)
         handleCodexCliReconnectDetected(tabId, normalizedReconnectClassification);
       notifyLog(`codexError.failed.reconnecting tab=${tabId} kind=${normalizedReconnectClassification.kind}`);
       return;
@@ -4443,6 +4390,8 @@ export default function CodexFlowManagerUI() {
       ? {
         ...previous,
         buffer: "",
+        lastReconnectErrorKey: undefined,
+        lastReconnectStatusAt: undefined,
         pendingFinalErrorKey: undefined,
         pendingFinalErrorKind: undefined,
         pendingFinalError: undefined,
@@ -4468,7 +4417,7 @@ export default function CodexFlowManagerUI() {
           reconnectAttempt: chunkRuntimeStatus.reconnectAttempt,
           reconnectMaxAttempts: chunkRuntimeStatus.reconnectMaxAttempts,
         };
-        const reconnectErrorKey = buildCodexCliErrorNotificationKey(reconnectClassification);
+        const reconnectErrorKey = buildCodexCliErrorKey(reconnectClassification);
         codexErrorScanByTabRef.current[tabId] = {
           ...latestScanState,
           buffer: nextBuffer,
@@ -4477,9 +4426,9 @@ export default function CodexFlowManagerUI() {
           pendingFinalError: undefined,
           pendingFinalErrorAt: undefined,
           pendingFinalErrorTimerId: undefined,
-          notifiedErrorKeys: pushNotifiedCodexErrorKey(latestScanState, reconnectErrorKey),
+          lastReconnectErrorKey: reconnectErrorKey,
         };
-        if (!hasNotifiedCodexErrorKey(previous, reconnectErrorKey))
+        if (previous.lastReconnectErrorKey !== reconnectErrorKey)
           handleCodexCliReconnectDetected(tabId, reconnectClassification);
         notifyLog(`codexError.pendingFinal.reconnecting tab=${tabId} kind=${reconnectClassification.kind} ageMs=${pendingAgeMs}`);
         return;
@@ -4503,7 +4452,7 @@ export default function CodexFlowManagerUI() {
       return;
     }
 
-    const errorKey = buildCodexCliErrorNotificationKey(classification);
+    const errorKey = buildCodexCliErrorKey(classification);
     if (classification.phase === "reconnecting") {
       if (typeof previous.pendingFinalErrorTimerId === "number") {
         try { window.clearTimeout(previous.pendingFinalErrorTimerId); } catch {}
@@ -4511,14 +4460,14 @@ export default function CodexFlowManagerUI() {
       codexErrorScanByTabRef.current[tabId] = {
         ...latestScanState,
         buffer: nextBuffer,
+        lastReconnectErrorKey: errorKey,
         pendingFinalErrorKey: undefined,
         pendingFinalErrorKind: undefined,
         pendingFinalError: undefined,
         pendingFinalErrorAt: undefined,
         pendingFinalErrorTimerId: undefined,
-        notifiedErrorKeys: pushNotifiedCodexErrorKey(latestScanState, errorKey),
       };
-      if (hasNotifiedCodexErrorKey(previous, errorKey)) return;
+      if (previous.lastReconnectErrorKey === errorKey) return;
       handleCodexCliReconnectDetected(tabId, classification);
       return;
     }
@@ -4549,9 +4498,9 @@ export default function CodexFlowManagerUI() {
     codexErrorScanByTabRef.current[tabId] = {
       ...latestScanState,
       buffer: nextBuffer,
-      notifiedErrorKeys: pushNotifiedCodexErrorKey(latestScanState, errorKey),
+      lastFinalErrorKey: errorKey,
     };
-    if (hasNotifiedCodexErrorKey(previous, errorKey)) return;
+    if (previous.lastFinalErrorKey === errorKey) return;
     handleCodexCliErrorDetected(tabId, classification, errorKey);
   }
 
@@ -5944,6 +5893,8 @@ export default function CodexFlowManagerUI() {
     codexErrorScanByTabRef.current[id] = {
       ...state,
       buffer: "",
+      lastReconnectErrorKey: undefined,
+      lastFinalErrorKey: undefined,
       pendingErrorKey: undefined,
       pendingErrorKind: undefined,
       autoContinueTimerId: undefined,
@@ -5999,6 +5950,8 @@ export default function CodexFlowManagerUI() {
     codexErrorScanByTabRef.current[id] = {
       ...state,
       buffer: "",
+      lastReconnectErrorKey: undefined,
+      lastFinalErrorKey: undefined,
       pendingErrorKey: undefined,
       pendingErrorKind: undefined,
       autoContinueTimerId: undefined,

--- a/web/src/features/git/api.ts
+++ b/web/src/features/git/api.ts
@@ -170,6 +170,7 @@ function shouldEmitGitFeatureActivity(action: string): boolean {
  */
 function buildStaleCancelableGitRequestKey(action: string, payload?: any): string {
   if (!STALE_CANCEL_GIT_ACTIONS.has(action)) return "";
+  if (action === "console.get" && payload?.preserveAllEntries === true) return "";
   const repoPath = String(payload?.repoPath || payload?.repoRoot || "").trim().replace(/\\/g, "/").toLowerCase();
   const path = String(payload?.path || "").trim();
   const mode = String(payload?.mode || "").trim();
@@ -1203,12 +1204,13 @@ export async function removeWorktreeAsync(repoPath: string, payload: { path: str
 export async function getGitConsoleAsync(
   repoPath: string,
   limit: number = 200,
-  options?: { includeLongText?: boolean },
+  options?: { includeLongText?: boolean; preserveAllEntries?: boolean },
 ): Promise<GitFeatureResponse<{ repoRoot?: string; items: GitConsoleEntry[] }>> {
   return await callGitFeatureAsync("console.get", {
     repoPath,
     limit,
     includeLongText: options?.includeLongText === true,
+    preserveAllEntries: options?.preserveAllEntries === true,
   });
 }
 

--- a/web/src/features/git/git-workbench-utils.test.ts
+++ b/web/src/features/git/git-workbench-utils.test.ts
@@ -796,4 +796,45 @@ describe("git workbench utils", () => {
     expect(text).toContain("exitCode: 1");
     expect(text).toContain("fatal: bad revision");
   });
+
+  it("Git 控制台复制文本应保留所有条目", () => {
+    const text = buildGitConsoleCopyText([
+      createConsoleEntry({ id: 1, command: "git status", stdout: "first" }),
+      createConsoleEntry({ id: 2, command: "git log --oneline", stdout: "second" }),
+      createConsoleEntry({ id: 3, command: "git diff --stat", stdout: "third" }),
+    ]);
+
+    expect(text).toContain("$ git status");
+    expect(text).toContain("first");
+    expect(text).toContain("$ git log --oneline");
+    expect(text).toContain("second");
+    expect(text).toContain("$ git diff --stat");
+    expect(text).toContain("third");
+  });
+
+  it("Git 控制台选中文本的复制结果应直接保留原文", () => {
+    expect(buildGitConsoleCopyText([
+      createConsoleEntry({
+        command: "git show",
+        stdout: "97fd661a82fd1dc25fbf9efd242b0628b8bc22af",
+      }),
+    ])).toContain("97fd661a82fd1dc25fbf9efd242b0628b8bc22af");
+  });
+
+  it("Git 控制台复制文本应清理 NUL 与 RS 控制字符", () => {
+    const text = buildGitConsoleCopyText([
+      createConsoleEntry({
+        command: "git log",
+        stdout: "97fd661a82fd1dc25fbf9efd242b0628b8bc22af\u0000后续内容",
+        stderr: "warn\u001e第二段",
+      }),
+    ]);
+
+    expect(text).not.toContain("\u0000");
+    expect(text).not.toContain("\u001e");
+    expect(text).toContain("97fd661a82fd1dc25fbf9efd242b0628b8bc22af");
+    expect(text).toContain("后续内容");
+    expect(text).toContain("warn");
+    expect(text).toContain("第二段");
+  });
 });

--- a/web/src/features/git/git-workbench-utils.ts
+++ b/web/src/features/git/git-workbench-utils.ts
@@ -650,14 +650,25 @@ export function buildGitConsoleCopyText(entries: GitConsoleEntry[]): string {
         String(entry.cwd || "").trim(),
       ].filter(Boolean).join(" ");
       return [
-        header,
-        entry.running ? "" : `exitCode: ${exitCode}`,
-        `$ ${String(entry.command || "").trim()}`,
-        String(entry.stdout || ""),
-        String(entry.stderr || ""),
-        String(entry.error || ""),
+        normalizeGitConsoleClipboardText(header),
+        entry.running ? "" : normalizeGitConsoleClipboardText(`exitCode: ${exitCode}`),
+        normalizeGitConsoleClipboardText(`$ ${String(entry.command || "").trim()}`),
+        normalizeGitConsoleClipboardText(String(entry.stdout || "")),
+        normalizeGitConsoleClipboardText(String(entry.stderr || "")),
+        normalizeGitConsoleClipboardText(String(entry.error || "")),
       ].filter((one) => one.length > 0).join("\n");
     })
     .filter(Boolean)
     .join("\n\n");
+}
+
+/**
+ * 把 Git 控制台文本规整为可安全复制的纯文本，避免 NUL / RS 这类控制字符截断剪贴板。
+ */
+export function normalizeGitConsoleClipboardText(text: string): string {
+  return String(text || "")
+    .replace(/%x(?:00|1e)/gi, " ")
+    .replace(/\x00|\x1e/g, "\n")
+    .replace(/\r\n?/g, "\n")
+    .replace(/[\u0001-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "");
 }

--- a/web/src/features/git/git-workbench.tsx
+++ b/web/src/features/git/git-workbench.tsx
@@ -217,6 +217,7 @@ import {
   resolveLogActionOperationFailureFeedback,
   resolveGitWorkbenchBootstrapRefresh,
   resolvePartialCommitValidationDiffMode,
+  normalizeGitConsoleClipboardText,
   shouldFinalizeCherryPickByCommit,
   shouldRefreshAfterClosingOperationProblem,
   shouldSkipCommitDetailsRequest,
@@ -936,7 +937,6 @@ const LOG_PAGE_SIZE = 200;
 const LOG_BRANCH_GROUP_MAX_VISIBLE = 2;
 const LOG_TAG_GROUP_MAX_VISIBLE = 1;
 const GIT_CONSOLE_VIEW_LIMIT = 250;
-const GIT_CONSOLE_COPY_LIMIT = 500;
 const DEFAULT_BOTTOM_HEIGHT = 260;
 const DEFAULT_LEFT_PANEL_WIDTH = 360;
 const DEFAULT_BRANCH_PANEL_WIDTH = 220;
@@ -3176,6 +3176,27 @@ type ToolbarDropdownSubmenuProps = {
   panelClassName?: string;
   children: React.ReactNode;
 };
+
+/**
+ * 判断文本选区是否落在指定容器内。
+ */
+function isSelectionInsideElement(selection: Selection | null | undefined, element: HTMLElement | null | undefined): boolean {
+  if (!selection || !element || selection.rangeCount <= 0) return false;
+  for (let index = 0; index < selection.rangeCount; index += 1) {
+    const range = selection.getRangeAt(index);
+    if (element.contains(range.commonAncestorContainer)) return true;
+    if (element.contains(range.startContainer) || element.contains(range.endContainer)) return true;
+  }
+  return false;
+}
+
+/**
+ * 判断节点是否位于指定选择器对应的祖先元素内。
+ */
+function isNodeInsideClosestSelector(node: Node | null | undefined, selector: string): boolean {
+  const element = node instanceof Element ? node : node?.parentElement;
+  return !!element?.closest?.(selector);
+}
 
 /**
  * 工具栏下拉菜单专用子菜单，尺寸与普通下拉项保持一致，不复用右键菜单样式。
@@ -6365,6 +6386,23 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     selectedDetailNodeKeys,
   ]);
 
+  /**
+   * 判断当前浏览器文本选区是否属于 Git 工作台中可直接复制的文本区域。
+   */
+  const hasGitTextSelection = useCallback((selection: Selection | null | undefined, target: HTMLElement | null): boolean => {
+    if (!selection || selection.isCollapsed || !normalizeGitConsoleClipboardText(selection.toString())) return false;
+    if (isSelectionInsideElement(selection, consoleListRef.current)) return true;
+    if (isSelectionInsideElement(selection, logVirtual.containerRef.current)) return true;
+    if (isSelectionInsideElement(selection, commitTreeContainerRef.current)) return true;
+    if (isSelectionInsideElement(selection, detailTreeContainerRef.current)) return true;
+    if (isSelectionInsideElement(selection, branchPanelContainerRef.current)) return true;
+    const anchorNode = selection.anchorNode;
+    const focusNode = selection.focusNode;
+    if (isNodeInsideClosestSelector(anchorNode, ".cf-git-log-row, .cf-git-console, .cf-git-pane, .cf-git-bottom-panel")) return true;
+    if (isNodeInsideClosestSelector(focusNode, ".cf-git-log-row, .cf-git-console, .cf-git-pane, .cf-git-bottom-panel")) return true;
+    return !!target?.closest?.(".cf-git-log-row, .cf-git-console, .cf-git-pane, .cf-git-bottom-panel");
+  }, [logVirtual.containerRef]);
+
   const logDecorationContextKey = useMemo<string>(() => {
     return `${String(repoBranch || "").trim()}\n${JSON.stringify(branchPopup?.repositories || [])}\n${JSON.stringify(branchPopup?.groups || {})}`;
   }, [branchPopup?.groups, branchPopup?.repositories, repoBranch]);
@@ -7510,7 +7548,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     let entries = gitConsoleItems;
     let fetchError = "";
     if (repoRoot) {
-      const res = await getGitConsoleAsync(repoRoot, GIT_CONSOLE_COPY_LIMIT, { includeLongText: true });
+      const res = await getGitConsoleAsync(repoRoot, 0, { includeLongText: true, preserveAllEntries: true });
       if (res.ok && res.data) {
         entries = Array.isArray(res.data.items) ? res.data.items : [];
       } else {
@@ -12065,6 +12103,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
   const selectCommitHash = useCallback(
     (hash: string, event: React.MouseEvent): void => {
       if (!hash) return;
+      if (hasGitTextSelection(window.getSelection?.(), event.currentTarget as HTMLElement)) return;
       if (event.shiftKey && selectedCommitHashes.length > 0) {
         const last = selectedCommitHashes[selectedCommitHashes.length - 1];
         const from = logItems.findIndex((x) => x.hash === last);
@@ -12082,7 +12121,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
       }
       setSelectedCommitHashes([hash]);
     },
-    [logItems, selectedCommitHashes],
+    [hasGitTextSelection, logItems, selectedCommitHashes],
   );
 
   /**
@@ -15020,6 +15059,14 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
         return;
       }
       if (ctrl && !event.altKey && !event.shiftKey && key === "c") {
+        const selection = window.getSelection?.();
+        const selectionText = normalizeGitConsoleClipboardText(selection?.toString() || "");
+        if (selectionText && hasGitTextSelection(selection, target)) {
+          event.preventDefault();
+          event.stopImmediatePropagation();
+          void window.host?.utils?.copyText?.(selectionText);
+          return;
+        }
         if (isTextEditable) return;
         const text = buildActiveGitCopyText(target);
         if (!text) return;
@@ -15058,6 +15105,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     buildActiveGitCopyText,
     commitVisibleRowKeys,
     detailVisibleNodeKeys,
+    hasGitTextSelection,
     runBranchTreeActionAsync,
     runChangeMenuActionAsync,
     runFlowActionAsync,
@@ -15066,6 +15114,25 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     selectedCommitTreeKeys.length,
     selectedDetailNodeKeys.length,
   ]);
+
+  /**
+   * 兜底处理 Git 工作台内的原生复制事件，保证真实文本选区优先且剪贴板文本不含控制分隔符。
+   */
+  useEffect(() => {
+    if (!active) return;
+    const onCopy = (event: ClipboardEvent) => {
+      if (event.defaultPrevented) return;
+      const selection = window.getSelection?.();
+      const target = event.target as HTMLElement | null;
+      const selectionText = normalizeGitConsoleClipboardText(selection?.toString() || "");
+      if (!selectionText || !hasGitTextSelection(selection, target)) return;
+      event.preventDefault();
+      event.clipboardData?.setData("text/plain", selectionText);
+      if (!event.clipboardData) void window.host?.utils?.copyText?.(selectionText);
+    };
+    document.addEventListener("copy", onCopy, true);
+    return () => document.removeEventListener("copy", onCopy, true);
+  }, [active, hasGitTextSelection]);
 
   /**
    * 分支弹窗键盘导航（上下/回车/Esc）。

--- a/web/src/lib/codex-cli-error-classifier.test.ts
+++ b/web/src/lib/codex-cli-error-classifier.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   classifyCodexCliErrorText,
-  buildCodexCliErrorNotificationKey,
   detectCodexCliRuntimeStatusText,
   getCodexCliErrorKindLabel,
   isCodexCliErrorAutoRetryable,
@@ -194,20 +193,6 @@ describe("codex-cli-error-classifier（Codex TUI 错误识别）", () => {
     const result = classifyCodexCliErrorText(text);
     expect(result?.kind).toBe("serviceUnavailable");
     expect(result?.phase).toBe("final");
-  });
-
-  it("同一错误在 final 和 reconnecting 阶段会生成相同的通知键", () => {
-    const finalResult = classifyCodexCliErrorText(
-      "unexpected status 503 Service Unavailable: openai_error, url: http://example.test/v1/responses",
-    );
-    const reconnectingResult = classifyCodexCliErrorText(`
-      Reconnecting... 1/5 (4m 18s  esc to interrupt)
-        unexpected status 503 Service Unavailable: openai_error, url: http://example.test/v1/responses
-    `);
-
-    expect(finalResult?.phase).toBe("final");
-    expect(reconnectingResult?.phase).toBe("reconnecting");
-    expect(buildCodexCliErrorNotificationKey(finalResult!)).toBe(buildCodexCliErrorNotificationKey(reconnectingResult!));
   });
 
   it("Codex 最终历史错误行会压住旧的 Reconnecting 状态", () => {

--- a/web/src/lib/codex-cli-error-classifier.ts
+++ b/web/src/lib/codex-cli-error-classifier.ts
@@ -178,16 +178,6 @@ export function shouldDelayCodexCliFinalErrorForReconnect(classification: CodexC
 }
 
 /**
- * 生成 Codex 错误通知去重键。
- * 说明：只保留错误类别和错误文本本身，忽略 phase 与重连次数，避免同一条错误在重绘或回放时重复弹出。
- */
-export function buildCodexCliErrorNotificationKey(classification: Pick<CodexCliErrorClassification, "kind" | "matchedText">): string {
-  const kind = String(classification?.kind || "").trim();
-  const text = normalizeCodexCliErrorText(String(classification?.matchedText || "")).toLowerCase();
-  return `${kind}:${text}`;
-}
-
-/**
  * 返回 Codex 错误类别对应的英文识别文本，用于设置面板与状态展示。
  */
 export function getCodexCliErrorKindLabel(kind: CodexCliErrorKind | undefined): string {


### PR DESCRIPTION
本次把前面 3 个自动提交整理为一个正式提交，主要包含：
- 修复 Git 控制台按仓库读取和清理时的归属判断，兼容仓库子目录执行的命令记录
- 支持在 Git 工作台里优先复制真实文本选区，并清理控制字符，避免剪贴板内容被截断
- 复制控制台日志时改为按完整记录拉取，保留更完整的 stdout / stderr / error 内容
- 补充控制台归属、复制文本净化、复制链路与控制台读取相关单测

验证：
- `npm test -- --run electron/git/consoleStore.test.ts web/src/features/git/git-workbench-utils.test.ts electron/git/featureService.operation.test.ts`