### PR TITLE
fix(git): 修复自动刷新自噪音循环

### DIFF
--- a/web/src/features/git/api.test.ts
+++ b/web/src/features/git/api.test.ts
@@ -137,14 +137,43 @@ describe("git api alignment", () => {
     }));
   });
 
-  it("连续 Git 读请求应取消同键旧请求，避免后台读取堆积", async () => {
-    const firstStatus = createDeferred<{ ok: boolean }>();
-    let firstStatusRequestId = 0;
+  it("连续可取消 Git 读请求应取消同键旧请求，避免后台读取堆积", async () => {
+    const firstDiff = createDeferred<{ ok: boolean }>();
+    let firstDiffRequestId = 0;
     const call = vi.fn(async (args: any) => {
-      if (args?.action === "status.get" && !firstStatusRequestId) {
-        firstStatusRequestId = Number(args.requestId || 0);
-        return await firstStatus.promise;
+      if (args?.action === "diff.get" && !firstDiffRequestId) {
+        firstDiffRequestId = Number(args.requestId || 0);
+        return await firstDiff.promise;
       }
+      return { ok: true };
+    });
+    (globalThis as any).window = {
+      host: {
+        gitFeature: { call },
+      },
+    };
+
+    const first = api.getDiffAsync("/repo", { path: "src/a.ts", mode: "working" });
+    await Promise.resolve();
+    const second = api.getDiffAsync("/repo", { path: "src/a.ts", mode: "working" });
+    await Promise.resolve();
+
+    expect(call).toHaveBeenCalledWith(expect.objectContaining({
+      action: "request.cancel",
+      payload: expect.objectContaining({
+        targetRequestId: firstDiffRequestId,
+      }),
+      requestId: 0,
+    }));
+    firstDiff.resolve({ ok: true });
+    await Promise.all([first, second]);
+  });
+
+  it("连续状态刷新不应取消旧 status.get 请求", async () => {
+    const firstStatus = createDeferred<{ ok: boolean }>();
+    const call = vi.fn(async (args: any) => {
+      if (args?.action === "status.get")
+        return await firstStatus.promise;
       return { ok: true };
     });
     (globalThis as any).window = {
@@ -158,12 +187,8 @@ describe("git api alignment", () => {
     const second = api.getStatusAsync("/repo");
     await Promise.resolve();
 
-    expect(call).toHaveBeenCalledWith(expect.objectContaining({
+    expect(call).not.toHaveBeenCalledWith(expect.objectContaining({
       action: "request.cancel",
-      payload: expect.objectContaining({
-        targetRequestId: firstStatusRequestId,
-      }),
-      requestId: 0,
     }));
     firstStatus.resolve({ ok: true });
     await Promise.all([first, second]);

--- a/web/src/features/git/api.ts
+++ b/web/src/features/git/api.ts
@@ -102,8 +102,6 @@ const STALE_CANCEL_GIT_ACTIONS = new Set<string>([
   "push.preview",
   "shelf.list",
   "stash.list",
-  "status.get",
-  "status.getIgnored",
   "worktree.list",
 ]);
 

--- a/web/src/features/git/git-workbench.tsx
+++ b/web/src/features/git/git-workbench.tsx
@@ -7031,6 +7031,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
     refreshStatusAsync: refreshStatusForAutoRefreshAsync,
     refreshRefsAsync: refreshRefsForAutoRefreshAsync,
     refreshWorktreesAsync: refreshWorktreeItemsForAutoRefreshAsync,
+    isRefreshBusy: refreshAllController.isBusy,
   });
 
   /**

--- a/web/src/features/git/use-git-auto-refresh.test.ts
+++ b/web/src/features/git/use-git-auto-refresh.test.ts
@@ -69,6 +69,7 @@ function TestHarness(props: {
   refreshStatusAsync?: (options?: { debounceMs?: number }) => Promise<void>;
   refreshRefsAsync?: (options?: { debounceMs?: number }) => Promise<void>;
   refreshWorktreesAsync?: (options?: { debounceMs?: number }) => Promise<void>;
+  isRefreshBusy?: () => boolean;
 }): JSX.Element | null {
   useGitAutoRefresh(props);
   return null;
@@ -559,6 +560,108 @@ describe("useGitAutoRefresh", () => {
       await flushMicrotasksAsync();
     });
     expect(refreshAllAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("整仓刷新中的 index 元数据事件应视为自噪音", async () => {
+    const hostApis = createHostApis();
+    const refreshAllAsync = vi.fn(async (_options?: { keepLog?: boolean; debounceMs?: number }) => {});
+    const refreshStatusAsync = vi.fn(async (_options?: { debounceMs?: number }) => {});
+    Object.defineProperty(window, "host", {
+      configurable: true,
+      writable: true,
+      value: {
+        fileIndex: hostApis.fileIndex,
+        gitRepoWatch: hostApis.gitRepoWatch,
+      },
+    });
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(React.createElement(TestHarness, {
+        active: true,
+        repoRoot: "/repo-a",
+        refreshAllAsync,
+        refreshStatusAsync,
+        isRefreshBusy: () => true,
+      }));
+      await flushMicrotasksAsync();
+    });
+
+    await act(async () => {
+      hostApis.emitRepoWatch({ repoRoot: "/repo-a", reason: "index", paths: ["/repo-a/.git/index"] });
+      await flushMicrotasksAsync();
+    });
+
+    expect(refreshStatusAsync).not.toHaveBeenCalled();
+    expect(refreshAllAsync).not.toHaveBeenCalled();
+  });
+
+  it("相同 roots 的重新渲染不能清空刷新中的自噪音窗口", async () => {
+    const hostApis = createHostApis();
+    const statusResolvers: Array<() => void> = [];
+    const refreshAllAsync = vi.fn(async (_options?: { keepLog?: boolean; debounceMs?: number }) => {});
+    const refreshStatusAsync = vi.fn(async (_options?: { debounceMs?: number }) => {
+      await new Promise<void>((resolve) => {
+        statusResolvers.push(resolve);
+      });
+    });
+    Object.defineProperty(window, "host", {
+      configurable: true,
+      writable: true,
+      value: {
+        fileIndex: hostApis.fileIndex,
+        gitRepoWatch: hostApis.gitRepoWatch,
+      },
+    });
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(React.createElement(TestHarness, {
+        active: true,
+        repoRoot: "/repo-a",
+        repoRoots: ["/repo-a"],
+        refreshAllAsync,
+        refreshStatusAsync,
+      }));
+      await flushMicrotasksAsync();
+    });
+
+    await act(async () => {
+      hostApis.emitFileIndex({ root: "/repo-a" });
+      await flushMicrotasksAsync();
+    });
+    expect(refreshStatusAsync).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root!.render(React.createElement(TestHarness, {
+        active: true,
+        repoRoot: "/repo-a",
+        repoRoots: ["/repo-a"],
+        refreshAllAsync,
+        refreshStatusAsync,
+      }));
+      await flushMicrotasksAsync();
+    });
+
+    await act(async () => {
+      hostApis.emitRepoWatch({ repoRoot: "/repo-a", reason: "index", paths: ["/repo-a/.git/index"] });
+      await flushMicrotasksAsync();
+    });
+
+    expect(refreshStatusAsync).toHaveBeenCalledTimes(1);
+    expect(refreshAllAsync).not.toHaveBeenCalled();
+
+    await act(async () => {
+      for (const resolve of statusResolvers)
+        resolve();
+      await flushMicrotasksAsync();
+    });
   });
 
   it("刷新中的非 index 元数据事件仍应在静默窗口后补一次刷新", async () => {

--- a/web/src/features/git/use-git-auto-refresh.ts
+++ b/web/src/features/git/use-git-auto-refresh.ts
@@ -12,6 +12,7 @@ type UseGitAutoRefreshArgs = {
   refreshStatusAsync?: (options?: { debounceMs?: number }) => Promise<void>;
   refreshRefsAsync?: (options?: { debounceMs?: number }) => Promise<void>;
   refreshWorktreesAsync?: (options?: { debounceMs?: number }) => Promise<void>;
+  isRefreshBusy?: () => boolean;
 };
 
 const GIT_AUTO_REFRESH_SELF_NOISE_COOLDOWN_MS = 2000;
@@ -171,6 +172,8 @@ function mergeRefreshKind(
 export function useGitAutoRefresh(args: UseGitAutoRefreshArgs): void {
   const registrationIdRef = useRef<number>(0);
   const rootsKeyRef = useRef<string>("");
+  const isRefreshBusyRef = useRef(args.isRefreshBusy);
+  isRefreshBusyRef.current = args.isRefreshBusy;
   if (registrationIdRef.current <= 0) {
     gitAutoRefreshRegistrationSeq += 1;
     registrationIdRef.current = gitAutoRefreshRegistrationSeq;
@@ -206,6 +209,15 @@ export function useGitAutoRefresh(args: UseGitAutoRefreshArgs): void {
     inactiveDirtyKind: null,
     inactiveDirtyDebounceMs: 0,
   });
+  const roots = Array.from(new Set(
+    [args.repoRoot, ...(args.repoRoots || [])]
+      .map(normalizeGitAutoRefreshRoot)
+      .filter(Boolean),
+  ));
+  const rootsKey = buildGitAutoRefreshRootsKey(roots);
+  const hasRefreshStatusAsync = !!args.refreshStatusAsync;
+  const hasRefreshRefsAsync = !!args.refreshRefsAsync;
+  const hasRefreshWorktreesAsync = !!args.refreshWorktreesAsync;
 
   useEffect(() => {
     return () => {
@@ -214,12 +226,6 @@ export function useGitAutoRefresh(args: UseGitAutoRefreshArgs): void {
   }, []);
 
   useEffect(() => {
-    const roots = Array.from(new Set(
-      [args.repoRoot, ...(args.repoRoots || [])]
-        .map(normalizeGitAutoRefreshRoot)
-        .filter(Boolean),
-    ));
-    const rootsKey = buildGitAutoRefreshRootsKey(roots);
     const activeRootSet = new Set(roots);
     const refreshState = refreshStateRef.current;
     if (rootsKeyRef.current !== rootsKey) {
@@ -307,11 +313,11 @@ export function useGitAutoRefresh(args: UseGitAutoRefreshArgs): void {
      */
     const resolveRefreshKind = (source: "fileIndex" | "repoWatch", reason?: string): GitAutoRefreshKind => {
       if (source === "fileIndex")
-        return args.refreshStatusAsync ? "status" : "full";
+        return hasRefreshStatusAsync ? "status" : "full";
       const normalizedReason = String(reason || "").trim();
-      if (source === "repoWatch" && String(reason || "").trim() === "worktrees" && args.refreshWorktreesAsync)
+      if (source === "repoWatch" && String(reason || "").trim() === "worktrees" && hasRefreshWorktreesAsync)
         return "worktrees";
-      if ((normalizedReason === "index" || normalizedReason === "exclude") && args.refreshStatusAsync)
+      if ((normalizedReason === "index" || normalizedReason === "exclude") && hasRefreshStatusAsync)
         return "status";
       if (
         (normalizedReason === "head"
@@ -320,7 +326,7 @@ export function useGitAutoRefresh(args: UseGitAutoRefreshArgs): void {
           || normalizedReason === "merge"
           || normalizedReason === "cherry-pick"
           || normalizedReason === "revert")
-        && args.refreshRefsAsync
+        && hasRefreshRefsAsync
       )
         return "refs";
       return "full";
@@ -339,7 +345,14 @@ export function useGitAutoRefresh(args: UseGitAutoRefreshArgs): void {
         upsertGitAutoRefreshRootRegistration(registrationIdRef.current, roots, false);
         return;
       }
-      const inSuppressedWindow = !!refreshState.runningKind || Date.now() < refreshState.suppressedUntil;
+      const workbenchRefreshBusy = (() => {
+        try {
+          return isRefreshBusyRef.current?.() === true;
+        } catch {
+          return false;
+        }
+      })();
+      const inSuppressedWindow = !!refreshState.runningKind || workbenchRefreshBusy || Date.now() < refreshState.suppressedUntil;
       const normalizedReason = String(reason || "").trim();
       if (inSuppressedWindow && source === "repoWatch" && normalizedReason === "index")
         return;
@@ -391,11 +404,10 @@ export function useGitAutoRefresh(args: UseGitAutoRefreshArgs): void {
     };
   }, [
     args.active,
-    args.refreshRefsAsync,
-    args.refreshStatusAsync,
-    args.refreshWorktreesAsync,
-    args.repoRoot,
-    args.repoRoots,
+    hasRefreshRefsAsync,
+    hasRefreshStatusAsync,
+    hasRefreshWorktreesAsync,
+    rootsKey,
     refreshRefsRunner,
     refreshRunner,
     refreshStatusRunner,


### PR DESCRIPTION
Git 工作台的状态刷新会读取仓库状态，过程中可能触发 `.git/index` 等 watcher 事件。 这类事件如果再次进入状态刷新链路，会造成界面持续刷新，影响 Git 面板首屏和日常操作体验。

本次调整：
- status.get 不再使用同键旧请求取消，避免连续状态刷新互相取消。
- 自动刷新 hook 接收工作台整仓刷新忙碌状态，并把刷新中的 index 事件视为自噪音。
- 稳定 watcher roots 的 effect 依赖，避免相同 roots 重新渲染时重置静默窗口。
- 补充状态请求取消和自动刷新自噪音回归测试。