### PR TITLE
fix(git): 恢复提交树更改列表右键菜单

### DIFF
--- a/web/src/features/git/commit-panel/context-menu-model.test.ts
+++ b/web/src/features/git/commit-panel/context-menu-model.test.ts
@@ -12,7 +12,7 @@ function flattenMenuIds(sections: ReturnType<typeof buildCommitTreeSharedMenuSec
 }
 
 describe("commit tree context menu model", () => {
-  it("应按参考实现提交工具窗口结构输出共享菜单，并移除 changelist 管理段", () => {
+  it("应按参考实现提交工具窗口结构输出共享菜单，并包含 changelist 管理段", () => {
     const sections = buildCommitTreeSharedMenuSections({
       selection: {
         canCommit: true,
@@ -25,6 +25,10 @@ describe("commit tree context menu model", () => {
         canIgnore: false,
         canShowHistory: true,
         canShelve: true,
+        changeListsEnabled: true,
+        canDeleteList: true,
+        canSetActiveList: false,
+        canEditList: true,
       },
       singleSelection: true,
     });
@@ -32,10 +36,40 @@ describe("commit tree context menu model", () => {
     expect(flattenMenuIds(sections)).toEqual([
       ["commitFile", "rollback", "move", "showDiff", "showStandaloneDiff", "editSource"],
       ["delete"],
+      ["newChangelist", "removeChangelist", "editChangelist"],
       ["createPatch", "copyPatch", "shelve"],
       ["refresh", "localHistory", "git"],
     ]);
-    expect(sections.flatMap((section) => section.map((node) => node.id))).not.toContain("newChangelist");
+    expect(sections.flatMap((section) => section.map((node) => node.id))).not.toContain("setActiveChangelist");
+  });
+
+  it("非活动 changelist 应显示设为活动入口，并位于删除与编辑之间", () => {
+    const sections = buildCommitTreeSharedMenuSections({
+      selection: {
+        canCommit: true,
+        canRollback: true,
+        canMoveToList: true,
+        canShowDiff: true,
+        canOpenSource: true,
+        canDelete: true,
+        canAddToVcs: false,
+        canIgnore: false,
+        canShowHistory: true,
+        canShelve: true,
+        changeListsEnabled: true,
+        canDeleteList: true,
+        canSetActiveList: true,
+        canEditList: true,
+      },
+      singleSelection: true,
+    });
+
+    expect(flattenMenuIds(sections)[2]).toEqual([
+      "newChangelist",
+      "removeChangelist",
+      "setActiveChangelist",
+      "editChangelist",
+    ]);
   });
 
   it("存在未跟踪文件时应暴露 add-to-vcs 与 ignore，且历史子菜单在非单选时禁用", () => {

--- a/web/src/features/git/commit-panel/context-menu-model.ts
+++ b/web/src/features/git/commit-panel/context-menu-model.ts
@@ -13,6 +13,10 @@ export type CommitTreeSharedMenuActionId =
   | "delete"
   | "addToVcs"
   | "ignore"
+  | "newChangelist"
+  | "removeChangelist"
+  | "setActiveChangelist"
+  | "editChangelist"
   | "createPatch"
   | "copyPatch"
   | "shelve"
@@ -48,7 +52,13 @@ type CommitTreeSharedSelectionSnapshot = Pick<
   | "canIgnore"
   | "canShowHistory"
   | "canShelve"
->;
+> & Partial<Pick<
+  CommitSelectionContext,
+  | "canEditList"
+  | "canDeleteList"
+  | "canSetActiveList"
+  | "changeListsEnabled"
+>>;
 
 /**
  * 保持与参考实现一致的提交树共享菜单的删除入口显示规则。
@@ -110,7 +120,7 @@ function createSubmenuNode(
 
 /**
  * 按参考实现提交工具窗口 `MultipleLocalChangeListsBrowser` 的结构构建主提交树共享右键菜单。
- * 这里故意不输出 changelist 管理项，只保留 commit tool window 实际会出现的公共动作与共享子菜单。
+ * changelist 管理段位于文件删除/添加段之后、补丁与搁置段之前。
  */
 export function buildCommitTreeSharedMenuSections(args: {
   selection: CommitTreeSharedSelectionSnapshot;
@@ -124,6 +134,15 @@ export function buildCommitTreeSharedMenuSections(args: {
   const showAddToVcs = args.showAddToVcs ?? selection.canAddToVcs;
   const showDelete = args.showDelete ?? true;
   const showEditSource = args.showEditSource ?? true;
+  const showChangeListActions = selection.changeListsEnabled === true;
+  const changeListActions = showChangeListActions
+    ? [
+        createActionNode("newChangelist"),
+        ...(selection.canDeleteList ? [createActionNode("removeChangelist")] : []),
+        ...(selection.canSetActiveList ? [createActionNode("setActiveChangelist")] : []),
+        ...(selection.canEditList ? [createActionNode("editChangelist", { shortcut: "Ctrl+R, R" })] : []),
+      ]
+    : [];
 
   return [
     [
@@ -147,6 +166,7 @@ export function buildCommitTreeSharedMenuSections(args: {
         ? [createActionNode("ignore")]
         : []),
     ],
+    ...(changeListActions.length > 0 ? [changeListActions] : []),
     [
       createActionNode("createPatch", { disabled: !selection.canShowDiff }),
       createActionNode("copyPatch", { disabled: !selection.canShowDiff, shortcut: "F24" }),

--- a/web/src/features/git/git-workbench.tsx
+++ b/web/src/features/git/git-workbench.tsx
@@ -18166,6 +18166,18 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
         if (node.id === "ignore") {
           return <ContextMenuItem key="ignore" label={gt("workbench.changes.context.ignore", "忽略")} disabled={node.disabled} shortcut={node.shortcut} title={node.title} onClick={() => { runMenuChangeAction("ignore"); }} />;
         }
+        if (node.id === "newChangelist") {
+          return <ContextMenuItem key="new-changelist" label={gt("workbench.changes.context.newChangelist", "新建更改列表...")} disabled={node.disabled} shortcut={node.shortcut} title={node.title} onClick={() => { runMenuChangeAction("newList"); }} />;
+        }
+        if (node.id === "removeChangelist") {
+          return <ContextMenuItem key="remove-changelist" label={gt("workbench.changes.context.removeChangelist", "删除更改列表")} disabled={node.disabled} shortcut={node.shortcut} title={node.title} onClick={() => { runMenuChangeAction("removeList"); }} />;
+        }
+        if (node.id === "setActiveChangelist") {
+          return <ContextMenuItem key="set-active-changelist" label={gt("workbench.changes.context.setActiveChangelist", "设为活动更改列表")} disabled={node.disabled} shortcut={node.shortcut} title={node.title} onClick={() => { runMenuChangeAction("setActiveList"); }} />;
+        }
+        if (node.id === "editChangelist") {
+          return <ContextMenuItem key="edit-changelist" label={gt("workbench.changes.context.editChangelist", "编辑更改列表...")} disabled={node.disabled} shortcut={node.shortcut} title={node.title} onClick={() => { runMenuChangeAction("editList"); }} />;
+        }
         if (node.id === "createPatch") {
           return <ContextMenuItem key="create-patch" label={gt("workbench.changes.context.createPatchFromLocalCommit", "从本地更改创建补丁...")} disabled={node.disabled} shortcut={node.shortcut} title={node.title} onClick={() => { setMenu(null); void exportPatchFromChangeSelectionAsync("save"); }} />;
         }
@@ -18224,6 +18236,7 @@ export default function GitWorkbench(props: GitWorkbenchProps): JSX.Element {
             ] : [],
             sharedMenuSections[2]?.map((node) => renderSharedMenuNode(node)) || [],
             sharedMenuSections[3]?.map((node) => renderSharedMenuNode(node)) || [],
+            sharedMenuSections[4]?.map((node) => renderSharedMenuNode(node)) || [],
           ])}
         </ContextMenu>
       );


### PR DESCRIPTION
## 动机

Git 提交树已具备更改列表能力，但右键菜单缺少新建、删除、设为活动和编辑入口，导致用户无法从该位置管理更改列表。

## 变更范围

- 恢复提交树共享菜单中的更改列表管理分组，并按当前选择状态显示可用操作。
- 将菜单项映射到既有的更改列表动作，不改动 Git 后端或数据存储。
- 补充活动列表与非活动列表下的菜单顺序、显示规则测试。

## 验证

- `npm run i18n:check`
- 菜单模型专项测试：9/9 通过
- `npm run test`：类型检查通过；1201 项中 1188 项通过。13 项 SQLite 相关失败由本机 `better-sqlite3` 原生模块与当前 Node ABI 不匹配导致，与本 PR 无关。