### PR TITLE
fix(terminal): 完善终端 256 色支持

### DIFF
--- a/electron/antigravity/usage.ts
+++ b/electron/antigravity/usage.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import http from "node:http";
 import https from "node:https";
 import { execFile } from "node:child_process";
-import * as pty from "@lydell/node-pty";
+import * as pty from "node-pty";
 import { perfLogger } from "../log";
 
 export type AntigravityUsageWindow = {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2921,7 +2921,7 @@ ipcMain.handle('pty:open', async (_event, args: {
   // 中文说明：打开 PTY 是标签页点击热路径；这里不做 WSL 枚举/CLI 检测，直接按请求环境启动。
   const requestedTerminal = args?.terminal ? normalizeTerminal(args.terminal) : undefined;
   const requestedDistro = String(args?.distro || "").trim();
-  const opened = ptyManager.openWSLConsole({
+  const opened = await ptyManager.openWSLConsole({
     terminal: requestedTerminal,
     distro: requestedDistro,
     wslPath: args?.wslPath,
@@ -2960,6 +2960,22 @@ ipcMain.handle('pty:backlog', async (_e, args: { id: string; maxChars?: number }
 
 ipcMain.on('pty:write', (_e, { id, data }: { id: string; data: string }) => {
   ptyManager.write(id, data);
+});
+
+ipcMain.on('pty:ready', (_e, payload: {
+  id?: unknown;
+  colors?: { foreground?: unknown; background?: unknown };
+}) => {
+  const id = String(payload?.id || "").trim();
+  const colors = {
+    foreground: typeof payload?.colors?.foreground === "string"
+      ? payload.colors.foreground.slice(0, 32)
+      : undefined,
+    background: typeof payload?.colors?.background === "string"
+      ? payload.colors.background.slice(0, 32)
+      : undefined,
+  };
+  ptyManager.ready(id, colors);
 });
 
 ipcMain.on('pty:resize', (_e, { id, cols, rows }: { id: string; cols: number; rows: number }) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -7,6 +7,7 @@ const { contextBridge, ipcRenderer } = require('electron');
 type TerminalMode = 'wsl' | 'windows' | 'pwsh' | 'cmd';
 type OpenArgs = { terminal?: TerminalMode; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string> };
 type OpenResult = { id: string; terminal?: TerminalMode; distro?: string; fallbackReason?: string };
+type TerminalPaletteColors = { foreground: string; background: string };
 
 type PtyDataPayload = { id: string; data: string };
 type PtyExitPayload = { id: string; exitCode?: number };
@@ -342,6 +343,9 @@ contextBridge.exposeInMainWorld('host', {
     },
     write: (id: string, data: string) => {
       ipcRenderer.send('pty:write', { id, data });
+    },
+    ready: (id: string, colors?: TerminalPaletteColors) => {
+      ipcRenderer.send('pty:ready', { id, colors });
     },
     resize: (id: string, cols: number, rows: number) => {
       ipcRenderer.send('pty:resize', { id, cols, rows });

--- a/electron/pty.test.ts
+++ b/electron/pty.test.ts
@@ -1,12 +1,35 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@lydell/node-pty', () => ({
+const settingsMock = vi.hoisted(() => ({
+  terminalCapabilities: {
+    normalizeTerm: true,
+    trueColor: false,
+  },
+  getSettings: vi.fn(),
+  getTerminalCapabilitySettings: vi.fn(),
+}));
+
+vi.mock('node-pty', () => ({
   spawn: vi.fn(),
 }));
 
+vi.mock('./wslConptyProxy.js', async () => {
+  const actual = await vi.importActual<typeof import('./wslConpty')>('./wslConpty');
+  return {
+    spawnIsolatedWslConpty: vi.fn(async (options) => new actual.WslConptyPty(options as any)),
+  };
+});
+
 vi.mock('./settings.js', () => ({
   default: {
-    getSettings: () => ({ terminal: 'pwsh' }),
+    getSettings: () => {
+      settingsMock.getSettings();
+      return { terminal: 'pwsh', terminalCapabilities: settingsMock.terminalCapabilities };
+    },
+    getTerminalCapabilitySettings: () => {
+      settingsMock.getTerminalCapabilitySettings();
+      return settingsMock.terminalCapabilities;
+    },
   },
 }));
 
@@ -19,8 +42,16 @@ vi.mock('./log.js', () => ({
 }));
 
 import { PTYManager } from './pty';
+import * as pty from 'node-pty';
 
 describe('PTYManager', () => {
+  afterEach(() => {
+    settingsMock.terminalCapabilities.normalizeTerm = true;
+    settingsMock.terminalCapabilities.trueColor = false;
+    settingsMock.getSettings.mockClear();
+    settingsMock.getTerminalCapabilitySettings.mockClear();
+  });
+
   /**
    * 创建带可观察 IPC 发送能力的窗口桩。
    */
@@ -40,6 +71,286 @@ describe('PTYManager', () => {
       },
     };
   }
+
+  /**
+   * 创建满足 PTYManager 注册监听所需的最小 PTY 桩。
+   */
+  function createPtyStub() {
+    return {
+      onData: vi.fn(),
+      onExit: vi.fn(),
+      write: vi.fn(),
+      pause: vi.fn(),
+      resume: vi.fn(),
+    };
+  }
+
+  it('显式指定终端时应从内存读取能力设置，不加载完整设置与 WSL 列表', async () => {
+    const { win } = createWindowStub();
+    const manager = new PTYManager(() => [win as any]);
+    const spawn = vi.mocked(pty.spawn);
+    spawn.mockReset();
+    spawn.mockReturnValue(createPtyStub() as any);
+
+    await manager.openWSLConsole({ terminal: 'pwsh' });
+
+    expect(settingsMock.getTerminalCapabilitySettings).toHaveBeenCalledTimes(1);
+    expect(settingsMock.getSettings).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [undefined, 'xterm-256color'],
+    ['', 'xterm-256color'],
+    ['dumb', 'xterm-256color'],
+    ['DUMB', 'xterm-256color'],
+    ['screen-256color', 'screen-256color'],
+  ])('打开 PTY 时应安全归一化 TERM：%s -> %s', async (term, expected) => {
+    const { win } = createWindowStub();
+    const manager = new PTYManager(() => [win as any]);
+    const spawn = vi.mocked(pty.spawn);
+    spawn.mockReset();
+    spawn.mockReturnValue(createPtyStub() as any);
+
+    await manager.openWSLConsole({
+      terminal: 'pwsh',
+      env: term === undefined ? {} : { TERM: term },
+    });
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn.mock.calls[0]?.[2]?.env?.TERM).toBe(expected);
+  });
+
+  it.each(['windows', 'pwsh', 'cmd'] as const)('%s 自动启动命令应等待前端双向绑定', async (terminal) => {
+    const { win } = createWindowStub();
+    const manager = new PTYManager(() => [win as any]);
+    const spawn = vi.mocked(pty.spawn);
+    const proc = createPtyStub();
+    spawn.mockReset();
+    spawn.mockReturnValue(proc as any);
+
+    const opened = await manager.openWSLConsole({ terminal, startupCmd: 'codex --yolo' });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(proc.write).not.toHaveBeenCalled();
+    expect((spawn.mock.calls[0]?.[2] as { useConptyDll?: boolean } | undefined)?.useConptyDll).toBeUndefined();
+    manager.ready(opened.id);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(proc.write).toHaveBeenCalledWith('codex --yolo\r');
+    manager.ready(opened.id);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(proc.write).toHaveBeenCalledTimes(1);
+  });
+
+  it('Windows 原生终端在首次 resize 暂停结束前不应启动 Codex', async () => {
+    const { win } = createWindowStub();
+    const manager = new PTYManager(() => [win as any]);
+    const spawn = vi.mocked(pty.spawn);
+    const proc = createPtyStub();
+    spawn.mockReset();
+    spawn.mockReturnValue(proc as any);
+
+    const opened = await manager.openWSLConsole({ terminal: 'pwsh', startupCmd: 'codex --yolo' });
+    manager.pause(opened.id);
+    manager.ready(opened.id);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(proc.write).not.toHaveBeenCalled();
+    manager.resume(opened.id);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(proc.write).toHaveBeenCalledTimes(1);
+    expect(proc.write).toHaveBeenCalledWith('codex --yolo\r');
+  });
+
+  it('旧渲染层未发送 ready 时应在 2 秒后兜底启动原生终端命令', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      const { win } = createWindowStub();
+      const manager = new PTYManager(() => [win as any]);
+      const spawn = vi.mocked(pty.spawn);
+      const proc = createPtyStub();
+      spawn.mockReset();
+      spawn.mockReturnValue(proc as any);
+
+      await manager.openWSLConsole({ terminal: 'cmd', startupCmd: 'codex --yolo' });
+      expect(proc.write).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(2_000);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(proc.write).toHaveBeenCalledWith('codex --yolo\r');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('原生终端关闭后应取消尚未释放的启动命令', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      const { win } = createWindowStub();
+      const manager = new PTYManager(() => [win as any]);
+      const spawn = vi.mocked(pty.spawn);
+      const proc = createPtyStub();
+      spawn.mockReset();
+      spawn.mockReturnValue(proc as any);
+
+      const opened = await manager.openWSLConsole({ terminal: 'pwsh', startupCmd: 'codex --yolo' });
+      manager.close(opened.id);
+      manager.ready(opened.id);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(proc.write).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('应过滤 dumb 父进程注入的 NO_COLOR，但保留终端显式设置', async () => {
+    const previousTerm = process.env.TERM;
+    const previousNoColor = process.env.NO_COLOR;
+    process.env.TERM = 'dumb';
+    process.env.NO_COLOR = '1';
+    const { win } = createWindowStub();
+    const manager = new PTYManager(() => [win as any]);
+    const spawn = vi.mocked(pty.spawn);
+    spawn.mockReset();
+    spawn.mockReturnValue(createPtyStub() as any);
+
+    try {
+      await manager.openWSLConsole({ terminal: 'pwsh' });
+      expect(spawn.mock.calls[0]?.[2]?.env?.TERM).toBe('xterm-256color');
+      expect(spawn.mock.calls[0]?.[2]?.env).not.toHaveProperty('NO_COLOR');
+
+      await manager.openWSLConsole({ terminal: 'cmd', env: { NO_COLOR: '1' } });
+      expect(spawn.mock.calls[1]?.[2]?.env).toHaveProperty('NO_COLOR', '1');
+
+      process.env.TERM = 'screen-256color';
+      await manager.openWSLConsole({ terminal: 'windows' });
+      expect(spawn.mock.calls[2]?.[2]?.env).toHaveProperty('NO_COLOR', '1');
+    } finally {
+      if (previousTerm === undefined) delete process.env.TERM;
+      else process.env.TERM = previousTerm;
+      if (previousNoColor === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = previousNoColor;
+    }
+  });
+
+  it('内置和系统 ConPTY 都失败时才应把 WSL 切换为 PowerShell', async () => {
+    const { win } = createWindowStub();
+    const manager = new PTYManager(() => [win as any]);
+    const spawn = vi.mocked(pty.spawn);
+    const powershell = createPtyStub();
+    spawn.mockReset();
+    spawn
+      .mockImplementationOnce(() => { throw new Error('bundled conpty failed'); })
+      .mockImplementationOnce(() => { throw new Error('system conpty failed'); })
+      .mockReturnValueOnce(powershell as any);
+
+    const opened = await manager.openWSLConsole({ terminal: 'wsl' });
+
+    expect(opened.terminal).toBe('windows');
+    expect(opened.fallbackReason).toBe('wsl_spawn_failed');
+    expect(spawn).toHaveBeenCalledTimes(3);
+    expect((spawn.mock.calls[0]?.[2] as { useConptyDll?: boolean }).useConptyDll).toBe(true);
+    expect((spawn.mock.calls[1]?.[2] as { useConptyDll?: boolean }).useConptyDll).toBe(false);
+  });
+
+  it('WSL 回退到 PowerShell 后也应等待前端绑定再执行启动命令', async () => {
+    const { win } = createWindowStub();
+    const manager = new PTYManager(() => [win as any]);
+    const spawn = vi.mocked(pty.spawn);
+    const powershell = createPtyStub();
+    spawn.mockReset();
+    spawn
+      .mockImplementationOnce(() => { throw new Error('bundled conpty failed'); })
+      .mockImplementationOnce(() => { throw new Error('system conpty failed'); })
+      .mockReturnValueOnce(powershell as any);
+
+    const opened = await manager.openWSLConsole({ terminal: 'wsl', startupCmd: 'codex --yolo' });
+    expect(opened.terminal).toBe('windows');
+    expect(powershell.write).not.toHaveBeenCalled();
+
+    manager.ready(opened.id);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(powershell.write).toHaveBeenLastCalledWith('codex --yolo\r');
+  });
+
+  it('WSL 自动启动命令应等待前端完成绑定', async () => {
+    const { win } = createWindowStub();
+    const manager = new PTYManager(() => [win as any]);
+    const spawn = vi.mocked(pty.spawn);
+    const proc = createPtyStub();
+    spawn.mockReset();
+    spawn.mockReturnValue(proc as any);
+
+    const opened = await manager.openWSLConsole({ terminal: 'wsl', startupCmd: 'codex --yolo' });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(proc.write).not.toHaveBeenCalled();
+    manager.ready(opened.id);
+    expect(proc.write).toHaveBeenCalledWith("bash -lc 'codex --yolo'\r");
+  });
+
+  it('ready 应安全忽略无待启动命令的原生 PTY，并向 WSL 同步主题色', () => {
+    const manager = new PTYManager(() => []);
+    const markFrontendReady = vi.fn();
+    (manager as any).sessions.set('wsl-conpty', { markFrontendReady });
+    (manager as any).sessions.set('windows-pty', {});
+    const colors = { foreground: '#F8F8F2', background: '#282A36' };
+
+    expect(() => manager.ready('windows-pty', colors)).not.toThrow();
+    manager.ready('wsl-conpty', colors);
+
+    expect(markFrontendReady).toHaveBeenCalledTimes(1);
+    expect(markFrontendReady).toHaveBeenCalledWith(colors);
+  });
+
+  it('WSL 应传递能力设置实际补齐的 TERM 与 COLORTERM', async () => {
+    settingsMock.terminalCapabilities.trueColor = true;
+    const previousNoColor = process.env.NO_COLOR;
+    const previousColorTerm = process.env.COLORTERM;
+    delete process.env.NO_COLOR;
+    delete process.env.COLORTERM;
+    const { win } = createWindowStub();
+    const manager = new PTYManager(() => [win as any]);
+    const spawn = vi.mocked(pty.spawn);
+    spawn.mockReset();
+    spawn.mockReturnValue(createPtyStub() as any);
+
+    try {
+      await manager.openWSLConsole({
+        terminal: 'wsl',
+        env: { TERM: 'dumb' },
+      });
+
+      const spawnedEnv = spawn.mock.calls[0]?.[2]?.env;
+      const spawnedOptions = spawn.mock.calls[0]?.[2] as { useConptyDll?: boolean } | undefined;
+      expect(spawnedEnv?.TERM).toBe('xterm-256color');
+      expect(spawnedEnv?.COLORTERM).toBe('truecolor');
+      expect(spawnedOptions?.useConptyDll).toBe(true);
+      expect(String(spawnedEnv?.WSLENV || '').split(':')).toEqual(expect.arrayContaining(['TERM', 'COLORTERM']));
+    } finally {
+      if (previousNoColor === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = previousNoColor;
+      if (previousColorTerm === undefined) delete process.env.COLORTERM;
+      else process.env.COLORTERM = previousColorTerm;
+    }
+  });
+
+  it('WSL 存在 NO_COLOR 时不应传递 COLORTERM', async () => {
+    settingsMock.terminalCapabilities.trueColor = true;
+    const { win } = createWindowStub();
+    const manager = new PTYManager(() => [win as any]);
+    const spawn = vi.mocked(pty.spawn);
+    spawn.mockReset();
+    spawn.mockReturnValue(createPtyStub() as any);
+
+    await manager.openWSLConsole({
+      terminal: 'wsl',
+      env: { TERM: 'dumb', NO_COLOR: '' },
+    });
+
+    const spawnedEnv = spawn.mock.calls[0]?.[2]?.env;
+    expect(spawnedEnv?.COLORTERM).not.toBe('truecolor');
+    expect(String(spawnedEnv?.WSLENV || '').split(':')).not.toContain('COLORTERM');
+  });
 
   it('resize 遇到底层已退出 PTY 异常时应清理 session、发送尾部输出并通知前端退出', () => {
     const { send, win } = createWindowStub();

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -4,12 +4,21 @@
 import os from 'node:os';
 import settings from './settings.js';
 import { resolveWindowsShell, type TerminalMode } from './shells.js';
-import type { IPty } from '@lydell/node-pty';
-import * as pty from '@lydell/node-pty';
+import type { IPty } from 'node-pty';
+import * as pty from 'node-pty';
 import { BrowserWindow } from 'electron';
 import { perfLogger } from './log.js';
 import { getDebugConfig } from './debugConfig.js';
 import { safeWindowSend } from './ipcSafe';
+import {
+  applyTerminalCapabilityEnvironment,
+  normalizeTerminalCapabilitySettings,
+  sanitizeInheritedTerminalColorEnvironment,
+} from './terminalCapabilities';
+import {
+  type TerminalPaletteColors,
+} from './wslConpty.js';
+import { spawnIsolatedWslConpty } from './wslConptyProxy.js';
 
 // 终端日志总开关（主进程）。默认关闭，由统一调试配置控制，也可通过 IPC 置位。
 let TERM_DEBUG = (() => { try { return !!(getDebugConfig().terminal.pty.debug); } catch { return false; } })();
@@ -26,6 +35,8 @@ const PTY_IPC_FLUSH_MS = 16;
 // 中文说明：单个 PTY 在一次 flush 窗口内允许积累的最大字符数（超过则裁剪旧数据）。
 // 目的：避免渲染卡顿/不可见时 IPC 队列与字符串拼接无上限增长，最终导致白屏/崩溃。
 const PTY_IPC_MAX_PENDING_CHARS = 280_000;
+// 旧渲染进程未发送 ready 时仍允许原生终端启动，避免永久停在空 shell。
+const PTY_STARTUP_READY_FALLBACK_MS = 2_000;
 
 /**
  * 将字符串转换为 Bash 单引号安全字面量。
@@ -174,6 +185,15 @@ type PtyIpcPendingState = {
   droppedChars: number;
 };
 
+type PtyPendingWindowsStartupState = {
+  timer: NodeJS.Timeout | null;
+  attempt: NodeJS.Immediate | null;
+  startupNotice: string;
+  startupCmd: string;
+  mode: "windows" | "pwsh" | "cmd";
+  frontendReady: boolean;
+};
+
 export type PtyOpenResult = {
   id: string;
   terminal: TerminalMode;
@@ -185,6 +205,8 @@ export class PTYManager {
   private sessions = new Map<string, IPty>();
   private backlogs = new Map<string, PtyBacklogBuffer>();
   private ipcPendingById = new Map<string, PtyIpcPendingState>();
+  private pendingWindowsStartupById = new Map<string, PtyPendingWindowsStartupState>();
+  private pausedPtyIds = new Set<string>();
   private getWindows: () => BrowserWindow[];
 
   constructor(getWindows: () => BrowserWindow[]) {
@@ -330,6 +352,7 @@ export class PTYManager {
     const hadSession = this.sessions.has(key);
     // 先 flush，避免短命令最后一段输出卡在合并队列中。
     try { this.flushPtyData(key); } catch {}
+    this.clearPendingWindowsStartup(key);
     this.sessions.delete(key);
     try { this.clearPendingPtyData(key); } catch {}
     try { this.backlogs.get(key)?.clear(); } catch {}
@@ -337,6 +360,69 @@ export class PTYManager {
     if (hadSession) {
       this.sendToRenderer('pty:exit', { id: key, exitCode });
     }
+  }
+
+  /** 登记 Windows 原生终端的启动命令，等待 xterm 双向连接稳定后执行。 */
+  private queuePendingWindowsStartup(
+    id: string,
+    state: Pick<PtyPendingWindowsStartupState, "startupNotice" | "startupCmd" | "mode">,
+  ): void {
+    if (!state.startupNotice && !state.startupCmd)
+      return;
+    const timer = setTimeout(() => {
+      const pending = this.pendingWindowsStartupById.get(id);
+      if (!pending)
+        return;
+      pending.frontendReady = true;
+      this.schedulePendingWindowsStartup(id, "fallback");
+    }, PTY_STARTUP_READY_FALLBACK_MS);
+    try { timer.unref(); } catch {}
+    this.pendingWindowsStartupById.set(id, {
+      ...state,
+      timer,
+      attempt: null,
+      frontendReady: false,
+    });
+  }
+
+  /** 在当前一轮 IPC 消息处理完成后尝试释放原生终端启动命令。 */
+  private schedulePendingWindowsStartup(id: string, source: "ready" | "resume" | "fallback"): void {
+    const pending = this.pendingWindowsStartupById.get(id);
+    if (!pending?.frontendReady || pending.attempt)
+      return;
+    pending.attempt = setImmediate(() => {
+      const current = this.pendingWindowsStartupById.get(id);
+      if (!current)
+        return;
+      current.attempt = null;
+      if (!current.frontendReady || this.pausedPtyIds.has(id))
+        return;
+      this.pendingWindowsStartupById.delete(id);
+      if (current.timer)
+        clearTimeout(current.timer);
+      const proc = this.sessions.get(id);
+      if (!proc)
+        return;
+      if (current.startupNotice) {
+        try { proc.write(current.startupNotice); } catch {}
+      }
+      if (!current.startupCmd)
+        return;
+      proc.write(`${current.startupCmd}\r`);
+      dlog(`[pty] startupCmd executed source=${source} id=${id} shell=${current.mode}`);
+    });
+    try { pending.attempt.unref(); } catch {}
+  }
+
+  /** 清理尚未执行的原生终端启动命令及其计时器。 */
+  private clearPendingWindowsStartup(id: string): void {
+    const pending = this.pendingWindowsStartupById.get(id);
+    if (pending?.timer)
+      clearTimeout(pending.timer);
+    if (pending?.attempt)
+      clearImmediate(pending.attempt);
+    this.pendingWindowsStartupById.delete(id);
+    this.pausedPtyIds.delete(id);
   }
 
   /**
@@ -368,7 +454,7 @@ export class PTYManager {
    * 打开一个 PTY 会话。
    * - 允许通过 opts.terminal 覆盖全局 settings.terminal，用于实现 Provider 级别环境隔离。
    */
-  openWSLConsole(opts: { terminal?: TerminalMode; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string> }): PtyOpenResult {
+  async openWSLConsole(opts: { terminal?: TerminalMode; distro?: string; wslPath?: string; winPath?: string; cols?: number; rows?: number; startupCmd?: string; env?: Record<string, string> }): Promise<PtyOpenResult> {
     const distro = opts.distro || 'Ubuntu-22.04';
     const wslPath = opts.wslPath || '~';
     const winPath = String(opts.winPath || '').trim();
@@ -380,8 +466,23 @@ export class PTYManager {
 
     const id = uid();
 
-    let env = { ...process.env } as Record<string, string>;
+    let env = sanitizeInheritedTerminalColorEnvironment(
+      { ...process.env } as Record<string, string>,
+    );
     env = mergeExtraEnv(env, opts.env);
+    const terminalCapabilities = normalizeTerminalCapabilitySettings(
+      settings.getTerminalCapabilitySettings(),
+    );
+    env = applyTerminalCapabilityEnvironment(env, terminalCapabilities);
+    const capabilityEnvKeys: string[] = [];
+    if (terminalCapabilities.normalizeTerm && String(env.TERM || "").trim())
+      capabilityEnvKeys.push("TERM");
+    if (
+      terminalCapabilities.trueColor
+      && !Object.prototype.hasOwnProperty.call(env, "NO_COLOR")
+      && String(env.COLORTERM || "").trim()
+    )
+      capabilityEnvKeys.push("COLORTERM");
 
     // 根据设置选择 WSL 或 Windows 本地终端
     let termMode = (opts.terminal || settings.getSettings().terminal || 'wsl');
@@ -421,18 +522,29 @@ export class PTYManager {
           args.push('--cd', wslPath);
         }
       }
-      if (os.platform() === 'win32' && opts.env && Object.keys(opts.env).length > 0) {
-        const keys = Object.keys(opts.env).map((k) => String(k || "").trim()).filter(Boolean);
+      if (os.platform() === 'win32') {
+        const keys = [
+          ...Object.keys(opts.env || {}),
+          ...capabilityEnvKeys,
+        ].map((key) => String(key || "").trim()).filter(Boolean);
         if (keys.length > 0) env.WSLENV = appendWslEnv(env.WSLENV, keys);
       }
       try {
-        proc = pty.spawn(shell, args, {
-          name: 'xterm-256color',
-          cols,
-          rows,
-          cwd: undefined,
-          env
+        const wslPty = await spawnIsolatedWslConpty({
+          file: shell,
+          args,
+          ptyOptions: {
+            name: 'xterm-256color',
+            cols,
+            rows,
+            cwd: undefined,
+            env,
+          },
+          onFallback: (reason) => dlog(`[pty] bundled ConPTY fallback to system ConPTY: ${reason}`),
+          onDiagnostic: (message) => dlog(`[pty] WSL protocol id=${id} ${message}`),
         });
+        proc = wslPty;
+        dlog(`[pty] WSL ConPTY backend=${wslPty.backend} host=isolated`);
       } catch (error: any) {
         const resolved = resolveWindowsShell('windows');
         termMode = 'windows';
@@ -463,32 +575,41 @@ export class PTYManager {
       this.cleanupExitedSession(id, evt?.exitCode);
     });
 
-    // 关键修复：延迟执行 startupCmd，确保前端有足够时间订阅 'pty:data' 事件
-    // 使用 setImmediate 让前端的 IPC 订阅先完成，避免早期输出（包括 OSC 通知）丢失
+    // Windows 原生终端等待前端绑定和首次 resize 稳定；WSL 在隔离宿主内独立门控。
     if (startupNotice || startupCmd) {
       const isWin = os.platform() === 'win32';
       const mode = isWin ? (termMode || 'wsl') : 'posix';
       const isWinShell = mode === 'windows' || mode === 'pwsh' || mode === 'cmd';
-      setImmediate(() => {
-        const p = this.sessions.get(id);
-        if (!p) return; // PTY 可能已关闭
-        if (startupNotice) {
-          try { p.write(startupNotice); } catch {}
-        }
-        if (!startupCmd) return;
-        if (isWinShell) {
-          // Windows 本地 shell 中直接执行命令（cwd 已设置）
-          p.write(`${startupCmd}\r`);
-          dlog(`[pty] startupCmd executed (windows) id=${id} shell=${mode}`);
-        } else if (isWin) {
-          // WSL：通过 bash -lc 执行
-          p.write(`bash -lc ${bashSingleQuote(startupCmd)}\r`);
-          dlog(`[pty] startupCmd executed (wsl) id=${id}`);
-        } else {
-          p.write(`${startupCmd}\r`);
-          dlog(`[pty] startupCmd executed (posix) id=${id}`);
-        }
-      });
+      if (isWinShell) {
+        this.queuePendingWindowsStartup(id, {
+          startupNotice,
+          startupCmd,
+          mode,
+        });
+      } else {
+        setImmediate(() => {
+          const p = this.sessions.get(id);
+          if (!p) return;
+          if (startupNotice) {
+            try { p.write(startupNotice); } catch {}
+          }
+          if (!startupCmd) return;
+          if (isWin) {
+            const command = `bash -lc ${bashSingleQuote(startupCmd)}\r`;
+            const frontendAwarePty = p as IPty & { writeWhenFrontendReady?: (data: string) => void };
+            if (typeof frontendAwarePty.writeWhenFrontendReady === 'function') {
+              frontendAwarePty.writeWhenFrontendReady(command);
+              dlog(`[pty] startupCmd queued until frontend ready (wsl) id=${id}`);
+            } else {
+              p.write(command);
+              dlog(`[pty] startupCmd executed (wsl-conpty) id=${id}`);
+            }
+          } else {
+            p.write(`${startupCmd}\r`);
+            dlog(`[pty] startupCmd executed (posix) id=${id}`);
+          }
+        });
+      }
     }
 
     return { id, terminal: termMode as TerminalMode, distro, fallbackReason };
@@ -502,6 +623,27 @@ export class PTYManager {
   write(id: string, data: string) {
     const p = this.sessions.get(id);
     if (p) p.write(data);
+  }
+
+  /**
+   * 通知 PTY：xterm.js 已完成双向绑定；WSL 同步主题色，原生终端释放启动门控。
+   * @param id PTY 会话 id
+   * @param colors 当前终端主题的前景色与背景色
+   */
+  ready(id: string, colors?: Partial<TerminalPaletteColors>): void {
+    const key = String(id || '').trim();
+    const pendingWindowsStartup = this.pendingWindowsStartupById.get(key);
+    if (pendingWindowsStartup) {
+      pendingWindowsStartup.frontendReady = true;
+      this.schedulePendingWindowsStartup(key, "ready");
+    }
+    const p = this.sessions.get(key) as (
+      IPty & { markFrontendReady?: (colors?: Partial<TerminalPaletteColors>) => void }
+    ) | undefined;
+    if (typeof p?.markFrontendReady !== 'function')
+      return;
+    p.markFrontendReady(colors);
+    dlog(`[pty] frontend ready id=${key} mode=wsl-conpty`);
   }
 
   /**
@@ -539,6 +681,7 @@ export class PTYManager {
       try { p.kill(); } catch { /* noop */ }
       this.sessions.delete(id);
     }
+    this.clearPendingWindowsStartup(id);
     // 中文说明：关闭时尽量把最后的 pending 输出发送出去，避免 UI 看到“少一截”。
     try { this.flushPtyData(id); } catch {}
     try { this.clearPendingPtyData(id); } catch {}
@@ -553,6 +696,8 @@ export class PTYManager {
    */
   pause(id: string) {
     const p = this.sessions.get(id);
+    if (this.pendingWindowsStartupById.has(id))
+      this.pausedPtyIds.add(id);
     dlog(`[pty] pause id=${id}`);
     try { p?.pause(); } catch {}
   }
@@ -565,6 +710,8 @@ export class PTYManager {
     const p = this.sessions.get(id);
     dlog(`[pty] resume id=${id}`);
     try { p?.resume(); } catch {}
+    this.pausedPtyIds.delete(id);
+    this.schedulePendingWindowsStartup(id, "resume");
   }
 
   // 与前端清屏同步，通知 ConPTY 清除其内部缓冲（仅 Windows/ConPTY 有效，其他平台为 no-op）
@@ -584,6 +731,7 @@ export class PTYManager {
   disposeAll() {
     for (const [id, p] of Array.from(this.sessions.entries())) {
       try { p.kill(); } catch {}
+      this.clearPendingWindowsStartup(id);
       this.sessions.delete(id);
       // 中文说明：同 close(id)，在全量清理时也尽量 flush 尾部输出。
       try { this.flushPtyData(id); } catch {}

--- a/electron/settings.ts
+++ b/electron/settings.ts
@@ -9,6 +9,11 @@ import { getSessionsRootsFastAsync, listDistros } from './wsl.js';
 import { hasPwsh, normalizeTerminal, type TerminalMode } from './shells.js';
 import type { TerminalThemeId } from '@/types/terminal-theme';
 import type { DistroInfo } from './wsl';
+import {
+  DEFAULT_TERMINAL_CAPABILITIES,
+  normalizeTerminalCapabilitySettings,
+  type TerminalCapabilitySettings,
+} from './terminalCapabilities';
 
 export type NotificationSettings = {
   /** 任务完成时是否在任务栏显示徽标计数 */
@@ -144,6 +149,8 @@ export type AppSettings = {
   terminal?: TerminalMode;
   /** 终端配色主题 */
   terminalTheme?: TerminalThemeId;
+  /** 内置终端向 CLI 声明的兼容性与颜色能力。 */
+  terminalCapabilities?: TerminalCapabilitySettings;
   /** WSL 发行版名称（当 terminal=wsl 时生效） */
   distro: string;
   /** 启动 CodexFlow 的命令（渲染层会做包装） */
@@ -218,6 +225,9 @@ const DEFAULT_WSL_DISTRO = 'Ubuntu-24.04';
 const DISTRO_CACHE_TTL_MS = 30_000;
 let cachedDistros: DistroInfo[] | null = null;
 let cachedDistrosAt = 0;
+let cachedTerminalCapabilitySettings: Required<TerminalCapabilitySettings> = {
+  ...DEFAULT_TERMINAL_CAPABILITIES,
+};
 const DEFAULT_NOTIFICATIONS: NotificationSettings = {
   badge: true,
   system: true,
@@ -645,6 +655,7 @@ function mergeWithDefaults(raw: Partial<AppSettings>, preloadedDistros?: DistroI
   const defaults: AppSettings = {
     terminal: 'wsl',
     terminalTheme: DEFAULT_TERMINAL_THEME,
+    terminalCapabilities: { ...DEFAULT_TERMINAL_CAPABILITIES },
     distro: pickPreferredDistro('', distros),
     // 渲染层会按“每标签独立 tmux 会话”包装该命令；默认仅保存基础命令
     codexCmd: 'codex',
@@ -715,6 +726,7 @@ function mergeWithDefaults(raw: Partial<AppSettings>, preloadedDistros?: DistroI
   merged.distro = pickPreferredDistro(merged.distro, distros);
   merged.theme = normalizeTheme((raw as any)?.theme ?? merged.theme);
   merged.terminalTheme = normalizeTerminalTheme((raw as any)?.terminalTheme ?? merged.terminalTheme);
+  merged.terminalCapabilities = normalizeTerminalCapabilitySettings((raw as any)?.terminalCapabilities);
   merged.providers = normalizeProviders(merged, distros);
   merged.claudeCode = normalizeClaudeCodeSettings((merged as any).claudeCode);
   merged.gitWorktree = normalizeGitWorktreeSettings((raw as any)?.gitWorktree);
@@ -740,13 +752,24 @@ export function getSettings(): AppSettings {
   try {
     const p = getStorePath();
     const distros = loadDistroList();
-    if (!fs.existsSync(p)) return mergeWithDefaults({}, distros);
-    const raw = fs.readFileSync(p, 'utf8');
-    const parsed = JSON.parse(raw || '{}') as Partial<AppSettings>;
-    return mergeWithDefaults(parsed, distros);
+    const parsed = fs.existsSync(p)
+      ? JSON.parse(fs.readFileSync(p, 'utf8') || '{}') as Partial<AppSettings>
+      : {};
+    const next = mergeWithDefaults(parsed, distros);
+    cachedTerminalCapabilitySettings = normalizeTerminalCapabilitySettings(next.terminalCapabilities);
+    return next;
   } catch (e) {
-    return defaultSettings();
+    const next = defaultSettings();
+    cachedTerminalCapabilitySettings = normalizeTerminalCapabilitySettings(next.terminalCapabilities);
+    return next;
   }
+}
+
+/**
+ * 返回内存中的终端能力设置，供 PTY 打开热路径使用。
+ */
+export function getTerminalCapabilitySettings(): Required<TerminalCapabilitySettings> {
+  return { ...cachedTerminalCapabilitySettings };
 }
 
 export function updateSettings(partial: Partial<AppSettings>) {
@@ -754,6 +777,13 @@ export function updateSettings(partial: Partial<AppSettings>) {
     const distros = loadDistroList();
     const cur = mergeWithDefaults(getSettings(), distros);
     const mergedRaw: Partial<AppSettings> = Object.assign({}, cur, partial);
+    // 对 terminalCapabilities 做浅层合并，避免只更新单个开关时重置另一个开关。
+    try {
+      const current = normalizeTerminalCapabilitySettings((cur as any)?.terminalCapabilities);
+      const patch = (partial as any)?.terminalCapabilities;
+      if (patch && typeof patch === "object")
+        (mergedRaw as any).terminalCapabilities = { ...current, ...patch };
+    } catch {}
     // 对 dragDrop 做浅层合并，避免渲染层只更新单个字段时覆盖其它子字段
     try {
       const curDrag = (cur as any)?.dragDrop && typeof (cur as any).dragDrop === "object" ? (cur as any).dragDrop : {};
@@ -806,6 +836,7 @@ export function updateSettings(partial: Partial<AppSettings>) {
     } catch {}
     const next = mergeWithDefaults(mergedRaw, distros);
     fs.writeFileSync(getStorePath(), JSON.stringify(next, null, 2), 'utf8');
+    cachedTerminalCapabilitySettings = normalizeTerminalCapabilitySettings(next.terminalCapabilities);
     return next;
   } catch (e) {
     return getSettings();
@@ -873,6 +904,12 @@ export async function ensureFirstRunTerminalSelection(): Promise<AppSettings> {
   }
 }
 
-export default { getSettings, updateSettings, hasSettingsStore, hasSavedRuntimeEnvSelection };
+export default {
+  getSettings,
+  getTerminalCapabilitySettings,
+  updateSettings,
+  hasSettingsStore,
+  hasSavedRuntimeEnvSelection,
+};
 
 

--- a/electron/terminalCapabilities.test.ts
+++ b/electron/terminalCapabilities.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyTerminalCapabilityEnvironment,
+  normalizeTerminalCapabilitySettings,
+  sanitizeInheritedTerminalColorEnvironment,
+} from "./terminalCapabilities";
+
+describe("terminalCapabilities", () => {
+  it("旧设置应默认启用兼容性补齐并关闭真彩色注入", () => {
+    expect(normalizeTerminalCapabilitySettings(undefined)).toEqual({
+      normalizeTerm: true,
+      trueColor: false,
+    });
+  });
+
+  it("应清理 dumb 父进程临时注入的禁色变量", () => {
+    expect(sanitizeInheritedTerminalColorEnvironment({
+      TERM: "dumb",
+      COLORTERM: "",
+      NO_COLOR: "1",
+      FORCE_COLOR: "1",
+    })).toEqual({ TERM: "dumb" });
+  });
+
+  it("父进程已是交互终端时应保留用户颜色控制变量", () => {
+    expect(sanitizeInheritedTerminalColorEnvironment({
+      TERM: "xterm-256color",
+      NO_COLOR: "1",
+    })).toEqual({ TERM: "xterm-256color", NO_COLOR: "1" });
+  });
+
+  it.each([undefined, "", "dumb", "DUMB"])("应把退化 TERM=%s 补齐为 xterm-256color", (term) => {
+    const env = applyTerminalCapabilityEnvironment(
+      term === undefined ? {} : { TERM: term },
+      { normalizeTerm: true, trueColor: false },
+    );
+    expect(env.TERM).toBe("xterm-256color");
+  });
+
+  it("应保留用户已有的有效 TERM", () => {
+    const env = applyTerminalCapabilityEnvironment(
+      { TERM: "screen-256color" },
+      { normalizeTerm: true },
+    );
+    expect(env.TERM).toBe("screen-256color");
+  });
+
+  it("关闭兼容性补齐后应保留 dumb", () => {
+    const env = applyTerminalCapabilityEnvironment(
+      { TERM: "dumb" },
+      { normalizeTerm: false },
+    );
+    expect(env.TERM).toBe("dumb");
+  });
+
+  it("开启真彩色后应仅在缺失时注入 COLORTERM", () => {
+    expect(applyTerminalCapabilityEnvironment({}, { trueColor: true }).COLORTERM).toBe("truecolor");
+    expect(applyTerminalCapabilityEnvironment(
+      { COLORTERM: "24bit" },
+      { trueColor: true },
+    ).COLORTERM).toBe("24bit");
+  });
+
+  it("存在 NO_COLOR 时不应注入真彩色声明", () => {
+    const env = applyTerminalCapabilityEnvironment(
+      { NO_COLOR: "" },
+      { trueColor: true },
+    );
+    expect(env.COLORTERM).toBeUndefined();
+  });
+});

--- a/electron/terminalCapabilities.ts
+++ b/electron/terminalCapabilities.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+export type TerminalCapabilitySettings = {
+  /** 缺失或退化时补齐 xterm-256color，保留其它有效 TERM。 */
+  normalizeTerm?: boolean;
+  /** 缺失且未声明 NO_COLOR 时补齐 COLORTERM=truecolor。 */
+  trueColor?: boolean;
+};
+
+export const DEFAULT_TERMINAL_CAPABILITIES: Required<TerminalCapabilitySettings> = {
+  normalizeTerm: true,
+  trueColor: false,
+};
+
+/**
+ * 清理非交互父进程注入的颜色控制变量，避免污染新建的交互式终端。
+ * 用户通过终端环境显式传入的同名变量会在调用方后续合并时恢复。
+ */
+export function sanitizeInheritedTerminalColorEnvironment(
+  input: Record<string, string>,
+): Record<string, string> {
+  const env = { ...input };
+  if (String(env.TERM || "").trim().toLowerCase() !== "dumb")
+    return env;
+  delete env.NO_COLOR;
+  delete env.FORCE_COLOR;
+  if (!String(env.COLORTERM || "").trim())
+    delete env.COLORTERM;
+  return env;
+}
+
+/**
+ * 归一化终端能力设置，确保旧设置文件也能获得稳定默认值。
+ */
+export function normalizeTerminalCapabilitySettings(raw: unknown): Required<TerminalCapabilitySettings> {
+  const source = raw && typeof raw === "object" ? raw as TerminalCapabilitySettings : {};
+  return {
+    normalizeTerm: source.normalizeTerm !== false,
+    trueColor: source.trueColor === true,
+  };
+}
+
+/**
+ * 按设置补齐终端能力环境变量，不覆盖用户已有的有效声明。
+ */
+export function applyTerminalCapabilityEnvironment(
+  input: Record<string, string>,
+  rawSettings: unknown,
+): Record<string, string> {
+  const env = { ...input };
+  const capabilities = normalizeTerminalCapabilitySettings(rawSettings);
+  const currentTerm = String(env.TERM || "").trim();
+  if (capabilities.normalizeTerm && (!currentTerm || currentTerm.toLowerCase() === "dumb"))
+    env.TERM = "xterm-256color";
+
+  const hasNoColor = Object.prototype.hasOwnProperty.call(env, "NO_COLOR");
+  if (capabilities.trueColor && !hasNoColor && !String(env.COLORTERM || "").trim())
+    env.COLORTERM = "truecolor";
+  return env;
+}

--- a/electron/wslConpty.test.ts
+++ b/electron/wslConpty.test.ts
@@ -1,0 +1,303 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { IPty } from "node-pty";
+import { WslConptyPty } from "./wslConpty";
+
+/** 创建可观察委托行为的最小 PTY 桩。 */
+function createPtyStub(): IPty {
+  return {
+    pid: 42,
+    cols: 120,
+    rows: 30,
+    process: "wsl.exe",
+    handleFlowControl: false,
+    onData: vi.fn(() => ({ dispose: vi.fn() })),
+    onExit: vi.fn(() => ({ dispose: vi.fn() })),
+    write: vi.fn(),
+    resize: vi.fn(),
+    clear: vi.fn(),
+    kill: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+  };
+}
+
+/** 向 WSL ConPTY 包装层触发一段底层 PTY 输出。 */
+function emitPtyData(pty: IPty, data: string): void {
+  const calls = (pty.onData as any).mock.calls as Array<[(data: string) => void]>;
+  const listener = calls[0]?.[0];
+  if (!listener)
+    throw new Error("missing inner PTY data listener");
+  listener(data);
+}
+
+/** 向 WSL ConPTY 包装层触发底层 PTY 退出事件。 */
+function emitPtyExit(pty: IPty, exitCode = 0): void {
+  const calls = (pty.onExit as any).mock.calls as Array<[
+    (event: { exitCode: number }) => void,
+  ]>;
+  const listener = calls[0]?.[0];
+  if (!listener)
+    throw new Error("missing inner PTY exit listener");
+  listener({ exitCode });
+}
+
+/** 创建统一的 WSL PTY 启动参数。 */
+function createOptions(spawn: ReturnType<typeof vi.fn>, frontendReadyTimeoutMs?: number) {
+  return {
+    file: "wsl.exe",
+    args: ["-d", "Ubuntu"],
+    ptyOptions: {
+      name: "xterm-256color",
+      cols: 120,
+      rows: 30,
+      env: { TERM: "xterm-256color" },
+    },
+    frontendReadyTimeoutMs,
+    spawn: spawn as any,
+  };
+}
+
+describe("WslConptyPty", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("应优先启用应用内置 ConPTY", () => {
+    const inner = createPtyStub();
+    const spawn = vi.fn(() => inner);
+    const terminal = new WslConptyPty(createOptions(spawn));
+
+    expect(terminal.backend).toBe("bundled");
+    expect(terminal.fallbackReason).toBeUndefined();
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn).toHaveBeenCalledWith(
+      "wsl.exe",
+      ["-d", "Ubuntu"],
+      expect.objectContaining({ useConpty: true, useConptyDll: true }),
+    );
+  });
+
+  it("内置 ConPTY 同步启动失败时应退回系统 ConPTY", () => {
+    const inner = createPtyStub();
+    const onFallback = vi.fn();
+    const spawn = vi.fn()
+      .mockImplementationOnce(() => { throw new Error("bundled conpty unavailable"); })
+      .mockReturnValueOnce(inner);
+    const terminal = new WslConptyPty({
+      ...createOptions(spawn),
+      onFallback,
+    });
+
+    expect(terminal.backend).toBe("system");
+    expect(terminal.fallbackReason).toBe("bundled conpty unavailable");
+    expect(onFallback).toHaveBeenCalledWith("bundled conpty unavailable");
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(spawn.mock.calls[1]?.[2]).toEqual(
+      expect.objectContaining({ useConpty: true, useConptyDll: false }),
+    );
+  });
+
+  it("自动启动命令应等待前端完成绑定", () => {
+    const inner = createPtyStub();
+    const spawn = vi.fn(() => inner);
+    const terminal = new WslConptyPty(createOptions(spawn));
+
+    terminal.writeWhenFrontendReady("bash -lc codex\r");
+    expect(inner.write).not.toHaveBeenCalled();
+
+    terminal.markFrontendReady();
+    expect(inner.write).toHaveBeenCalledWith("bash -lc codex\r");
+
+    terminal.writeWhenFrontendReady("echo ready\r");
+    expect(inner.write).toHaveBeenLastCalledWith("echo ready\r");
+  });
+
+  it("前端未发送就绪事件时应按超时兜底启动", () => {
+    vi.useFakeTimers();
+    const inner = createPtyStub();
+    const spawn = vi.fn(() => inner);
+    const terminal = new WslConptyPty(createOptions(spawn, 25));
+
+    terminal.writeWhenFrontendReady("bash -lc codex\r");
+    vi.advanceTimersByTime(24);
+    expect(inner.write).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(inner.write).toHaveBeenCalledWith("bash -lc codex\r");
+  });
+
+  it("应在主进程直接回答 OSC 10/11 查询并阻止查询重复进入 xterm", () => {
+    const inner = createPtyStub();
+    const spawn = vi.fn(() => inner);
+    const terminal = new WslConptyPty(createOptions(spawn));
+    const output = vi.fn();
+    terminal.onData(output);
+    terminal.markFrontendReady({
+      foreground: "#123456",
+      background: "#ABCDEF",
+    });
+
+    emitPtyData(
+      inner,
+      `before\x1B]10;?\x1B\\middle\x1B]11;?\x1B\\after`,
+    );
+
+    expect(output).toHaveBeenCalledTimes(1);
+    expect(output).toHaveBeenCalledWith("beforemiddleafter");
+    expect(inner.write).toHaveBeenNthCalledWith(
+      1,
+      "\x1B]10;rgb:1212/3434/5656\x1B\\",
+    );
+    expect(inner.write).toHaveBeenNthCalledWith(
+      2,
+      "\x1B]11;rgb:abab/cdcd/efef\x1B\\",
+    );
+  });
+
+  it("OSC 10/11 查询跨多个 PTY 数据块时仍应稳定回答", () => {
+    const inner = createPtyStub();
+    const spawn = vi.fn(() => inner);
+    const terminal = new WslConptyPty(createOptions(spawn));
+    const output = vi.fn();
+    terminal.onData(output);
+    terminal.markFrontendReady({
+      foreground: "#102030",
+      background: "#405060",
+    });
+
+    emitPtyData(inner, "普通\x1B]1");
+    emitPtyData(inner, "0;?\x1B");
+    emitPtyData(inner, "\\输出\x1B]11;?");
+    emitPtyData(inner, "\x07完成");
+
+    expect(output.mock.calls.map(([data]) => data).join("")).toBe("普通输出完成");
+    expect(inner.write).toHaveBeenNthCalledWith(
+      1,
+      "\x1B]10;rgb:1010/2020/3030\x1B\\",
+    );
+    expect(inner.write).toHaveBeenNthCalledWith(
+      2,
+      "\x1B]11;rgb:4040/5050/6060\x1B\\",
+    );
+  });
+
+  it("前端画面暂停期间仍应读取并立即回答颜色查询", () => {
+    vi.useFakeTimers();
+    const inner = createPtyStub();
+    const spawn = vi.fn(() => inner);
+    const onDiagnostic = vi.fn();
+    const terminal = new WslConptyPty({
+      ...createOptions(spawn),
+      onDiagnostic,
+    });
+    const output = vi.fn();
+    terminal.onData(output);
+    terminal.markFrontendReady({
+      foreground: "#123456",
+      background: "#ABCDEF",
+    });
+
+    terminal.pause();
+    terminal.pause();
+    emitPtyData(inner, "before\x1B]1");
+    emitPtyData(inner, "0;?\x1B");
+    emitPtyData(inner, "\\middle\x1B]11;?");
+    emitPtyData(inner, "\x07after");
+
+    expect(inner.pause).not.toHaveBeenCalled();
+    expect(inner.write).toHaveBeenNthCalledWith(
+      1,
+      "\x1B]10;rgb:1212/3434/5656\x1B\\",
+    );
+    expect(inner.write).toHaveBeenNthCalledWith(
+      2,
+      "\x1B]11;rgb:abab/cdcd/efef\x1B\\",
+    );
+    expect(output).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(150);
+    expect(onDiagnostic).toHaveBeenCalledWith(
+      "osc-query slot=11 frontendPaused=1",
+    );
+
+    terminal.resume();
+    terminal.resume();
+
+    expect(inner.resume).not.toHaveBeenCalled();
+    expect(output).toHaveBeenCalledTimes(1);
+    expect(output).toHaveBeenCalledWith("beforemiddleafter");
+  });
+
+  it("暂停缓存达到上限时应无损直通且不暂停底层 socket", () => {
+    const inner = createPtyStub();
+    const spawn = vi.fn(() => inner);
+    const terminal = new WslConptyPty(createOptions(spawn));
+    const output = vi.fn();
+    terminal.onData(output);
+    terminal.markFrontendReady();
+    terminal.pause();
+    const largeOutput = "x".repeat(200_000);
+
+    emitPtyData(inner, largeOutput);
+
+    expect(inner.pause).not.toHaveBeenCalled();
+    expect(output).toHaveBeenCalledTimes(1);
+    expect(output).toHaveBeenCalledWith(largeOutput);
+    terminal.resume();
+    expect(output).toHaveBeenCalledTimes(1);
+  });
+
+  it("暂停状态退出时应先释放普通输出和未决协议前缀", () => {
+    const inner = createPtyStub();
+    const spawn = vi.fn(() => inner);
+    const terminal = new WslConptyPty(createOptions(spawn));
+    const order: string[] = [];
+    terminal.onData((data) => order.push(`data:${data}`));
+    terminal.onExit(() => order.push("exit"));
+    terminal.markFrontendReady();
+    terminal.pause();
+
+    emitPtyData(inner, "output\x1B");
+    emitPtyExit(inner);
+
+    expect(order).toEqual(["data:output\x1B", "exit"]);
+  });
+
+  it("非颜色查询及前端就绪前的输出应保持原样", () => {
+    const inner = createPtyStub();
+    const spawn = vi.fn(() => inner);
+    const terminal = new WslConptyPty(createOptions(spawn));
+    const output = vi.fn();
+    terminal.onData(output);
+
+    emitPtyData(inner, "\x1B]10;?\x1B\\");
+    terminal.markFrontendReady();
+    emitPtyData(inner, "\x1B]1");
+    emitPtyData(inner, "2;?\x1B\\");
+
+    expect(output.mock.calls.map(([data]) => data).join("")).toBe(
+      "\x1B]10;?\x1B\\\x1B]12;?\x1B\\",
+    );
+    expect(inner.write).not.toHaveBeenCalled();
+  });
+
+  it("非法主题色应回退到 Campbell 默认色且不能注入终端协议", () => {
+    const inner = createPtyStub();
+    const spawn = vi.fn(() => inner);
+    const terminal = new WslConptyPty(createOptions(spawn));
+    terminal.markFrontendReady({
+      foreground: "red\x1B]52;bad",
+      background: "#010203",
+    });
+
+    emitPtyData(inner, "\x1B]10;?\x07\x1B]11;?\x07");
+
+    expect(inner.write).toHaveBeenNthCalledWith(
+      1,
+      "\x1B]10;rgb:cccc/cccc/cccc\x1B\\",
+    );
+    expect(inner.write).toHaveBeenNthCalledWith(
+      2,
+      "\x1B]11;rgb:0101/0202/0303\x1B\\",
+    );
+  });
+});

--- a/electron/wslConpty.ts
+++ b/electron/wslConpty.ts
@@ -1,0 +1,401 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import * as nodePty from "node-pty";
+import type {
+  IEvent,
+  IPty,
+  IWindowsPtyForkOptions,
+} from "node-pty";
+
+const FRONTEND_READY_FALLBACK_MS = 2_000;
+const PAUSED_FRONTEND_OUTPUT_MAX_CHARS = 200_000;
+const DEFAULT_TERMINAL_COLORS: TerminalPaletteColors = {
+  foreground: "#CCCCCC",
+  background: "#0C0C0C",
+};
+
+const OSC_COLOR_QUERIES = [
+  { sequence: "\x1B]10;?\x1B\\", slot: 10 },
+  { sequence: "\x1B]10;?\x07", slot: 10 },
+  { sequence: "\x1B]11;?\x1B\\", slot: 11 },
+  { sequence: "\x1B]11;?\x07", slot: 11 },
+] as const;
+
+type SpawnPty = typeof nodePty.spawn;
+
+export type WslConptyBackend = "bundled" | "system";
+
+export type TerminalPaletteColors = {
+  foreground: string;
+  background: string;
+};
+
+export type WslConptyOptions = {
+  file: string;
+  args: string[];
+  ptyOptions: IWindowsPtyForkOptions;
+  onFallback?: (reason: string) => void;
+  onDiagnostic?: (message: string) => void;
+  frontendReadyTimeoutMs?: number;
+  spawn?: SpawnPty;
+};
+
+/** 把未知异常转换为可记录的简短原因。 */
+function describeError(error: unknown): string {
+  if (error instanceof Error && error.message)
+    return error.message;
+  return String(error || "unknown error");
+}
+
+/** 把前端主题色规范为可安全写入终端协议的六位十六进制颜色。 */
+function normalizeHexColor(value: unknown, fallback: string): string {
+  const color = typeof value === "string" ? value.trim() : "";
+  return /^#[0-9a-f]{6}$/i.test(color) ? color.toUpperCase() : fallback;
+}
+
+/** 规范前端传入的终端前景色与背景色，非法值回退到 Campbell 默认色。 */
+function normalizeTerminalColors(colors?: Partial<TerminalPaletteColors>): TerminalPaletteColors {
+  return {
+    foreground: normalizeHexColor(colors?.foreground, DEFAULT_TERMINAL_COLORS.foreground),
+    background: normalizeHexColor(colors?.background, DEFAULT_TERMINAL_COLORS.background),
+  };
+}
+
+/** 把六位十六进制颜色转换为 xterm OSC 查询使用的 16 位 RGB 表示。 */
+function formatOscRgb(color: string): string {
+  const red = color.slice(1, 3).toLowerCase();
+  const green = color.slice(3, 5).toLowerCase();
+  const blue = color.slice(5, 7).toLowerCase();
+  return `rgb:${red}${red}/${green}${green}/${blue}${blue}`;
+}
+
+/** 计算数据末尾可能属于 OSC 10/11 查询前缀的字符数。 */
+function findPendingOscQueryPrefixLength(data: string): number {
+  const maxLength = Math.min(
+    data.length,
+    Math.max(...OSC_COLOR_QUERIES.map(({ sequence }) => sequence.length)) - 1,
+  );
+  for (let length = maxLength; length > 0; length -= 1) {
+    const suffix = data.slice(-length);
+    if (OSC_COLOR_QUERIES.some(({ sequence }) => sequence.startsWith(suffix)))
+      return length;
+  }
+  return 0;
+}
+
+/** 查找一段终端输出中的下一条完整 OSC 10/11 颜色查询。 */
+function findNextOscColorQuery(
+  data: string,
+  offset: number,
+): { index: number; sequence: string; slot: 10 | 11 } | null {
+  let next: { index: number; sequence: string; slot: 10 | 11 } | null = null;
+  for (const query of OSC_COLOR_QUERIES) {
+    const index = data.indexOf(query.sequence, offset);
+    if (index < 0 || (next && index >= next.index))
+      continue;
+    next = { index, sequence: query.sequence, slot: query.slot };
+  }
+  return next;
+}
+
+/**
+ * 使用应用内置 ConPTY 启动 WSL，并在同步启动失败时退回系统 ConPTY。
+ */
+export class WslConptyPty implements IPty {
+  private readonly inner: IPty;
+  private readonly frontendReadyTimeoutMs: number;
+  private readonly onDiagnostic?: (message: string) => void;
+  private readonly dataListeners = new Set<(data: string) => unknown>();
+  private frontendReady = false;
+  private frontendOutputPaused = false;
+  private frontendReadyTimer: NodeJS.Timeout | null = null;
+  private pendingFrontendWrites: string[] = [];
+  private pausedFrontendOutput: string[] = [];
+  private pausedFrontendOutputChars = 0;
+  private pendingOscQueryPrefix = "";
+  private terminalColors = { ...DEFAULT_TERMINAL_COLORS };
+
+  public readonly backend: WslConptyBackend;
+  public readonly fallbackReason?: string;
+
+  /** 创建带系统 ConPTY 回退和前端就绪门控的 WSL PTY。 */
+  constructor(options: WslConptyOptions) {
+    const spawn = options.spawn || nodePty.spawn;
+    this.onDiagnostic = options.onDiagnostic;
+    this.frontendReadyTimeoutMs = Math.max(
+      1,
+      Math.floor(options.frontendReadyTimeoutMs ?? FRONTEND_READY_FALLBACK_MS),
+    );
+
+    try {
+      this.inner = spawn(options.file, options.args, {
+        ...options.ptyOptions,
+        useConpty: true,
+        useConptyDll: true,
+      });
+      this.backend = "bundled";
+    } catch (error) {
+      const reason = describeError(error);
+      try { options.onFallback?.(reason); } catch {}
+      this.inner = spawn(options.file, options.args, {
+        ...options.ptyOptions,
+        useConpty: true,
+        useConptyDll: false,
+      });
+      this.backend = "system";
+      this.fallbackReason = reason;
+    }
+
+    this.inner.onData((data) => this.handleInnerData(data));
+  }
+
+  /** 返回底层 PTY 进程编号。 */
+  public get pid(): number {
+    return this.inner.pid;
+  }
+
+  /** 返回当前终端列数。 */
+  public get cols(): number {
+    return this.inner.cols;
+  }
+
+  /** 返回当前终端行数。 */
+  public get rows(): number {
+    return this.inner.rows;
+  }
+
+  /** 返回底层活动进程名称。 */
+  public get process(): string {
+    return this.inner.process;
+  }
+
+  /** 返回底层流控制开关。 */
+  public get handleFlowControl(): boolean {
+    return this.inner.handleFlowControl;
+  }
+
+  /** 同步设置底层流控制开关。 */
+  public set handleFlowControl(value: boolean) {
+    this.inner.handleFlowControl = value;
+  }
+
+  /** 注册经过终端颜色查询处理后的输出监听器。 */
+  public readonly onData: IEvent<string> = (listener) => {
+    this.dataListeners.add(listener);
+    return {
+      dispose: () => this.dataListeners.delete(listener),
+    };
+  };
+
+  /** 注册终端退出监听器，并清理尚未执行的启动命令。 */
+  public readonly onExit: IEvent<{ exitCode: number; signal?: number }> = (listener) => (
+    this.inner.onExit((event) => {
+      this.flushPendingOscQueryPrefix();
+      this.frontendOutputPaused = false;
+      this.flushPausedFrontendOutput();
+      this.disposeFrontendReadyGate();
+      listener(event);
+    })
+  );
+
+  /** 向底层 PTY 写入用户输入或终端协议回复。 */
+  public write(data: string | Buffer): void {
+    this.inner.write(data);
+  }
+
+  /** 在前端完成双向绑定后写入自动启动命令。 */
+  public writeWhenFrontendReady(data: string): void {
+    if (this.frontendReady) {
+      this.inner.write(data);
+      return;
+    }
+    this.pendingFrontendWrites.push(data);
+    if (this.frontendReadyTimer)
+      return;
+    this.frontendReadyTimer = setTimeout(
+      () => this.releaseFrontendWrites(),
+      this.frontendReadyTimeoutMs,
+    );
+    try { this.frontendReadyTimer.unref(); } catch {}
+  }
+
+  /** 标记 xterm.js 输入输出通道已经完成绑定，并同步当前终端主题色。 */
+  public markFrontendReady(colors?: Partial<TerminalPaletteColors>): void {
+    this.terminalColors = normalizeTerminalColors(colors);
+    this.reportDiagnostic(
+      `frontend-ready foreground=${this.terminalColors.foreground} background=${this.terminalColors.background}`,
+    );
+    this.releaseFrontendWrites();
+  }
+
+  /** 调整底层 PTY 的字符尺寸。 */
+  public resize(columns: number, rows: number): void {
+    this.inner.resize(columns, rows);
+  }
+
+  /** 清理底层 ConPTY 的内部屏幕缓存。 */
+  public clear(): void {
+    this.inner.clear();
+  }
+
+  /** 关闭底层 PTY 并丢弃尚未执行的启动命令。 */
+  public kill(signal?: string): void {
+    this.disposeFrontendReadyGate();
+    this.pendingOscQueryPrefix = "";
+    this.pausedFrontendOutput = [];
+    this.pausedFrontendOutputChars = 0;
+    this.dataListeners.clear();
+    this.inner.kill(signal);
+  }
+
+  /** 暂停向前端转发普通画面，但保持读取底层 PTY 以便及时处理终端协议。 */
+  public pause(): void {
+    if (this.frontendOutputPaused)
+      return;
+    this.frontendOutputPaused = true;
+    this.reportDiagnostic(`frontend-output-paused buffered=${this.pausedFrontendOutputChars}`);
+  }
+
+  /** 恢复向前端转发，并按原顺序释放暂停期间缓存的普通画面。 */
+  public resume(): void {
+    if (!this.frontendOutputPaused && this.pausedFrontendOutputChars <= 0)
+      return;
+    const bufferedChars = this.pausedFrontendOutputChars;
+    this.frontendOutputPaused = false;
+    this.flushPausedFrontendOutput();
+    this.reportDiagnostic(`frontend-output-resumed flushed=${bufferedChars}`);
+  }
+
+  /** 过滤 WSL 输出中的 OSC 10/11 查询，并直接把当前主题色写回 PTY。 */
+  private handleInnerData(data: string): void {
+    if (!data)
+      return;
+    if (!this.frontendReady) {
+      this.emitData(data);
+      return;
+    }
+
+    const buffered = this.pendingOscQueryPrefix + data;
+    this.pendingOscQueryPrefix = "";
+    let forwarded = "";
+    let offset = 0;
+    const answeredSlots: Array<10 | 11> = [];
+    let query = findNextOscColorQuery(buffered, offset);
+    while (query) {
+      forwarded += buffered.slice(offset, query.index);
+      this.respondToOscColorQuery(query.slot);
+      answeredSlots.push(query.slot);
+      offset = query.index + query.sequence.length;
+      query = findNextOscColorQuery(buffered, offset);
+    }
+
+    const tail = buffered.slice(offset);
+    const pendingLength = findPendingOscQueryPrefixLength(tail);
+    if (pendingLength > 0) {
+      forwarded += tail.slice(0, -pendingLength);
+      this.pendingOscQueryPrefix = tail.slice(-pendingLength);
+    } else {
+      forwarded += tail;
+    }
+    for (const slot of answeredSlots) {
+      this.reportOscQueryDiagnostic(slot, this.frontendOutputPaused);
+    }
+    this.emitData(forwarded);
+  }
+
+  /** 向 WSL PTY 写回指定颜色槽位的 OSC RGB 响应。 */
+  private respondToOscColorQuery(slot: 10 | 11): void {
+    const color = slot === 10 ? this.terminalColors.foreground : this.terminalColors.background;
+    this.inner.write(`\x1B]${slot};${formatOscRgb(color)}\x1B\\`);
+  }
+
+  /** 把普通终端输出分发给上层；前端暂停期间只做有界缓存。 */
+  private emitData(data: string): void {
+    if (!data)
+      return;
+    if (this.frontendOutputPaused) {
+      this.pausedFrontendOutput.push(data);
+      this.pausedFrontendOutputChars += data.length;
+      if (this.pausedFrontendOutputChars < PAUSED_FRONTEND_OUTPUT_MAX_CHARS)
+        return;
+      this.reportDiagnostic(
+        `frontend-output-buffer-limit chars=${this.pausedFrontendOutputChars}`,
+      );
+      this.flushPausedFrontendOutput();
+      return;
+    }
+    this.dispatchData(data);
+  }
+
+  /** 不经过暂停判断，直接把终端画面分发给所有上层监听器。 */
+  private dispatchData(data: string): void {
+    if (!data)
+      return;
+    for (const listener of this.dataListeners)
+      listener(data);
+  }
+
+  /** 合并并释放暂停期间缓存的普通终端画面。 */
+  private flushPausedFrontendOutput(): void {
+    if (this.pausedFrontendOutputChars <= 0)
+      return;
+    const buffered = this.pausedFrontendOutput.join("");
+    this.pausedFrontendOutput = [];
+    this.pausedFrontendOutputChars = 0;
+    this.dispatchData(buffered);
+  }
+
+  /** 在进程退出时原样释放尚未能判定的 OSC 查询前缀。 */
+  private flushPendingOscQueryPrefix(): void {
+    const pending = this.pendingOscQueryPrefix;
+    this.pendingOscQueryPrefix = "";
+    this.emitData(pending);
+  }
+
+  /** 向调用方报告低频 WSL 终端协议诊断信息。 */
+  private reportDiagnostic(message: string): void {
+    try { this.onDiagnostic?.(message); } catch {}
+  }
+
+  /** 延后报告颜色查询，确保诊断 IPC 不进入 Codex 的 100ms 回复关键路径。 */
+  private reportOscQueryDiagnostic(slot: 10 | 11, frontendPaused: boolean): void {
+    const timer = setTimeout(() => {
+      this.reportDiagnostic(
+        `osc-query slot=${slot} frontendPaused=${frontendPaused ? "1" : "0"}`,
+      );
+    }, 150);
+    try { timer.unref(); } catch {}
+  }
+
+  /** 释放前端门控并按顺序写入等待中的启动命令。 */
+  private releaseFrontendWrites(): void {
+    if (this.frontendReady)
+      return;
+    this.frontendReady = true;
+    this.clearFrontendReadyTimer();
+    const writes = this.pendingFrontendWrites.splice(0);
+    this.reportDiagnostic(`startup-writes-released count=${writes.length}`);
+    for (const data of writes)
+      this.inner.write(data);
+  }
+
+  /** 丢弃等待中的启动命令并清理定时器。 */
+  private disposeFrontendReadyGate(): void {
+    this.clearFrontendReadyTimer();
+    this.pendingFrontendWrites = [];
+  }
+
+  /** 清理前端就绪兜底定时器。 */
+  private clearFrontendReadyTimer(): void {
+    if (!this.frontendReadyTimer)
+      return;
+    clearTimeout(this.frontendReadyTimer);
+    this.frontendReadyTimer = null;
+  }
+}
+
+/** 创建 WSL ConPTY 会话。 */
+export function spawnWslConpty(options: WslConptyOptions): WslConptyPty {
+  return new WslConptyPty(options);
+}

--- a/electron/wslConptyHost.ts
+++ b/electron/wslConptyHost.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import { WslConptyPty } from "./wslConpty.js";
+import type {
+  WslConptyHostCommand,
+  WslConptyHostEvent,
+} from "./wslConptyProtocol.js";
+
+type UtilityParentPort = {
+  postMessage(message: WslConptyHostEvent): void;
+  on(event: "message", listener: (event: { data: unknown }) => void): unknown;
+};
+
+const parentPort = (process as NodeJS.Process & {
+  parentPort?: UtilityParentPort;
+}).parentPort;
+
+if (!parentPort)
+  throw new Error("WSL PTY host parent port is unavailable");
+
+let terminal: WslConptyPty | null = null;
+
+/** 向 Electron 主进程发送一条 WSL PTY 宿主事件。 */
+function postEvent(event: WslConptyHostEvent): void {
+  parentPort.postMessage(event);
+}
+
+/** 把未知异常转换为可跨进程传递的错误文本。 */
+function describeError(error: unknown): string {
+  if (error instanceof Error && error.message)
+    return error.message;
+  return String(error || "unknown error");
+}
+
+/** 在独立工具进程中创建并接管一个 WSL ConPTY。 */
+function initializeTerminal(command: Extract<WslConptyHostCommand, { type: "init" }>): void {
+  if (terminal)
+    return;
+  try {
+    const created = new WslConptyPty({
+      file: command.file,
+      args: command.args,
+      ptyOptions: command.ptyOptions,
+      frontendReadyTimeoutMs: command.frontendReadyTimeoutMs,
+      onFallback: (reason) => postEvent({ type: "fallback", reason }),
+      onDiagnostic: (message) => postEvent({ type: "diagnostic", message }),
+    });
+    terminal = created;
+    created.onData((data) => postEvent({ type: "data", data }));
+    created.onExit((event) => {
+      postEvent({
+        type: "exit",
+        exitCode: event.exitCode,
+        signal: event.signal,
+      });
+      terminal = null;
+    });
+    postEvent({
+      type: "ready",
+      pid: created.pid,
+      cols: created.cols,
+      rows: created.rows,
+      process: created.process,
+      handleFlowControl: created.handleFlowControl,
+      backend: created.backend,
+      fallbackReason: created.fallbackReason,
+    });
+  } catch (error) {
+    postEvent({ type: "init-error", error: describeError(error) });
+  }
+}
+
+/** 把主进程命令转发给当前工具进程持有的 WSL ConPTY。 */
+function handleCommand(command: WslConptyHostCommand): void {
+  if (command.type === "init") {
+    initializeTerminal(command);
+    return;
+  }
+  const current = terminal;
+  if (!current)
+    return;
+  switch (command.type) {
+    case "write":
+      current.write(command.data);
+      break;
+    case "write-when-ready":
+      current.writeWhenFrontendReady(command.data);
+      break;
+    case "frontend-ready":
+      current.markFrontendReady(command.colors);
+      break;
+    case "resize":
+      current.resize(command.columns, command.rows);
+      break;
+    case "clear":
+      current.clear();
+      break;
+    case "kill":
+      current.kill(command.signal);
+      break;
+    case "pause":
+      current.pause();
+      break;
+    case "resume":
+      current.resume();
+      break;
+    case "flow-control":
+      current.handleFlowControl = command.enabled;
+      break;
+  }
+}
+
+parentPort.on("message", (event) => {
+  try {
+    handleCommand(event.data as WslConptyHostCommand);
+  } catch (error) {
+    postEvent({
+      type: "diagnostic",
+      message: `command-error ${describeError(error)}`,
+    });
+  }
+});

--- a/electron/wslConptyProtocol.ts
+++ b/electron/wslConptyProtocol.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import type { IWindowsPtyForkOptions } from "node-pty";
+import type {
+  TerminalPaletteColors,
+  WslConptyBackend,
+} from "./wslConpty.js";
+
+export type WslConptyHostCommand =
+  | {
+      type: "init";
+      file: string;
+      args: string[];
+      ptyOptions: IWindowsPtyForkOptions;
+      frontendReadyTimeoutMs?: number;
+    }
+  | { type: "write"; data: string }
+  | { type: "write-when-ready"; data: string }
+  | { type: "frontend-ready"; colors?: Partial<TerminalPaletteColors> }
+  | { type: "resize"; columns: number; rows: number }
+  | { type: "clear" }
+  | { type: "kill"; signal?: string }
+  | { type: "pause" }
+  | { type: "resume" }
+  | { type: "flow-control"; enabled: boolean };
+
+export type WslConptyHostEvent =
+  | {
+      type: "ready";
+      pid: number;
+      cols: number;
+      rows: number;
+      process: string;
+      handleFlowControl: boolean;
+      backend: WslConptyBackend;
+      fallbackReason?: string;
+    }
+  | { type: "data"; data: string }
+  | { type: "exit"; exitCode: number; signal?: number }
+  | { type: "fallback"; reason: string }
+  | { type: "diagnostic"; message: string }
+  | { type: "init-error"; error: string };

--- a/electron/wslConptyProxy.test.ts
+++ b/electron/wslConptyProxy.test.ts
@@ -1,0 +1,175 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import type { WslConptyHostCommand } from "./wslConptyProtocol";
+import {
+  spawnIsolatedWslConpty,
+  type ForkWslConptyHost,
+  type WslConptyHostProcess,
+} from "./wslConptyProxy";
+
+type FakeHost = EventEmitter & WslConptyHostProcess & {
+  posted: WslConptyHostCommand[];
+};
+
+/** 创建可观察命令并主动模拟宿主事件的工具进程桩。 */
+function createFakeHost(): FakeHost {
+  const host = new EventEmitter() as FakeHost;
+  host.posted = [];
+  host.postMessage = vi.fn((command: WslConptyHostCommand) => {
+    host.posted.push(command);
+    if (command.type !== "init")
+      return;
+    queueMicrotask(() => {
+      host.emit("message", {
+        type: "ready",
+        pid: 42,
+        cols: 120,
+        rows: 30,
+        process: "wsl.exe",
+        handleFlowControl: false,
+        backend: "bundled",
+      });
+    });
+  });
+  host.kill = vi.fn(() => true);
+  return host;
+}
+
+/** 创建统一的隔离 WSL PTY 启动参数。 */
+function createOptions(onDiagnostic = vi.fn(), onFallback = vi.fn()) {
+  return {
+    file: "wsl.exe",
+    args: ["-d", "Ubuntu"],
+    ptyOptions: {
+      name: "xterm-256color",
+      cols: 120,
+      rows: 30,
+      env: { TERM: "xterm-256color" },
+    },
+    onDiagnostic,
+    onFallback,
+  };
+}
+
+/** 创建会在下一微任务报告 spawn 的宿主工厂。 */
+function createFork(host: FakeHost): ForkWslConptyHost {
+  return vi.fn(() => {
+    queueMicrotask(() => host.emit("spawn"));
+    return host;
+  });
+}
+
+describe("IsolatedWslConptyPty", () => {
+  it("应等待独立宿主就绪并保留 WSL ConPTY 元数据", async () => {
+    const host = createFakeHost();
+    const fork = createFork(host);
+    const terminal = await spawnIsolatedWslConpty(createOptions(), fork);
+
+    expect(fork).toHaveBeenCalledTimes(1);
+    expect(host.posted[0]).toEqual(expect.objectContaining({
+      type: "init",
+      file: "wsl.exe",
+      args: ["-d", "Ubuntu"],
+    }));
+    expect(terminal.pid).toBe(42);
+    expect(terminal.cols).toBe(120);
+    expect(terminal.rows).toBe(30);
+    expect(terminal.process).toBe("wsl.exe");
+    expect(terminal.backend).toBe("bundled");
+  });
+
+  it("应在主进程代理与独立宿主之间完整转发 PTY 协议", async () => {
+    const host = createFakeHost();
+    const onDiagnostic = vi.fn();
+    const onFallback = vi.fn();
+    const terminal = await spawnIsolatedWslConpty(
+      createOptions(onDiagnostic, onFallback),
+      createFork(host),
+    );
+    const onData = vi.fn();
+    const onExit = vi.fn();
+    terminal.onData(onData);
+    terminal.onExit(onExit);
+
+    terminal.markFrontendReady({ foreground: "#CCCCCC", background: "#0C0C0C" });
+    terminal.writeWhenFrontendReady("bash -lc codex\r");
+    terminal.write("input");
+    terminal.pause();
+    terminal.resize(100, 24);
+    terminal.resume();
+    terminal.clear();
+
+    expect(host.posted).toEqual(expect.arrayContaining([
+      {
+        type: "frontend-ready",
+        colors: { foreground: "#CCCCCC", background: "#0C0C0C" },
+      },
+      { type: "write-when-ready", data: "bash -lc codex\r" },
+      { type: "write", data: "input" },
+      { type: "pause" },
+      { type: "resize", columns: 100, rows: 24 },
+      { type: "resume" },
+      { type: "clear" },
+    ]));
+
+    host.emit("message", { type: "data", data: "output" });
+    host.emit("message", { type: "diagnostic", message: "osc-query slot=11" });
+    host.emit("message", { type: "fallback", reason: "bundled unavailable" });
+    host.emit("message", { type: "exit", exitCode: 0 });
+
+    expect(onData).toHaveBeenCalledWith("output");
+    expect(onDiagnostic).toHaveBeenCalledWith("osc-query slot=11");
+    expect(onFallback).toHaveBeenCalledWith("bundled unavailable");
+    expect(onExit).toHaveBeenCalledWith({ exitCode: 0, signal: undefined });
+  });
+
+  it("宿主初始化失败时应拒绝创建而不是留下半连接会话", async () => {
+    const host = createFakeHost();
+    host.postMessage = vi.fn((command: WslConptyHostCommand) => {
+      host.posted.push(command);
+      if (command.type === "init") {
+        queueMicrotask(() => {
+          host.emit("message", { type: "init-error", error: "ConPTY unavailable" });
+        });
+      }
+    });
+
+    await expect(
+      spawnIsolatedWslConpty(createOptions(), createFork(host)),
+    ).rejects.toThrow("ConPTY unavailable");
+    expect(host.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("PTY 未返回退出事件时应超时强制回收工具进程", async () => {
+    vi.useFakeTimers();
+    try {
+      const host = createFakeHost();
+      const terminalPromise = spawnIsolatedWslConpty(createOptions(), createFork(host));
+      vi.runAllTicks();
+      const terminal = await terminalPromise;
+
+      terminal.kill();
+
+      expect(host.posted).toContainEqual({ type: "kill", signal: undefined });
+      expect(host.kill).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(host.kill).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("收到 PTY 退出事件后应立即回收宿主且不重复上报退出", async () => {
+    const host = createFakeHost();
+    const terminal = await spawnIsolatedWslConpty(createOptions(), createFork(host));
+    const onExit = vi.fn();
+    terminal.onExit(onExit);
+
+    host.emit("message", { type: "exit", exitCode: 0 });
+    host.emit("exit", 4294967295);
+
+    expect(host.kill).toHaveBeenCalledTimes(1);
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(onExit).toHaveBeenCalledWith({ exitCode: 0, signal: undefined });
+  });
+});

--- a/electron/wslConptyProxy.ts
+++ b/electron/wslConptyProxy.ts
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import path from "node:path";
+import { utilityProcess } from "electron";
+import type { IEvent, IPty } from "node-pty";
+import type {
+  TerminalPaletteColors,
+  WslConptyBackend,
+  WslConptyOptions,
+} from "./wslConpty.js";
+import type {
+  WslConptyHostCommand,
+  WslConptyHostEvent,
+} from "./wslConptyProtocol.js";
+
+const WSL_HOST_START_TIMEOUT_MS = 10_000;
+const WSL_HOST_KILL_TIMEOUT_MS = 1_000;
+
+export type WslConptyHostProcess = {
+  on(event: "message", listener: (message: unknown) => void): unknown;
+  once(event: "spawn", listener: () => void): unknown;
+  once(event: "exit", listener: (code: number) => void): unknown;
+  postMessage(message: WslConptyHostCommand): void;
+  kill(): boolean;
+};
+
+export type ForkWslConptyHost = (modulePath: string) => WslConptyHostProcess;
+
+/** 创建 Electron utility process 作为单个 WSL PTY 的隔离宿主。 */
+function forkDefaultHost(modulePath: string): WslConptyHostProcess {
+  return utilityProcess.fork(modulePath, [], {
+    serviceName: "CodexFlow WSL PTY",
+    stdio: "ignore",
+  }) as unknown as WslConptyHostProcess;
+}
+
+/** 返回编译后的 WSL PTY 工具进程入口。 */
+function resolveHostModulePath(): string {
+  return path.join(__dirname, "wslConptyHost.js");
+}
+
+/** 把未知宿主错误转换为可读文本。 */
+function describeHostError(error: unknown): string {
+  if (error instanceof Error && error.message)
+    return error.message;
+  return String(error || "unknown WSL PTY host error");
+}
+
+/**
+ * 在主进程中代理独立 WSL PTY 宿主，终端协议解析与回复始终留在工具进程内。
+ */
+export class IsolatedWslConptyPty implements IPty {
+  private readonly host: WslConptyHostProcess;
+  private readonly onFallback?: (reason: string) => void;
+  private readonly onDiagnostic?: (message: string) => void;
+  private readonly dataListeners = new Set<(data: string) => unknown>();
+  private readonly exitListeners = new Set<(event: { exitCode: number; signal?: number }) => unknown>();
+  private earlyData: string[] = [];
+  private pendingExit: { exitCode: number; signal?: number } | null = null;
+  private initResolve: (() => void) | null = null;
+  private initReject: ((error: Error) => void) | null = null;
+  private initialized = false;
+  private exited = false;
+  private hostTerminated = false;
+  private hostKillTimer: NodeJS.Timeout | null = null;
+  private currentPid = 0;
+  private currentCols: number;
+  private currentRows: number;
+  private currentProcess = "wsl.exe";
+  private flowControl = false;
+
+  public backend: WslConptyBackend = "bundled";
+  public fallbackReason?: string;
+
+  /** 创建一个尚未完成宿主握手的 WSL PTY 代理。 */
+  constructor(
+    host: WslConptyHostProcess,
+    options: Pick<WslConptyOptions, "ptyOptions" | "onFallback" | "onDiagnostic">,
+  ) {
+    this.host = host;
+    this.onFallback = options.onFallback;
+    this.onDiagnostic = options.onDiagnostic;
+    this.currentCols = options.ptyOptions.cols ?? 80;
+    this.currentRows = options.ptyOptions.rows ?? 24;
+    this.host.on("message", (message) => this.handleHostEvent(message));
+    this.host.once("exit", (code) => this.handleHostExit(code));
+  }
+
+  /** 启动工具进程内的 WSL ConPTY，并等待其返回元数据。 */
+  public initialize(options: WslConptyOptions): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.initResolve = resolve;
+      this.initReject = reject;
+      const timer = setTimeout(() => {
+        this.rejectInitialization(new Error("WSL PTY host startup timed out"));
+        this.terminateHost();
+      }, WSL_HOST_START_TIMEOUT_MS);
+      try { timer.unref(); } catch {}
+      const finishResolve = this.initResolve;
+      const finishReject = this.initReject;
+      this.initResolve = () => {
+        clearTimeout(timer);
+        finishResolve?.();
+      };
+      this.initReject = (error) => {
+        clearTimeout(timer);
+        finishReject?.(error);
+      };
+      this.host.once("spawn", () => {
+        this.postCommand({
+          type: "init",
+          file: options.file,
+          args: options.args,
+          ptyOptions: options.ptyOptions,
+          frontendReadyTimeoutMs: options.frontendReadyTimeoutMs,
+        });
+      });
+    });
+  }
+
+  /** 返回工具进程持有的 WSL PTY 进程编号。 */
+  public get pid(): number {
+    return this.currentPid;
+  }
+
+  /** 返回当前终端列数。 */
+  public get cols(): number {
+    return this.currentCols;
+  }
+
+  /** 返回当前终端行数。 */
+  public get rows(): number {
+    return this.currentRows;
+  }
+
+  /** 返回底层活动进程名称。 */
+  public get process(): string {
+    return this.currentProcess;
+  }
+
+  /** 返回当前流控制开关。 */
+  public get handleFlowControl(): boolean {
+    return this.flowControl;
+  }
+
+  /** 同步设置工具进程内 PTY 的流控制开关。 */
+  public set handleFlowControl(value: boolean) {
+    this.flowControl = value;
+    this.postCommand({ type: "flow-control", enabled: value });
+  }
+
+  /** 注册工具进程转发的终端输出监听器。 */
+  public readonly onData: IEvent<string> = (listener) => {
+    this.dataListeners.add(listener);
+    if (this.earlyData.length > 0) {
+      const buffered = this.earlyData.join("");
+      this.earlyData = [];
+      listener(buffered);
+    }
+    return { dispose: () => this.dataListeners.delete(listener) };
+  };
+
+  /** 注册 WSL PTY 退出监听器。 */
+  public readonly onExit: IEvent<{ exitCode: number; signal?: number }> = (listener) => {
+    this.exitListeners.add(listener);
+    if (this.pendingExit)
+      listener(this.pendingExit);
+    return { dispose: () => this.exitListeners.delete(listener) };
+  };
+
+  /** 向工具进程内的 WSL PTY 写入用户输入或终端回复。 */
+  public write(data: string | Buffer): void {
+    this.postCommand({
+      type: "write",
+      data: Buffer.isBuffer(data) ? data.toString("utf8") : data,
+    });
+  }
+
+  /** 等待前端完成绑定后，在工具进程内写入自动启动命令。 */
+  public writeWhenFrontendReady(data: string): void {
+    this.postCommand({ type: "write-when-ready", data });
+  }
+
+  /** 通知工具进程前端已绑定，并同步当前终端主题色。 */
+  public markFrontendReady(colors?: Partial<TerminalPaletteColors>): void {
+    this.postCommand({ type: "frontend-ready", colors });
+  }
+
+  /** 调整工具进程内 WSL PTY 的字符尺寸。 */
+  public resize(columns: number, rows: number): void {
+    this.currentCols = columns;
+    this.currentRows = rows;
+    this.postCommand({ type: "resize", columns, rows });
+  }
+
+  /** 清理工具进程内 ConPTY 的内部屏幕缓存。 */
+  public clear(): void {
+    this.postCommand({ type: "clear" });
+  }
+
+  /** 关闭工具进程内的 WSL PTY。 */
+  public kill(signal?: string): void {
+    this.postCommand({ type: "kill", signal });
+    this.scheduleHostTermination();
+  }
+
+  /** 暂停工具进程向主进程转发普通画面。 */
+  public pause(): void {
+    this.postCommand({ type: "pause" });
+  }
+
+  /** 恢复工具进程向主进程转发普通画面。 */
+  public resume(): void {
+    this.postCommand({ type: "resume" });
+  }
+
+  /** 处理工具进程发回的 PTY 事件。 */
+  private handleHostEvent(raw: unknown): void {
+    const event = raw as WslConptyHostEvent | null;
+    if (!event || typeof event !== "object" || typeof event.type !== "string")
+      return;
+    switch (event.type) {
+      case "ready":
+        this.currentPid = event.pid;
+        this.currentCols = event.cols;
+        this.currentRows = event.rows;
+        this.currentProcess = event.process;
+        this.flowControl = event.handleFlowControl;
+        this.backend = event.backend;
+        this.fallbackReason = event.fallbackReason;
+        this.initialized = true;
+        this.resolveInitialization();
+        break;
+      case "data":
+        this.emitData(event.data);
+        break;
+      case "exit":
+        this.emitExit({ exitCode: event.exitCode, signal: event.signal });
+        this.terminateHost();
+        break;
+      case "fallback":
+        try { this.onFallback?.(event.reason); } catch {}
+        break;
+      case "diagnostic":
+        try { this.onDiagnostic?.(event.message); } catch {}
+        break;
+      case "init-error":
+        this.rejectInitialization(new Error(event.error));
+        this.terminateHost();
+        break;
+    }
+  }
+
+  /** 处理工具进程意外退出，并保证上层能收到会话终止。 */
+  private handleHostExit(code: number): void {
+    this.markHostTerminated();
+    if (!this.initialized) {
+      this.rejectInitialization(new Error(`WSL PTY host exited with code ${code}`));
+      return;
+    }
+    if (!this.exited)
+      this.emitExit({ exitCode: code });
+  }
+
+  /** 分发工具进程输出；上层尚未订阅时暂存启动期输出。 */
+  private emitData(data: string): void {
+    if (!data)
+      return;
+    if (this.dataListeners.size === 0) {
+      this.earlyData.push(data);
+      return;
+    }
+    for (const listener of this.dataListeners)
+      listener(data);
+  }
+
+  /** 向所有退出监听器分发一次终端退出事件。 */
+  private emitExit(event: { exitCode: number; signal?: number }): void {
+    if (this.exited)
+      return;
+    this.exited = true;
+    this.pendingExit = event;
+    for (const listener of this.exitListeners)
+      listener(event);
+  }
+
+  /** 完成工具进程初始化等待。 */
+  private resolveInitialization(): void {
+    const resolve = this.initResolve;
+    this.initResolve = null;
+    this.initReject = null;
+    resolve?.();
+  }
+
+  /** 以给定错误结束工具进程初始化等待。 */
+  private rejectInitialization(error: Error): void {
+    const reject = this.initReject;
+    this.initResolve = null;
+    this.initReject = null;
+    reject?.(error);
+  }
+
+  /** PTY 未主动退出时，安排一次工具进程兜底回收。 */
+  private scheduleHostTermination(): void {
+    if (this.hostTerminated || this.hostKillTimer)
+      return;
+    this.hostKillTimer = setTimeout(() => {
+      this.hostKillTimer = null;
+      this.terminateHost();
+    }, WSL_HOST_KILL_TIMEOUT_MS);
+    try { this.hostKillTimer.unref(); } catch {}
+  }
+
+  /** 幂等结束工具进程，并清理兜底计时器。 */
+  private terminateHost(): void {
+    if (this.hostKillTimer) {
+      clearTimeout(this.hostKillTimer);
+      this.hostKillTimer = null;
+    }
+    if (this.hostTerminated)
+      return;
+    this.hostTerminated = true;
+    try {
+      this.host.kill();
+    } catch (error) {
+      try { this.onDiagnostic?.(`host-kill-error ${describeHostError(error)}`); } catch {}
+    }
+  }
+
+  /** 记录工具进程已经自行退出，并清理无须再执行的回收计时器。 */
+  private markHostTerminated(): void {
+    this.hostTerminated = true;
+    if (!this.hostKillTimer)
+      return;
+    clearTimeout(this.hostKillTimer);
+    this.hostKillTimer = null;
+  }
+
+  /** 安全地向 WSL PTY 工具进程发送命令。 */
+  private postCommand(command: WslConptyHostCommand): void {
+    if (this.exited)
+      return;
+    try {
+      this.host.postMessage(command);
+    } catch (error) {
+      try { this.onDiagnostic?.(`host-post-error ${describeHostError(error)}`); } catch {}
+    }
+  }
+}
+
+/** 创建并等待一个由独立工具进程持有的 WSL ConPTY。 */
+export async function spawnIsolatedWslConpty(
+  options: WslConptyOptions,
+  forkHost: ForkWslConptyHost = forkDefaultHost,
+): Promise<IsolatedWslConptyPty> {
+  const host = forkHost(resolveHostModulePath());
+  const terminal = new IsolatedWslConptyPty(host, options);
+  await terminal.initialize(options);
+  return terminal;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@lydell/node-pty": "^1.1.0",
         "better-sqlite3": "^11.10.0",
         "chokidar": "^3.6.0",
         "iconv-lite": "^0.6.3",
+        "node-pty": "1.1.0",
         "opentype.js": "^1.3.4",
         "undici": "^6.18.2"
       },
@@ -1369,91 +1369,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@lydell/node-pty": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.1.0.tgz",
-      "integrity": "sha512-VDD8LtlMTOrPKWMXUAcB9+LTktzuunqrMwkYR1DMRBkS6LQrCt+0/Ws1o2rMml/n3guePpS7cxhHF7Nm5K4iMw==",
-      "optionalDependencies": {
-        "@lydell/node-pty-darwin-arm64": "1.1.0",
-        "@lydell/node-pty-darwin-x64": "1.1.0",
-        "@lydell/node-pty-linux-arm64": "1.1.0",
-        "@lydell/node-pty-linux-x64": "1.1.0",
-        "@lydell/node-pty-win32-arm64": "1.1.0",
-        "@lydell/node-pty-win32-x64": "1.1.0"
-      }
-    },
-    "node_modules/@lydell/node-pty-darwin-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.1.0.tgz",
-      "integrity": "sha512-7kFD+owAA61qmhJCtoMbqj3Uvff3YHDiU+4on5F2vQdcMI3MuwGi7dM6MkFG/yuzpw8LF2xULpL71tOPUfxs0w==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@lydell/node-pty-darwin-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.1.0.tgz",
-      "integrity": "sha512-XZdvqj5FjAMjH8bdp0YfaZjur5DrCIDD1VYiE9EkkYVMDQqRUPHYV3U8BVEQVT9hYfjmpr7dNaELF2KyISWSNA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@lydell/node-pty-linux-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.1.0.tgz",
-      "integrity": "sha512-yyDBmalCfHpLiQMT2zyLcqL2Fay4Xy7rIs8GH4dqKLnEviMvPGOK7LADVkKAsbsyXBSISL3Lt1m1MtxhPH6ckg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@lydell/node-pty-linux-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.1.0.tgz",
-      "integrity": "sha512-NcNqRTD14QT+vXcEuqSSvmWY+0+WUBn2uRE8EN0zKtDpIEr9d+YiFj16Uqds6QfcLCHfZmC+Ls7YzwTaqDnanA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@lydell/node-pty-win32-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.1.0.tgz",
-      "integrity": "sha512-JOMbCou+0fA7d/m97faIIfIU0jOv8sn2OR7tI45u3AmldKoKoLP8zHY6SAvDDnI3fccO1R2HeR1doVjpS7HM0w==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@lydell/node-pty-win32-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.1.0.tgz",
-      "integrity": "sha512-3N56BZ+WDFnUMYRtsrr7Ky2mhWGl9xXcyqR6cexfuCqcz9RNWL+KoXRv/nZylY5dYaXkft4JaR1uVu+roiZDAw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "1.1.1",
@@ -7112,6 +7027,22 @@
       "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/node-pty/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.19",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "typecheck:web": "tsc -p web/tsconfig.typecheck.json"
   },
   "dependencies": {
-    "@lydell/node-pty": "^1.1.0",
+    "node-pty": "1.1.0",
     "better-sqlite3": "^11.10.0",
     "chokidar": "^3.6.0",
     "iconv-lite": "^0.6.3",
@@ -98,14 +98,23 @@
       "web/dist/**",
       "package.json",
       "LICENSE",
-      "NOTICE"
+      "NOTICE",
+      "!node_modules/node-pty/deps/**",
+      "!node_modules/node-pty/lib/**/*.map",
+      "!node_modules/node-pty/lib/**/*.test.js",
+      "!node_modules/node-pty/node_modules/node-addon-api/**",
+      "!node_modules/node-pty/scripts/**",
+      "!node_modules/node-pty/src/**",
+      "!node_modules/node-pty/third_party/**",
+      "!node_modules/node-pty/**/*.pdb"
     ],
     "compression": "maximum",
     "directories": {
       "buildResources": "build"
     },
     "asarUnpack": [
-      "node_modules/@lydell/node-pty/build/Release/**",
+      "node_modules/node-pty/build/Release/**",
+      "node_modules/node-pty/prebuilds/**",
       "node_modules/better-sqlite3/build/Release/**"
     ],
     "extraResources": [
@@ -125,6 +134,23 @@
       }
     ],
     "win": {
+      "files": [
+        "dist/electron/**",
+        "web/dist/**",
+        "package.json",
+        "LICENSE",
+        "NOTICE",
+        "!node_modules/node-pty/deps/**",
+        "!node_modules/node-pty/lib/**/*.map",
+        "!node_modules/node-pty/lib/**/*.test.js",
+        "!node_modules/node-pty/node_modules/node-addon-api/**",
+        "!node_modules/node-pty/scripts/**",
+        "!node_modules/node-pty/src/**",
+        "!node_modules/node-pty/third_party/**",
+        "!node_modules/node-pty/**/*.pdb",
+        "!node_modules/node-pty/prebuilds/darwin-*/**",
+        "!node_modules/node-pty/prebuilds/win32-arm64/**"
+      ],
       "icon": "build/icon.ico",
       "publisherName": [
         "Lulu"

--- a/tmp-pty-test.js
+++ b/tmp-pty-test.js
@@ -1,4 +1,4 @@
-﻿const pty = require('@lydell/node-pty');
+const pty = require('node-pty');
 const shell = process.env.SHELL_FOR_TEST || 'powershell.exe';
 const proc = pty.spawn(shell, ['-NoLogo'], { name: 'xterm-256color', cols: 120, rows: 30 });
 proc.onData((data) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -112,6 +112,10 @@ import {
   listManagedWorktreeChildIds as listManagedWorktreeChildIdsFromStore,
   resolveWorktreeManagementParentProjectId as resolveWorktreeManagementParentProjectIdFromStore,
 } from "@/lib/worktree-management";
+import {
+  areProviderEnvironmentsEqual,
+  isCurrentProviderEnvironmentRequest,
+} from "@/lib/providers/environment";
 import { normalizeProvidersSettings } from "@/lib/providers/normalize";
 import { isBuiltInSessionProviderId, openaiIconUrl, openaiDarkIconUrl, claudeIconUrl, geminiIconUrl, antigravityIconUrl } from "@/lib/providers/builtins";
 import { BUILT_IN_AGENT_PROVIDER_IDS, isBuiltInAgentProviderId } from "@/lib/providers/ids";
@@ -1740,6 +1744,7 @@ export default function CodexFlowManagerUI() {
   const [terminalMode, setTerminalMode] = useState<TerminalMode>('wsl');
   const [terminalFontFamily, setTerminalFontFamily] = useState<string>(DEFAULT_TERMINAL_FONT_FAMILY);
   const [terminalTheme, setTerminalTheme] = useState<TerminalThemeId>(DEFAULT_TERMINAL_THEME_ID);
+  const [terminalCapabilities, setTerminalCapabilities] = useState({ normalizeTerm: true, trueColor: false });
   const terminalThemeDef = useMemo(() => getTerminalTheme(terminalTheme), [terminalTheme]);
   const [codexTraceEnabled, setCodexTraceEnabled] = useState(false);
   const initialPtyByTab = useMemo<Record<string, string>>(() => restoredConsoleSession?.ptyByTab || {}, [restoredConsoleSession]);
@@ -6520,17 +6525,43 @@ export default function CodexFlowManagerUI() {
    * @param requestedEnv 用户请求切换到的环境
    */
   const selectActiveProviderEnv = useCallback(async (requestedEnv: Required<ProviderEnv>): Promise<Required<ProviderEnv>> => {
+    const providerId = activeProviderIdRef.current;
     const normalized: Required<ProviderEnv> = {
       terminal: normalizeTerminalMode(requestedEnv.terminal),
       distro: String(requestedEnv.distro || wslDistro || "").trim(),
     };
-    const env = await resolveVisibleProviderEnv(activeProviderId, normalized, { persist: true });
-    const changed = env.terminal !== normalized.terminal
-      || String(env.distro || "").toLowerCase() !== String(normalized.distro || "").toLowerCase();
+    const sequence = providerSwitchSeqRef.current + 1;
+    providerSwitchSeqRef.current = sequence;
+
+    // 先同步内存状态，确保紧接着的新建终端不会读到切换前的环境。
+    const optimisticMap = { ...providerEnvByIdRef.current, [providerId]: normalized };
+    providerEnvByIdRef.current = optimisticMap;
+    setProviderEnvById(optimisticMap);
+    setTerminalMode(normalized.terminal);
+    setWslDistro(normalized.distro);
+
+    // 后台校验不直接写状态；只有最后一次用户选择可以提交校验结果。
+    const env = await resolveVisibleProviderEnv(providerId, normalized, { persist: false, updateState: false });
+    if (!isCurrentProviderEnvironmentRequest(
+      { providerId, sequence },
+      activeProviderIdRef.current,
+      providerSwitchSeqRef.current,
+    ))
+      return env;
+
+    const changed = !areProviderEnvironmentsEqual(env, normalized);
+    if (changed) {
+      const resolvedMap = { ...providerEnvByIdRef.current, [providerId]: env };
+      providerEnvByIdRef.current = resolvedMap;
+      setProviderEnvById(resolvedMap);
+      setTerminalMode(env.terminal);
+      setWslDistro(env.distro);
+    }
+    queueProviderSettingsPersist();
     if (changed)
-      await notifyRuntimeEnvFallback({ providerId: activeProviderId, from: normalized, to: env, source: "envMenu" });
+      await notifyRuntimeEnvFallback({ providerId, from: normalized, to: env, source: "envMenu" });
     return env;
-  }, [activeProviderId, notifyRuntimeEnvFallback, resolveVisibleProviderEnv, wslDistro]);
+  }, [notifyRuntimeEnvFallback, queueProviderSettingsPersist, resolveVisibleProviderEnv, wslDistro]);
 
   // WSL 发行版列表：供环境下拉与设置面板复用（缓存到内存，避免重复请求）
   const [availableDistros, setAvailableDistros] = useState<string[]>([]);
@@ -6939,6 +6970,10 @@ export default function CodexFlowManagerUI() {
           setCodexErrorHandlingPrefs(normalizeCodexErrorHandlingPrefs((s as any).codexErrorHandling));
           setTerminalFontFamily(normalizeTerminalFontFamily((s as any).terminalFontFamily));
           setTerminalTheme(normalizeTerminalTheme((s as any).terminalTheme));
+          setTerminalCapabilities({
+            normalizeTerm: (s as any)?.terminalCapabilities?.normalizeTerm !== false,
+            trueColor: (s as any)?.terminalCapabilities?.trueColor === true,
+          });
           setClaudeCodeReadAgentHistory(!!(s as any)?.claudeCode?.readAgentHistory);
           setMultiInstanceEnabled(!!(s as any)?.experimental?.multiInstanceEnabled);
           // git worktree：默认开启自动提交与规则文件复制
@@ -11426,10 +11461,7 @@ export default function CodexFlowManagerUI() {
                     className="flex items-center justify-between gap-2"
                     onClick={async () => {
                       const nextEnv: Required<ProviderEnv> = { ...getProviderEnv(activeProviderId), distro: name };
-                      const nextMap = { ...providerEnvById, [activeProviderId]: nextEnv };
-                      setProviderEnvById(nextMap);
-                      setWslDistro(name);
-                      await persistProviders({ activeId: activeProviderId, items: providerItems, env: nextMap });
+                      await selectActiveProviderEnv(nextEnv);
                     }}
                   >
                     <span className="truncate">{name}</span>
@@ -16183,6 +16215,7 @@ export default function CodexFlowManagerUI() {
           defaultIde: defaultIdePrefs,
           terminalFontFamily,
           terminalTheme,
+          terminalCapabilities,
           claudeCodeReadAgentHistory,
           gitWorktree: {
             gitPath: gitWorktreeGitPath,
@@ -16203,6 +16236,10 @@ export default function CodexFlowManagerUI() {
           const nextCodexErrorHandling = normalizeCodexErrorHandlingPrefs((v as any).codexErrorHandling);
           const nextFontFamily = normalizeTerminalFontFamily(v.terminalFontFamily);
           const nextTerminalTheme = normalizeTerminalTheme(v.terminalTheme);
+          const nextTerminalCapabilities = {
+            normalizeTerm: v.terminalCapabilities?.normalizeTerm !== false,
+            trueColor: v.terminalCapabilities?.trueColor === true,
+          };
           const nextTheme = normalizeThemeSetting(v.theme);
           const nextClaudeAgentHistory = !!v.claudeCodeReadAgentHistory;
           const nextDefaultIde = normalizeIdeOpenPrefs((v as any).defaultIde);
@@ -16253,6 +16290,7 @@ export default function CodexFlowManagerUI() {
               },
               terminalFontFamily: nextFontFamily,
               terminalTheme: nextTerminalTheme,
+              terminalCapabilities: nextTerminalCapabilities,
               claudeCode: { readAgentHistory: nextClaudeAgentHistory },
             });
           } catch (e) { console.warn('settings.update failed', e); }
@@ -16287,6 +16325,7 @@ export default function CodexFlowManagerUI() {
           setMultiInstanceEnabled(nextMultiInstanceEnabled);
           setTerminalFontFamily(nextFontFamily);
           setTerminalTheme(nextTerminalTheme);
+          setTerminalCapabilities(nextTerminalCapabilities);
           setClaudeCodeReadAgentHistory(nextClaudeAgentHistory);
           setGitWorktreeAutoCommitEnabled(nextGitWorktreeAutoCommitEnabled);
           setGitWorktreeCopyRulesOnCreate(nextGitWorktreeCopyRulesOnCreate);

--- a/web/src/features/settings/settings-dialog.tsx
+++ b/web/src/features/settings/settings-dialog.tsx
@@ -90,6 +90,10 @@ type NotificationPrefs = {
   sound: boolean;
   subagent: boolean;
 };
+type TerminalCapabilitiesPrefs = {
+  normalizeTerm: boolean;
+  trueColor: boolean;
+};
 type ExternalGitToolId = "rider" | "sourcetree" | "fork" | "gitkraken" | "custom";
 type GitWorktreePrefs = {
   gitPath: string;
@@ -179,6 +183,7 @@ export type SettingsDialogProps = {
     defaultIde: IdeOpenPrefs;
     terminalFontFamily: string;
     terminalTheme: TerminalThemeId;
+    terminalCapabilities: TerminalCapabilitiesPrefs;
     claudeCodeReadAgentHistory: boolean;
     multiInstanceEnabled: boolean;
     gitWorktree: GitWorktreePrefs;
@@ -201,6 +206,7 @@ export type SettingsDialogProps = {
     defaultIde: IdeOpenPrefs;
     terminalFontFamily: string;
     terminalTheme: TerminalThemeId;
+    terminalCapabilities: TerminalCapabilitiesPrefs;
     claudeCodeReadAgentHistory: boolean;
     multiInstanceEnabled: boolean;
     gitWorktree: GitWorktreePrefs;
@@ -648,6 +654,10 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
   const [theme, setTheme] = useState<ThemeSetting>(normalizeThemeSetting(values.theme));
   const [multiInstanceEnabled, setMultiInstanceEnabled] = useState<boolean>(!!values.multiInstanceEnabled);
   const [terminalTheme, setTerminalTheme] = useState<TerminalThemeId>(values.terminalTheme);
+  const [terminalCapabilities, setTerminalCapabilities] = useState<TerminalCapabilitiesPrefs>({
+    normalizeTerm: values.terminalCapabilities?.normalizeTerm !== false,
+    trueColor: values.terminalCapabilities?.trueColor === true,
+  });
   const [systemTheme, setSystemTheme] = useState<ThemeMode>(() => resolveSystemTheme());
   const [availableDistros, setAvailableDistros] = useState<string[]>([]);
   const [terminalFontFamily, setTerminalFontFamily] = useState<string>(normalizeTerminalFontFamily(values.terminalFontFamily));
@@ -781,6 +791,10 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
     setGitWorktreeCopyRulesOnCreate(values.gitWorktree?.copyRulesOnCreate !== false);
     setTerminalFontFamily(normalizeTerminalFontFamily(values.terminalFontFamily));
     setTerminalTheme(normalizeTerminalTheme(values.terminalTheme));
+    setTerminalCapabilities({
+      normalizeTerm: values.terminalCapabilities?.normalizeTerm !== false,
+      trueColor: values.terminalCapabilities?.trueColor === true,
+    });
   }, [open]);
 
   /**
@@ -2612,6 +2626,57 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                 </CardContent>
               </Card>
 
+              <Card>
+                <details className="group">
+                  <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-6 py-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--cf-accent)] [&::-webkit-details-marker]:hidden">
+                    <div className="min-w-0">
+                      <CardTitle>{t("settings:terminalCapabilities.label")}</CardTitle>
+                      <p className="mt-1 text-sm font-normal text-slate-500 dark:text-[var(--cf-text-secondary)]">
+                        {t("settings:terminalCapabilities.help")}
+                      </p>
+                    </div>
+                    <ChevronDown className="h-4 w-4 shrink-0 text-slate-500 transition-transform duration-200 group-open:rotate-180 motion-reduce:transition-none" />
+                  </summary>
+                  <CardContent className="space-y-3 border-t border-slate-200/70 pt-4 dark:border-[var(--cf-border)]">
+                    <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200/70 bg-white/60 px-3 py-3 shadow-sm transition-colors hover:bg-slate-50 dark:border-[var(--cf-border)] dark:bg-[var(--cf-surface-muted)] dark:text-[var(--cf-text-primary)] dark:hover:bg-[var(--cf-surface-hover)] motion-reduce:transition-none">
+                      <input
+                        type="checkbox"
+                        className="mt-1 h-4 w-4 rounded border-slate-300 text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-[var(--cf-border)] dark:bg-[var(--cf-surface)] dark:checked:bg-[var(--cf-accent)] dark:focus-visible:ring-[var(--cf-accent)]/40"
+                        checked={terminalCapabilities.normalizeTerm}
+                        onChange={(event) => setTerminalCapabilities((current) => ({ ...current, normalizeTerm: event.target.checked }))}
+                      />
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium text-slate-800 dark:text-[var(--cf-text-primary)]">
+                          {t("settings:terminalCapabilities.normalizeTerm.label")}
+                        </div>
+                        <p className="text-xs text-slate-500 dark:text-[var(--cf-text-secondary)]">
+                          {t("settings:terminalCapabilities.normalizeTerm.desc")}
+                        </p>
+                      </div>
+                    </label>
+                    <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200/70 bg-white/60 px-3 py-3 shadow-sm transition-colors hover:bg-slate-50 dark:border-[var(--cf-border)] dark:bg-[var(--cf-surface-muted)] dark:text-[var(--cf-text-primary)] dark:hover:bg-[var(--cf-surface-hover)] motion-reduce:transition-none">
+                      <input
+                        type="checkbox"
+                        className="mt-1 h-4 w-4 rounded border-slate-300 text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-[var(--cf-border)] dark:bg-[var(--cf-surface)] dark:checked:bg-[var(--cf-accent)] dark:focus-visible:ring-[var(--cf-accent)]/40"
+                        checked={terminalCapabilities.trueColor}
+                        onChange={(event) => setTerminalCapabilities((current) => ({ ...current, trueColor: event.target.checked }))}
+                      />
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium text-slate-800 dark:text-[var(--cf-text-primary)]">
+                          {t("settings:terminalCapabilities.trueColor.label")}
+                        </div>
+                        <p className="text-xs text-slate-500 dark:text-[var(--cf-text-secondary)]">
+                          {t("settings:terminalCapabilities.trueColor.desc")}
+                        </p>
+                      </div>
+                    </label>
+                    <p className="text-xs text-slate-500 dark:text-[var(--cf-text-secondary)]">
+                      {t("settings:terminalCapabilities.note")}
+                    </p>
+                  </CardContent>
+                </details>
+              </Card>
+
             </div>
           ),
         };
@@ -3106,6 +3171,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
     t,
     terminalFontFamily,
     terminalTheme,
+    terminalCapabilities,
     themeLabel,
     systemThemeLabel,
     providersActiveId,
@@ -3299,6 +3365,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                           },
 	                        terminalFontFamily: normalizeTerminalFontFamily(terminalFontFamily),
 	                        terminalTheme,
+                          terminalCapabilities,
 	                        claudeCodeReadAgentHistory,
 	                      });
                       onOpenChange(false);

--- a/web/src/lib/TerminalManager.ts
+++ b/web/src/lib/TerminalManager.ts
@@ -9,6 +9,7 @@ import {
 } from '@/adapters/TerminalAdapter';
 import { isWindowsLikeTerminal, type TerminalMode } from '@/lib/shell';
 import {
+  getTerminalTheme,
   normalizeTerminalAppearance,
   type TerminalAppearance,
 } from '@/lib/terminal-appearance';
@@ -114,6 +115,8 @@ const NON_TEXT_INPUT_TYPES = new Set([
 export interface HostPtyAPI {
   onData: (id: string, handler: (data: string) => void) => (() => void);
   write: (id: string, data: string) => void;
+  /** 通知主进程 xterm.js 已完成双向绑定，并同步当前终端主题色。 */
+  ready?: (id: string, colors?: { foreground: string; background: string }) => void;
   resize: (id: string, cols: number, rows: number) => void;
   close: (id: string) => void;
   // 可选：暂停/恢复数据流及清屏（与 ConPTY 同步）
@@ -2525,10 +2528,25 @@ export default class TerminalManager {
     for (const [tabId, adapter] of Object.entries(this.adapters)) {
       if (!adapter) continue;
       try { adapter.setAppearance(next); } catch {}
+      if (themeChanged) {
+        const ptyId = this.getPtyId(tabId);
+        if (ptyId) {
+          try { this.notifyPtyFrontendReady(ptyId); } catch {}
+        }
+      }
       if (fontChanged) {
         try { this.scheduleResizeSync(tabId, true); } catch {}
       }
     }
+  }
+
+  /** 通知主进程前端已经绑定，并把当前主题的默认前景色与背景色一并同步。 */
+  private notifyPtyFrontendReady(ptyId: string): void {
+    const palette = getTerminalTheme(this.appearance.theme).palette;
+    this.hostPty.ready?.(ptyId, {
+      foreground: palette.foreground,
+      background: palette.background,
+    });
   }
 
   /**
@@ -2542,10 +2560,11 @@ export default class TerminalManager {
     try { this.inputUnsubByTab[tabId]?.(); } catch {}
     this.unsubByTab[tabId] = this.hostPty.onData(ptyId, (data) => adapter!.write(data));
     this.inputUnsubByTab[tabId] = adapter.onData((data) => this.hostPty.write(ptyId, data));
-    // 首次绑定后立即同步一次（走统一的去重/阈值/防抖逻辑，立即 flush）
+    // 先发出首次 resize 的 pause/resize，再通知 ready；主进程会等对应 resume 后启动原生 Codex。
     if (!options?.skipInitialResize) {
       try { this.scheduleResizeSync(tabId, true); } catch {}
     }
+    try { this.notifyPtyFrontendReady(ptyId); } catch {}
   }
 
   /**

--- a/web/src/lib/providers/environment.test.ts
+++ b/web/src/lib/providers/environment.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  areProviderEnvironmentsEqual,
+  isCurrentProviderEnvironmentRequest,
+} from "./environment";
+
+describe("Provider 环境切换", () => {
+  it("应忽略较早完成的异步环境检查", () => {
+    expect(isCurrentProviderEnvironmentRequest(
+      { providerId: "codex", sequence: 1 },
+      "codex",
+      2,
+    )).toBe(false);
+  });
+
+  it("切换 Provider 后不应提交旧 Provider 的检查结果", () => {
+    expect(isCurrentProviderEnvironmentRequest(
+      { providerId: "codex", sequence: 2 },
+      "claude",
+      2,
+    )).toBe(false);
+  });
+
+  it("最后一次选择应允许提交且发行版比较不区分大小写", () => {
+    expect(isCurrentProviderEnvironmentRequest(
+      { providerId: "codex", sequence: 3 },
+      "codex",
+      3,
+    )).toBe(true);
+    expect(areProviderEnvironmentsEqual(
+      { terminal: "wsl", distro: "Ubuntu-24.04" },
+      { terminal: "wsl", distro: "ubuntu-24.04" },
+    )).toBe(true);
+  });
+});

--- a/web/src/lib/providers/environment.ts
+++ b/web/src/lib/providers/environment.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
+
+import type { ProviderEnv } from "@/types/host";
+
+export type ProviderEnvironmentRequest = {
+  providerId: string;
+  sequence: number;
+};
+
+/** 判断两个 Provider 运行环境是否表示同一个终端目标。 */
+export function areProviderEnvironmentsEqual(
+  left: Required<ProviderEnv>,
+  right: Required<ProviderEnv>,
+): boolean {
+  return left.terminal === right.terminal
+    && String(left.distro || "").trim().toLowerCase() === String(right.distro || "").trim().toLowerCase();
+}
+
+/** 判断异步环境检查是否仍对应用户最后一次选择。 */
+export function isCurrentProviderEnvironmentRequest(
+  request: ProviderEnvironmentRequest,
+  activeProviderId: string,
+  currentSequence: number,
+): boolean {
+  return request.providerId === activeProviderId && request.sequence === currentSequence;
+}

--- a/web/src/lib/terminal-manager-backlog.test.ts
+++ b/web/src/lib/terminal-manager-backlog.test.ts
@@ -45,6 +45,7 @@ describe("TerminalManager（PTY 尾部回放）", () => {
       backlogResolvers,
       onData: vi.fn(() => () => {}),
       write: vi.fn(),
+      ready: vi.fn(),
       resize: vi.fn(),
       close: vi.fn(),
       pause: vi.fn(),
@@ -69,6 +70,11 @@ describe("TerminalManager（PTY 尾部回放）", () => {
     expect(hostPty.backlog).toHaveBeenCalledTimes(1);
     expect(hostPty.pause).toHaveBeenCalledTimes(1);
     expect(hostPty.onData).toHaveBeenCalledTimes(2);
+    expect(hostPty.ready).toHaveBeenCalledTimes(2);
+    expect(hostPty.ready).toHaveBeenLastCalledWith("pty-a", {
+      foreground: "#CCCCCC",
+      background: "#0C0C0C",
+    });
 
     hostPty.backlogResolvers[0]?.({ ok: true, data: "历史输出" });
     await Promise.resolve();
@@ -76,6 +82,60 @@ describe("TerminalManager（PTY 尾部回放）", () => {
 
     expect(adapter.write.mock.calls.filter((call: any[]) => call[0] === "历史输出")).toHaveLength(1);
     expect(hostPty.resume).toHaveBeenCalledWith("pty-a");
+
+    tm.disposeAll(false);
+  });
+
+  it("首次绑定和切换主题时都应同步当前终端前景色与背景色", () => {
+    const adapter: any = createAdapterStub();
+    const hostPty = createHostPtyStub();
+    createTerminalAdapterMock.mockReturnValue(adapter);
+
+    const ptyByTab: Record<string, string> = { "tab-a": "pty-a" };
+    const tm = new TerminalManager(
+      (tabId) => ptyByTab[tabId],
+      hostPty as any,
+      { theme: "dracula" },
+    );
+
+    tm.setPty("tab-a", "pty-a");
+    expect(hostPty.ready).toHaveBeenLastCalledWith("pty-a", {
+      foreground: "#F8F8F2",
+      background: "#282A36",
+    });
+
+    hostPty.ready.mockClear();
+    tm.setAppearance({ theme: "catppuccin-latte" });
+    expect(hostPty.ready).toHaveBeenCalledTimes(1);
+    expect(hostPty.ready).toHaveBeenCalledWith("pty-a", {
+      foreground: "#4C4F69",
+      background: "#EFF1F5",
+    });
+
+    tm.disposeAll(false);
+  });
+
+  it("首次绑定应先发送 resize 暂停与尺寸，再通知主进程 ready", () => {
+    const adapter: any = createAdapterStub();
+    const hostPty = createHostPtyStub();
+    createTerminalAdapterMock.mockReturnValue(adapter);
+
+    const tm = new TerminalManager(
+      () => "pty-a",
+      hostPty as any,
+      {},
+    );
+
+    tm.setPty("tab-a", "pty-a");
+
+    expect(hostPty.pause).toHaveBeenCalledWith("pty-a");
+    expect(hostPty.resize).toHaveBeenCalledWith("pty-a", 80, 24);
+    expect(hostPty.pause.mock.invocationCallOrder[0]).toBeLessThan(
+      hostPty.ready.mock.invocationCallOrder[0],
+    );
+    expect(hostPty.resize.mock.invocationCallOrder[0]).toBeLessThan(
+      hostPty.ready.mock.invocationCallOrder[0],
+    );
 
     tm.disposeAll(false);
   });

--- a/web/src/locales/en/settings.json
+++ b/web/src/locales/en/settings.json
@@ -249,6 +249,19 @@
       "fira": "Fira Code"
     }
   },
+  "terminalCapabilities": {
+    "label": "Advanced terminal compatibility",
+    "help": "Control the interaction and color capabilities reported to command-line programs.",
+    "normalizeTerm": {
+      "label": "Enhanced terminal compatibility (recommended)",
+      "desc": "Set TERM to xterm-256color only when it is missing or dumb. Other valid values are preserved."
+    },
+    "trueColor": {
+      "label": "24-bit true color",
+      "desc": "Report truecolor only when COLORTERM is unset and NO_COLOR is absent. Existing values are preserved."
+    },
+    "note": "Changes apply only to newly opened terminals. Existing terminals are unchanged."
+  },
   "loading": "Loading…",
   "codexTrace": {
     "label": "Codex TUI debugging",

--- a/web/src/locales/zh/settings.json
+++ b/web/src/locales/zh/settings.json
@@ -249,6 +249,19 @@
       "fira": "Fira Code"
     }
   },
+  "terminalCapabilities": {
+    "label": "高级终端兼容性",
+    "help": "控制内置终端向命令行程序声明的交互与颜色能力。",
+    "normalizeTerm": {
+      "label": "增强终端兼容性（推荐）",
+      "desc": "当 TERM 缺失或为 dumb 时补齐 xterm-256color；不会覆盖其他有效值。"
+    },
+    "trueColor": {
+      "label": "24 位真彩色",
+      "desc": "在未设置 COLORTERM 且没有 NO_COLOR 时声明 truecolor；不会覆盖用户已有值。"
+    },
+    "note": "保存后仅影响新打开的终端，现有终端保持不变。"
+  },
   "loading": "加载中…",
   "codexTrace": {
     "label": "Codex TUI 调试",

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -88,6 +88,13 @@ export type ProvidersSettings = {
 export type AppSettings = {
   terminal?: TerminalMode;
   terminalTheme?: TerminalThemeId;
+  /** 内置终端向 CLI 声明的兼容性与颜色能力。 */
+  terminalCapabilities?: {
+    /** 缺失或为 dumb 时补齐 TERM=xterm-256color。 */
+    normalizeTerm?: boolean;
+    /** 缺失且未声明 NO_COLOR 时补齐 COLORTERM=truecolor。 */
+    trueColor?: boolean;
+  };
   distro: string;
   codexCmd: string;
   providers?: ProvidersSettings;
@@ -410,6 +417,8 @@ export interface PtyAPI {
   /** 读取 PTY 的尾部输出缓存（用于渲染进程 reload/HMR 后恢复终端滚动区）。 */
   backlog?: (id: string, args?: { maxChars?: number }) => Promise<{ ok: boolean; data?: string; error?: string }>;
   write(id: string, data: string): void;
+  /** 通知主进程 xterm.js 已完成双向绑定，并同步当前终端主题色。 */
+  ready?: (id: string, colors?: { foreground: string; background: string }) => void;
   resize(id: string, cols: number, rows: number): void;
   close(id: string): void;
   onData(id: string, handler: (data: string) => void): () => void;


### PR DESCRIPTION
- 在 TERM 缺失或退化为 dumb 时补齐 xterm-256color，并通过 WSLENV 正确传递终端颜色能力
- 清理父进程遗留的颜色控制变量，保留用户有效配置，并提供可选的 24 位真彩色声明
- 使用隔离的 WSL ConPTY 与前端就绪门控，稳定颜色查询、首次尺寸同步和启动命令执行
- 修复 Provider 环境切换的异步结果覆盖，并缓存 PTY 启动热路径所需的终端能力配置
- 切换至官方 node-pty，补齐安装包资源过滤、双语文案和终端链路回归测试

验证：
- npm test（202 个测试文件，1252 项测试）
- npm run i18n:check
- npm run build
- Electron WSL 隔离 ConPTY 冒烟测试