### PR TITLE
fix(history): 优化彻底删除的响应与进行中反馈

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -5019,7 +5019,8 @@ ipcMain.handle('history.trashMany', async (_e, { filePaths }: { filePaths: strin
         if ((r as any).notFound) notFoundCount++; else okCount++;
       } else failCount++;
     }
-    await cleanupCodexStateForDeletedPathsSafely(Array.from(codexStateCleanupPaths), 'history.trashMany');
+    // SQLite 状态清理属于删除后的辅助收尾，不应阻塞删除结果返回与界面反馈。
+    void cleanupCodexStateForDeletedPathsSafely(Array.from(codexStateCleanupPaths), 'history.trashMany');
 
     return { ok: true, results, summary: { ok: okCount, notFound: notFoundCount, failed: failCount } } as any;
   } catch (e: any) {
@@ -5051,7 +5052,8 @@ ipcMain.handle('history.trash', async (_e, { filePath }: { filePath: string }) =
     // 候选均不存在则视为成功（无需删除）
     const anyExists = deleteCandidates.some((c) => { try { return fs.existsSync(c); } catch { return false; } });
     if (!anyExists) {
-      await cleanupCodexStateForDeletedPathsSafely([p0, ...deleteCandidates], 'history.trash.notFound');
+      // 即使文件已不存在，也在后台清理可能残留的 Codex 状态。
+      void cleanupCodexStateForDeletedPathsSafely([p0, ...deleteCandidates], 'history.trash.notFound');
       return { ok: true, notFound: true } as any;
     }
     // 依次尝试候选：永久删除
@@ -5078,7 +5080,8 @@ ipcMain.handle('history.trash', async (_e, { filePath }: { filePath: string }) =
       try { return fs.existsSync(cand); } catch { return false; }
     });
     if (deletedAny && remaining.length === 0) {
-      await cleanupCodexStateForDeletedPathsSafely([p0, ...deleteCandidates], 'history.trash');
+      // 历史文件、索引和缓存均已处理完成，SQLite 收尾无需继续占用删除弹窗。
+      void cleanupCodexStateForDeletedPathsSafely([p0, ...deleteCandidates], 'history.trash');
       return { ok: true };
     }
     const details = [...failed.map(f => `${f.cand}: ${String(f.err)}`), ...remaining.map((cand) => `${cand}: still_exists`)].join('; ');

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4884,7 +4884,7 @@ export default function CodexFlowManagerUI() {
   const [historyCtxMenu, setHistoryCtxMenu] = useState<{ show: boolean; x: number; y: number; item: HistorySession | null; groupKey: string | null }>({ show: false, x: 0, y: 0, item: null, groupKey: null });
   const historyCtxMenuRef = useRef<HTMLDivElement | null>(null);
   // 历史删除确认（应用内对话框，替代 window.confirm，避免同步阻塞导致的焦点/指针异常）
-  const [confirmDelete, setConfirmDelete] = useState<{ open: boolean; item: HistorySession | null; groupKey: string | null }>({ open: false, item: null, groupKey: null });
+  const [confirmDelete, setConfirmDelete] = useState<{ open: boolean; item: HistorySession | null; groupKey: string | null; deleting: boolean }>({ open: false, item: null, groupKey: null, deleting: false });
   // 标签关闭确认：手动关闭 working 标签页或带未发送输入内容的标签页时弹出。
   const [closeWorkingTabConfirm, setCloseWorkingTabConfirm] = useState<CloseWorkingTabConfirmState>({
     open: false,
@@ -11258,7 +11258,7 @@ export default function CodexFlowManagerUI() {
    */
   const openHistoryDeleteConfirm = useCallback((item: HistorySession | null, groupKey: string | null) => {
     if (!item) return;
-    setConfirmDelete({ open: true, item, groupKey });
+    setConfirmDelete({ open: true, item, groupKey, deleting: false });
     setHistoryCtxMenu((m) => ({ ...m, show: false }));
   }, []);
 
@@ -13262,6 +13262,7 @@ export default function CodexFlowManagerUI() {
 
       {/* 历史删除确认弹窗（非阻塞） */}
       <Dialog open={confirmDelete.open} onOpenChange={(v) => {
+        if (!v && confirmDelete.deleting) return;
         setConfirmDelete((m) => ({ ...m, open: v }));
         if (!v) {
           try { document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true })); } catch {}
@@ -13288,12 +13289,13 @@ export default function CodexFlowManagerUI() {
             </DialogDescription>
           </DialogHeader>
           <div className="flex justify-end gap-2 pt-2">
-            <Button variant="outline" onClick={() => setConfirmDelete((m) => ({ ...m, open: false }))}>{t('common:cancel')}</Button>
-            <Button className="border border-red-200 text-red-600 hover:bg-red-50 dark:border-[var(--cf-red-light)] dark:text-[var(--cf-red)] dark:hover:bg-[var(--cf-red-light)]" variant="secondary" onClick={async () => {
+            <Button variant="outline" disabled={confirmDelete.deleting} onClick={() => setConfirmDelete((m) => ({ ...m, open: false }))}>{t('common:cancel')}</Button>
+            <Button data-cf-dialog-primary="true" disabled={confirmDelete.deleting} className="border border-red-200 text-red-600 hover:bg-red-50 dark:border-[var(--cf-red-light)] dark:text-[var(--cf-red)] dark:hover:bg-[var(--cf-red-light)]" variant="secondary" onClick={async () => {
               try {
                 const it = confirmDelete.item; const fallbackKey = it ? historyTimelineGroupKey(it, new Date()) : HISTORY_UNKNOWN_GROUP_KEY;
                 const key = confirmDelete.groupKey || fallbackKey;
                 if (!it?.filePath) { setConfirmDelete((m) => ({ ...m, open: false })); return; }
+                setConfirmDelete((m) => ({ ...m, deleting: true }));
                 const res: any = await window.host.history.trash({ filePath: it.filePath });
                 if (!(res && res.ok)) { alert(String(t('history:cannotDelete', { error: res && res.error ? res.error : 'unknown' }))); setConfirmDelete((m) => ({ ...m, open: false })); return; }
                 setHistorySessions((cur) => {
@@ -13334,13 +13336,14 @@ export default function CodexFlowManagerUI() {
               } catch (err: any) {
                 alert(String(t('history:deleteFailed', { error: String(err) })));
               } finally {
-                setConfirmDelete((m) => ({ ...m, open: false }));
+                setConfirmDelete({ open: false, item: null, groupKey: null, deleting: false });
                 // 释放可能残留的指针捕获
                 try { document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true })); } catch {}
                 try { document.dispatchEvent(new PointerEvent('pointerup', { bubbles: true } as any)); } catch {}
               }
             }}>
-              <Trash2 className="mr-2 h-4 w-4" /> {t('settings:cleanupConfirm.confirm')}
+              {confirmDelete.deleting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Trash2 className="mr-2 h-4 w-4" />}
+              {confirmDelete.deleting ? t('history:deletingPermanently') : t('settings:cleanupConfirm.confirm')}
             </Button>
           </div>
         </DialogContent>

--- a/web/src/locales/en/history.json
+++ b/web/src/locales/en/history.json
@@ -53,6 +53,7 @@
   "cannotOpenDefault": "Unable to open with default app",
   "deleteToTrash": "Delete Permanently",
   "confirmPermanentDelete": "Permanently delete this history file? This action cannot be undone.",
+  "deletingPermanently": "Deleting permanently…",
   "untitledSessionTitle": "Untitled",
   "deleteFailed": "Delete failed: {error}",
   "cannotDelete": "Unable to delete: {error}",

--- a/web/src/locales/zh/history.json
+++ b/web/src/locales/zh/history.json
@@ -53,6 +53,7 @@
   "cannotOpenDefault": "无法用默认程序打开",
   "deleteToTrash": "彻底删除",
   "confirmPermanentDelete": "确认要彻底删除该历史文件吗？该操作不可恢复。",
+  "deletingPermanently": "正在彻底删除…",
   "untitledSessionTitle": "未命名",
   "deleteFailed": "删除失败：{error}",
   "cannotDelete": "无法删除：{error}",


### PR DESCRIPTION
将单条和批量历史删除后的 Codex SQLite 状态清理调整为后台串行
执行，删除文件、索引和缓存完成后即可返回结果，避免辅助清理继续
占用确认弹窗。

为单条历史删除增加进行中状态：禁用取消和重复确认，处理中阻止
关闭弹窗，并显示加载图标和中英文状态文案；操作结束后统一清空
弹窗上下文，确保成功与失败路径都能恢复。