### PR TITLE
fix(git): 取消旧 Git 读取不再弹错并修复提交历史信息失败

### DIFF
--- a/electron/git/featureService.interactive-rebase.test.ts
+++ b/electron/git/featureService.interactive-rebase.test.ts
@@ -457,6 +457,9 @@ describe("featureService interactive rebase", () => {
             completed: true,
           }),
         );
+        const rewrittenSubjects = String(await gitAsync(fixture.repo, ["log", "--format=%s", "--reverse"])).trim().split(/\r?\n/);
+        expect(rewrittenSubjects).toContain("one rewritten from log action");
+        expect(rewrittenSubjects).not.toContain("one");
 
         const rewrittenHeadHash = String(await gitAsync(fixture.repo, ["rev-parse", "HEAD"])).trim();
         const deleteRes = await dispatchGitFeatureAction({

--- a/electron/git/featureService.ts
+++ b/electron/git/featureService.ts
@@ -813,6 +813,22 @@ function toGitEditorCommand(execPath: string, scriptPath: string): string {
 }
 
 /**
+ * 生成 Git 编辑器脚本环境，确保打包后的 Electron 可执行文件按 Node 脚本模式运行。
+ */
+function buildGitEditorScriptEnvPatch(
+  sequenceEditorScriptPath: string,
+  commitEditorScriptPath: string,
+  extraEnv?: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  return {
+    ...(extraEnv || {}),
+    ELECTRON_RUN_AS_NODE: "1",
+    GIT_SEQUENCE_EDITOR: toGitEditorCommand(process.execPath, sequenceEditorScriptPath),
+    GIT_EDITOR: toGitEditorCommand(process.execPath, commitEditorScriptPath),
+  };
+}
+
+/**
  * 删除路径（不存在时忽略），用于清理临时脚本目录。
  */
 async function removePathIfExistsAsync(targetPath: string): Promise<void> {
@@ -9306,13 +9322,15 @@ async function runInteractiveRebasePlanActionAsync(
   let artifacts: GitInteractiveRebaseEditorArtifacts | null = null;
   try {
     artifacts = await createGitInteractiveRebaseEditorArtifactsAsync(ctx, todoRows, queueItems);
-    const envPatch: NodeJS.ProcessEnv = {
-      CODEXFLOW_GIT_REBASE_TODO_FILE: artifacts.todoFilePath,
-      CODEXFLOW_GIT_REBASE_QUEUE_FILE: artifacts.queueFilePath,
-      CODEXFLOW_GIT_REBASE_QUEUE_STATE_FILE: artifacts.queueStateFilePath,
-      GIT_SEQUENCE_EDITOR: toGitEditorCommand(process.execPath, artifacts.sequenceEditorScriptPath),
-      GIT_EDITOR: toGitEditorCommand(process.execPath, artifacts.commitEditorScriptPath),
-    };
+    const envPatch = buildGitEditorScriptEnvPatch(
+      artifacts.sequenceEditorScriptPath,
+      artifacts.commitEditorScriptPath,
+      {
+        CODEXFLOW_GIT_REBASE_TODO_FILE: artifacts.todoFilePath,
+        CODEXFLOW_GIT_REBASE_QUEUE_FILE: artifacts.queueFilePath,
+        CODEXFLOW_GIT_REBASE_QUEUE_STATE_FILE: artifacts.queueStateFilePath,
+      },
+    );
     const argv = plan.rootMode
       ? ["rebase", "-i", "--root", "--no-autosquash"]
       : ["rebase", "-i", "--no-autosquash", String(plan.baseHash || "")];
@@ -9820,12 +9838,14 @@ async function runLogActionAsync(ctx: GitFeatureContext, repoRoot: string, paylo
     let artifacts: GitRewordEditorArtifacts | null = null;
     try {
       artifacts = await createGitRewordEditorArtifactsAsync(ctx, message, target);
-      const envPatch: NodeJS.ProcessEnv = {
-        GIT_SEQUENCE_EDITOR: toGitEditorCommand(process.execPath, artifacts.sequenceEditorScriptPath),
-        GIT_EDITOR: toGitEditorCommand(process.execPath, artifacts.commitEditorScriptPath),
-        GIT_REWORD_TARGET: artifacts.targetPrefix,
-        GIT_REWORD_MESSAGE_FILE: artifacts.messageFilePath,
-      };
+      const envPatch = buildGitEditorScriptEnvPatch(
+        artifacts.sequenceEditorScriptPath,
+        artifacts.commitEditorScriptPath,
+        {
+          GIT_REWORD_TARGET: artifacts.targetPrefix,
+          GIT_REWORD_MESSAGE_FILE: artifacts.messageFilePath,
+        },
+      );
       const baseArgv = targetParents.length === 0 ? ["rebase", "-i", "--root"] : ["rebase", "-i", `${target}^`];
       const rebaseRes = await runGitSpawnAsync(ctx, repoRoot, baseArgv, 300_000, envPatch);
       if (!rebaseRes.ok) {

--- a/web/src/features/git/api.test.ts
+++ b/web/src/features/git/api.test.ts
@@ -18,6 +18,24 @@ describe("git api alignment", () => {
     return { promise, resolve };
   }
 
+  /**
+   * 构造空日志筛选条件，用于触发可取消的日志读取请求。
+   */
+  function createEmptyLogFilters() {
+    return {
+      text: "",
+      caseSensitive: false,
+      matchMode: "fuzzy" as const,
+      branch: "",
+      author: "",
+      dateFrom: "",
+      dateTo: "",
+      path: "",
+      revision: "",
+      followRenames: false,
+    };
+  }
+
   it("不应再导出 update 专用 shelf API", () => {
     expect("getUpdateShelvesAsync" in api).toBe(false);
     expect("restoreUpdateShelveAsync" in api).toBe(false);
@@ -194,6 +212,60 @@ describe("git api alignment", () => {
     await Promise.all([first, second]);
   });
 
+  it("旧 Git 读请求取消应返回静默标记，避免界面显示为错误", async () => {
+    const call = vi.fn(async () => {
+      throw new Error("已有更新的 Git 读取请求");
+    });
+    (globalThis as any).window = {
+      host: {
+        gitFeature: { call },
+      },
+    };
+
+    const result = await api.getLogAsync("/repo", 0, 200, createEmptyLogFilters());
+
+    expect(result.ok).toBe(false);
+    expect(result.meta?.staleReadRequest).toBe(true);
+    expect(result.meta?.silent).toBe(true);
+    expect(api.isStaleGitReadRequestResponse(result)).toBe(true);
+  });
+
+  it("旧 Git 读请求返回 aborted 时应按内部取消静默处理", async () => {
+    const call = vi.fn(async () => ({ ok: false, error: "aborted" }));
+    (globalThis as any).window = {
+      host: {
+        gitFeature: { call },
+      },
+    };
+
+    const result = await api.getLogAsync("/repo", 0, 200, createEmptyLogFilters());
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("已有更新的 Git 读取请求");
+    expect(result.meta?.staleReadRequest).toBe(true);
+    expect(result.meta?.silent).toBe(true);
+    expect(api.isStaleGitReadRequestResponse(result)).toBe(true);
+  });
+
+  it("旧 Git 读请求抛出 aborted 时应按内部取消静默处理", async () => {
+    const call = vi.fn(async () => {
+      throw new Error("aborted");
+    });
+    (globalThis as any).window = {
+      host: {
+        gitFeature: { call },
+      },
+    };
+
+    const result = await api.getLogAsync("/repo", 0, 200, createEmptyLogFilters());
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("已有更新的 Git 读取请求");
+    expect(result.meta?.staleReadRequest).toBe(true);
+    expect(result.meta?.silent).toBe(true);
+    expect(api.isStaleGitReadRequestResponse(result)).toBe(true);
+  });
+
   it("Git 写请求不应触发旧请求取消，避免误伤提交/暂存等真实操作", async () => {
     const call = vi.fn(async () => ({ ok: true }));
     (globalThis as any).window = {
@@ -211,20 +283,26 @@ describe("git api alignment", () => {
     }));
   });
 
+  it("Git 写请求返回 aborted 不应误标为旧读请求取消", async () => {
+    const call = vi.fn(async () => ({ ok: false, error: "aborted" }));
+    (globalThis as any).window = {
+      host: {
+        gitFeature: { call },
+      },
+    };
+
+    const result = await api.stageFilesAsync("/repo", ["a.txt"]);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("aborted");
+    expect(result.meta?.staleReadRequest).toBeUndefined();
+    expect(result.meta?.silent).toBeUndefined();
+    expect(api.isStaleGitReadRequestResponse(result)).toBe(false);
+  });
+
   it("日志分页读取应按 cursor 区分取消键，避免加载更多时取消首屏或相邻页", async () => {
     const call = vi.fn(async () => ({ ok: true }));
-    const filters = {
-      text: "",
-      caseSensitive: false,
-      matchMode: "fuzzy" as const,
-      branch: "",
-      author: "",
-      dateFrom: "",
-      dateTo: "",
-      path: "",
-      revision: "",
-      followRenames: false,
-    };
+    const filters = createEmptyLogFilters();
     (globalThis as any).window = {
       host: {
         gitFeature: { call },

--- a/web/src/features/git/api.ts
+++ b/web/src/features/git/api.ts
@@ -62,6 +62,8 @@ export type GitFeatureResponse<T = any> = {
   error?: string;
   meta?: {
     requestId: number;
+    staleReadRequest?: boolean;
+    silent?: boolean;
   };
 };
 
@@ -107,6 +109,7 @@ const STALE_CANCEL_GIT_ACTIONS = new Set<string>([
 
 let gitFeatureActivitySeq = 0;
 const latestGitRequestByKey = new Map<string, number>();
+const STALE_GIT_READ_REQUEST_REASON = "已有更新的 Git 读取请求";
 const gitFeatureProgressBridgeState: {
   installed: boolean;
 } = (globalThis as any).__cf_git_feature_progress_bridge_state__ || ((globalThis as any).__cf_git_feature_progress_bridge_state__ = {
@@ -193,11 +196,31 @@ function cancelPreviousStaleGitRequest(requestKey: string, nextRequestId: number
       action: "request.cancel",
       payload: {
         targetRequestId: previousRequestId,
-        reason: "已有更新的 Git 读取请求",
+        reason: STALE_GIT_READ_REQUEST_REASON,
       },
       requestId: 0,
     });
   } catch {}
+}
+
+/**
+ * 判断错误是否来自旧 Git 读取请求取消。
+ */
+export function isStaleGitReadRequestError(raw: unknown, options?: { allowAbort?: boolean }): boolean {
+  const text = String((raw as any)?.message || raw || "").trim();
+  if (text === STALE_GIT_READ_REQUEST_REASON || text.endsWith(`: ${STALE_GIT_READ_REQUEST_REASON}`)) return true;
+  if (options?.allowAbort !== true) return false;
+  const lowerText = text.toLowerCase();
+  return lowerText === "aborted" || lowerText === "error: aborted";
+}
+
+/**
+ * 判断响应是否是旧 Git 读取请求取消，供界面层静默丢弃。
+ */
+export function isStaleGitReadRequestResponse(response: GitFeatureResponse | null | undefined): boolean {
+  if (!response) return false;
+  if (response.meta?.staleReadRequest === true) return true;
+  return isStaleGitReadRequestError(response.error);
 }
 
 /**
@@ -420,11 +443,16 @@ export async function callGitFeatureAsync<T>(action: string, payload?: any): Pro
   }
   try {
     const res = await window.host.gitFeature?.call({ action: normalizedAction, payload, requestId });
-    const normalizedResponse = res
+    const rawResponse = res as GitFeatureResponse<T> | undefined;
+    const rawResponseStale = isStaleGitReadRequestError(rawResponse?.error, { allowAbort: !!staleRequestKey });
+    const normalizedResponse: GitFeatureResponse<T> = rawResponse
       ? ({
-          ...(res as GitFeatureResponse<T>),
+          ...rawResponse,
+          ...(rawResponseStale ? { error: STALE_GIT_READ_REQUEST_REASON } : {}),
           meta: {
+            ...(rawResponse.meta || {}),
             requestId,
+            ...(rawResponseStale ? { staleReadRequest: true, silent: true } : {}),
           },
         } satisfies GitFeatureResponse<T>)
       : { ok: false, error: resolveGitText("activity.errors.featureUnavailable", "Git 功能不可用"), meta: { requestId } };
@@ -452,7 +480,19 @@ export async function callGitFeatureAsync<T>(action: string, payload?: any): Pro
       });
     }
     clearLatestGitRequestMarker(staleRequestKey, requestId);
-    return { ok: false, error: String(e?.message || e), meta: { requestId } };
+    const errorText = String(e?.message || e);
+    if (isStaleGitReadRequestError(errorText, { allowAbort: !!staleRequestKey })) {
+      return {
+        ok: false,
+        error: STALE_GIT_READ_REQUEST_REASON,
+        meta: {
+          requestId,
+          staleReadRequest: true,
+          silent: true,
+        },
+      };
+    }
+    return { ok: false, error: errorText, meta: { requestId } };
   }
 }
 

--- a/web/src/features/git/git-workbench.tsx
+++ b/web/src/features/git/git-workbench.tsx
@@ -93,6 +93,7 @@ import {
   getLogDetailsActionAvailabilityAsync,
   getLogMessageDraftAsync,
   importShelvePatchFilesAsync,
+  isStaleGitReadRequestError,
   getPushPreviewAsync,
   getShelvesAsync,
   getStashListAsync,
@@ -224,7 +225,7 @@ import {
   shouldAutoPreviewCommitSelection,
   shouldShowDiffPartialCommit,
 } from "./git-workbench-utils";
-import { toErrorText } from "./error-text";
+import { toErrorText as formatRawGitErrorText } from "./error-text";
 import { resolveGitUpdateMethodLabel } from "./git-i18n";
 import {
   buildCommitDetailsContextMenuGroups,
@@ -762,6 +763,14 @@ function gitWorkbenchText(key: string, fallback: string, values?: Record<string,
     defaultValue: fallback,
     ...(values || {}),
   })), values);
+}
+
+/**
+ * 统一格式化 Git 错误；旧读取请求取消属于内部调度结果，不展示给用户。
+ */
+function toErrorText(raw: unknown, fallback: string): string {
+  if (isStaleGitReadRequestError(raw)) return "";
+  return formatRawGitErrorText(raw, fallback);
 }
 
 /**


### PR DESCRIPTION
产品变化：
- 快速切换 Git 日志、详情、diff 等可取消读取时，旧请求被取消不再显示红色错误提示。
- 编辑历史提交消息、交互式变基等历史改写操作在打包后的 Electron 环境中继续可用。

技术变化：
- 为可取消 Git 读取请求统一识别内部取消原因，并仅在可取消读取场景下将 aborted 标记为静默旧请求。
- 为 Git sequence/editor 脚本补充 ELECTRON_RUN_AS_NODE，确保 Electron 可执行文件按 Node 脚本模式运行。
- 补充 API 请求取消边界测试，以及历史提交消息改写后的结果断言。