### PR TITLE
fix(wsl): 修复WSL下 Codex 回复卡顿与 Claude Code 无回复

### DIFF
--- a/electron/antigravity/notifications.test.ts
+++ b/electron/antigravity/notifications.test.ts
@@ -99,6 +99,33 @@ describe("electron/antigravity/notifications", () => {
     expect(entry.Stop[0].command).not.toContain("\"");
   });
 
+  it("读取已有 hook 脚本失败时不应改写 hooks.json", async () => {
+    const geminiRoot = createTempDir("antigravity-notify-script-read-error-");
+    tempDirs.push(geminiRoot);
+    const root = path.join(geminiRoot, "antigravity-cli");
+    const scriptPath = path.join(root, "hooks", "codexflow_stop_notify.js");
+    const hooksJsonPath = path.join(geminiRoot, "config", "hooks.json");
+    const originalHooks = JSON.stringify({ "user-hook": { enabled: true } }, null, 2) + "\n";
+    fs.mkdirSync(path.join(root, "conversations"), { recursive: true });
+    fs.mkdirSync(path.dirname(scriptPath), { recursive: true });
+    fs.mkdirSync(path.dirname(hooksJsonPath), { recursive: true });
+    fs.writeFileSync(scriptPath, "user-owned-hook\n", "utf8");
+    fs.writeFileSync(hooksJsonPath, originalHooks, "utf8");
+
+    const readFile = fs.promises.readFile.bind(fs.promises);
+    vi.spyOn(fs.promises, "readFile").mockImplementation(async (...args: Parameters<typeof fs.promises.readFile>) => {
+      if (path.resolve(String(args[0])) === path.resolve(scriptPath))
+        throw Object.assign(new Error("read denied"), { code: "EACCES" });
+      return await (readFile as any)(...args);
+    });
+
+    const mod = await loadAntigravityNotificationsModule(root);
+    await mod.ensureAllAntigravityNotifications();
+
+    expect(fs.readFileSync(hooksJsonPath, "utf8")).toBe(originalHooks);
+    expect(fs.readFileSync(scriptPath, "utf8")).toBe("user-owned-hook\n");
+  });
+
   it("hydrateAntigravityNotifyPreview：hook 正文为空时从会话 DB 补最后一条助手回复", async () => {
     const geminiRoot = createTempDir("antigravity-notify-root-");
     tempDirs.push(geminiRoot);

--- a/electron/antigravity/notifications.ts
+++ b/electron/antigravity/notifications.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
-import fs from "node:fs";
+import { promises as fsp } from "node:fs";
 import path from "node:path";
 import { BrowserWindow } from "electron";
 import { perfLogger } from "../log";
@@ -225,11 +225,13 @@ type AntigravityNotifySource = {
   offset: number;
   remainder: string;
 };
+type WriteFileResult = { ok: boolean; changed: boolean };
 
 const antigravityNotifySources = new Map<string, AntigravityNotifySource>();
 let antigravityNotifyTimer: NodeJS.Timeout | null = null;
 let antigravityNotifyPolling = false;
 let antigravityNotifyWindowGetter: (() => BrowserWindow | null) | null = null;
+let antigravityNotifyBridgeGeneration = 0;
 let inflight: Promise<void> | null = null;
 
 /**
@@ -242,37 +244,41 @@ function logAntigravityNotification(message: string): void {
 /**
  * 确保目录存在。
  */
-function ensureDir(dirPath: string): void {
-  try { fs.mkdirSync(dirPath, { recursive: true }); } catch {}
+async function ensureDir(dirPath: string): Promise<void> {
+  try { await fsp.mkdir(dirPath, { recursive: true }); } catch {}
 }
 
 /**
  * 仅在内容变化时写入文件，避免频繁刷新 hook 脚本修改时间。
  */
-function writeFileIfChanged(filePath: string, content: string): boolean {
+async function writeFileIfChanged(filePath: string, content: string): Promise<WriteFileResult> {
   try {
-    if (fs.existsSync(filePath)) {
-      const current = fs.readFileSync(filePath, "utf8");
-      if (current === content) return false;
-    }
-  } catch {}
+    const current = await fsp.readFile(filePath, "utf8");
+    if (current === content) return { ok: true, changed: false };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") return { ok: false, changed: false };
+  }
   try {
-    ensureDir(path.dirname(filePath));
-    fs.writeFileSync(filePath, content, "utf8");
-    return true;
+    await ensureDir(path.dirname(filePath));
+    await fsp.writeFile(filePath, content, "utf8");
+    return { ok: true, changed: true };
   } catch (error) {
     logAntigravityNotification(`write script failed path=${filePath} error=${String(error)}`);
-    return false;
+    return { ok: false, changed: false };
   }
 }
 
 /**
  * 安全读取 JSON 配置文件，空文件按空对象处理。
  */
-function readJsonFile(filePath: string): any | null {
+async function readJsonFile(filePath: string): Promise<any | null> {
   try {
-    if (!fs.existsSync(filePath)) return {};
-    const raw = fs.readFileSync(filePath, "utf8");
+    let raw = "";
+    try {
+      raw = await fsp.readFile(filePath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") throw error;
+    }
     return raw.trim() ? JSON.parse(raw) : {};
   } catch (error) {
     logAntigravityNotification(`read hooks failed path=${filePath} error=${String(error)}`);
@@ -283,10 +289,10 @@ function readJsonFile(filePath: string): any | null {
 /**
  * 将 JSON 配置按 2 空格缩进写回。
  */
-function writeJsonFile(filePath: string, data: any): boolean {
+async function writeJsonFile(filePath: string, data: any): Promise<boolean> {
   try {
-    ensureDir(path.dirname(filePath));
-    fs.writeFileSync(filePath, JSON.stringify(data ?? {}, null, 2) + "\n", "utf8");
+    await ensureDir(path.dirname(filePath));
+    await fsp.writeFile(filePath, JSON.stringify(data ?? {}, null, 2) + "\n", "utf8");
     return true;
   } catch (error) {
     logAntigravityNotification(`write hooks failed path=${filePath} error=${String(error)}`);
@@ -458,11 +464,13 @@ async function ensureAntigravityNotificationsAtRoot(candidate: SessionsRootCandi
   const scriptPath = path.join(rootPath, "hooks", ANTIGRAVITY_HOOK_FILENAME);
   const hooksJsonPath = resolveAntigravityHooksJsonPath(rootPath);
   const command = buildAntigravityHookCommand(scriptPath, hooksJsonPath);
-  const scriptChanged = writeFileIfChanged(scriptPath, ANTIGRAVITY_HOOK_SCRIPT);
-  const current = readJsonFile(hooksJsonPath);
+  const scriptResult = await writeFileIfChanged(scriptPath, ANTIGRAVITY_HOOK_SCRIPT);
+  if (!scriptResult.ok) return;
+  const scriptChanged = scriptResult.changed;
+  const current = await readJsonFile(hooksJsonPath);
   if (current == null) return;
   const { next, changed } = ensureAntigravityHooksFile(current, command);
-  const hooksChanged = changed ? writeJsonFile(hooksJsonPath, next) : false;
+  const hooksChanged = changed ? await writeJsonFile(hooksJsonPath, next) : false;
   if (scriptChanged || hooksChanged)
     logAntigravityNotification(`ensure notifications root=${rootPath} script=${scriptChanged ? "1" : "0"} hooks=${hooksChanged ? "1" : "0"}`);
 }
@@ -503,7 +511,8 @@ async function listAntigravityNotifyFiles(): Promise<string[]> {
 /**
  * 同步通知源列表，并保留已有读取偏移。
  */
-function syncAntigravityNotifySources(paths: string[]): void {
+async function syncAntigravityNotifySources(paths: string[], generation = antigravityNotifyBridgeGeneration): Promise<void> {
+  if (generation !== antigravityNotifyBridgeGeneration) return;
   const normalized = new Set<string>();
   for (const p of paths) {
     const key = String(p || "").replace(/\\/g, "/").toLowerCase();
@@ -515,17 +524,18 @@ function syncAntigravityNotifySources(paths: string[]): void {
       logAntigravityNotification(`notify source removed path=${source.filePath}`);
     }
   }
-  for (const p of paths) {
+  await Promise.all(paths.map(async (p) => {
     const key = String(p || "").replace(/\\/g, "/").toLowerCase();
-    if (!key || antigravityNotifySources.has(key)) continue;
+    if (!key || antigravityNotifySources.has(key)) return;
     let offset = 0;
     try {
-      const st = fs.statSync(p);
+      const st = await fsp.stat(p);
       if (st && st.isFile && st.isFile()) offset = typeof st.size === "number" ? st.size : 0;
     } catch {}
+    if (generation !== antigravityNotifyBridgeGeneration) return;
     antigravityNotifySources.set(key, { filePath: p, offset, remainder: "" });
     logAntigravityNotification(`notify source added path=${p} offset=${offset}`);
-  }
+  }));
 }
 
 /**
@@ -618,21 +628,35 @@ function resolveAntigravityRootFromTranscriptPath(transcriptPath?: string): stri
 /**
  * 定位 Antigravity 会话 SQLite DB；hook 只给 sessionId 时，用本地 conversations 目录补足。
  */
-function resolveAntigravityConversationDbPath(entry: AntigravityNotifyEntry, sourcePath?: string): string {
+function listAntigravityConversationDbCandidates(entry: AntigravityNotifyEntry, sourcePath?: string): string[] {
   const sessionId = sanitizeAntigravitySessionId(entry.sessionId);
-  if (!sessionId) return "";
+  if (!sessionId) return [];
   const roots = [
     resolveAntigravityRootFromNotifyPath(sourcePath),
     resolveAntigravityRootFromTranscriptPath(entry.transcriptPath),
   ].filter(Boolean);
-  for (const root of roots) {
-    const dbPath = path.join(root, "conversations", `${sessionId}.db`);
+  return roots.map((root) => path.join(root, "conversations", `${sessionId}.db`));
+}
+
+/**
+ * 根据通知内容返回一个会话 DB 候选路径；仅做字符串处理，不访问 WSL 文件系统。
+ */
+function resolveAntigravityConversationDbPath(entry: AntigravityNotifyEntry, sourcePath?: string): string {
+  return listAntigravityConversationDbCandidates(entry, sourcePath)[0] || "";
+}
+
+/**
+ * 异步选择实际存在的 Antigravity 会话 DB，避免主进程同步访问 UNC 路径。
+ */
+async function resolveAntigravityConversationDbPathAsync(entry: AntigravityNotifyEntry, sourcePath?: string): Promise<string> {
+  const candidates = listAntigravityConversationDbCandidates(entry, sourcePath);
+  for (const candidate of candidates) {
     try {
-      const st = fs.statSync(dbPath);
-      if (st && st.isFile && st.isFile()) return dbPath;
+      const st = await fsp.stat(candidate);
+      if (st.isFile()) return candidate;
     } catch {}
   }
-  return roots[0] ? path.join(roots[0], "conversations", `${sessionId}.db`) : "";
+  return candidates[0] || "";
 }
 
 /**
@@ -673,11 +697,11 @@ function extractLastAssistantPreview(details: Awaited<ReturnType<typeof parseAnt
 async function hydrateAntigravityNotifyPreview(entry: AntigravityNotifyEntry, sourcePath?: string): Promise<AntigravityNotifyEntry> {
   const currentPreview = String(entry.preview || "").trim();
   if (currentPreview && !isAntigravityStatusPreview(currentPreview)) return entry;
-  const dbPath = resolveAntigravityConversationDbPath(entry, sourcePath);
+  const dbPath = await resolveAntigravityConversationDbPathAsync(entry, sourcePath);
   if (!dbPath) return entry;
   try {
-    const stat = fs.statSync(dbPath);
-    if (!stat || !stat.isFile || !stat.isFile()) return entry;
+    const stat = await fsp.stat(dbPath);
+    if (!stat || !stat.isFile()) return entry;
     const details = await parseAntigravitySessionFile(dbPath, stat, { summaryOnly: false });
     const preview = extractLastAssistantPreview(details);
     if (!preview) return currentPreview && isAntigravityStatusPreview(currentPreview) ? { ...entry, preview: "" } : entry;
@@ -692,9 +716,9 @@ async function hydrateAntigravityNotifyPreview(entry: AntigravityNotifyEntry, so
 /**
  * 从通知文件读取新增 JSONL 内容。
  */
-function readAntigravityNotifyEntries(source: AntigravityNotifySource): AntigravityNotifyEntry[] {
+async function readAntigravityNotifyEntries(source: AntigravityNotifySource): Promise<AntigravityNotifyEntry[]> {
   try {
-    const st = fs.statSync(source.filePath);
+    const st = await fsp.stat(source.filePath);
     if (!st || !st.isFile || !st.isFile()) return [];
     const size = typeof st.size === "number" ? st.size : 0;
     if (size < source.offset) {
@@ -712,12 +736,16 @@ function readAntigravityNotifyEntries(source: AntigravityNotifySource): Antigrav
       logAntigravityNotification(`notify tail read: path=${source.filePath} len=${length}`);
     }
 
-    const fd = fs.openSync(source.filePath, "r");
+    const fd = await fsp.open(source.filePath, "r");
     const buf = Buffer.alloc(length);
-    try { fs.readSync(fd, buf, 0, length, start); } finally { try { fs.closeSync(fd); } catch {} }
-    source.offset = start + length;
+    let bytesRead = 0;
+    try {
+      const result = await fd.read(buf, 0, length, start);
+      bytesRead = result.bytesRead;
+    } finally { try { await fd.close(); } catch {} }
+    source.offset = start + bytesRead;
 
-    const text = source.remainder + buf.toString("utf8");
+    const text = source.remainder + buf.subarray(0, bytesRead).toString("utf8");
     const lines = text.split(/\r?\n/);
     source.remainder = lines.pop() || "";
     const out: AntigravityNotifyEntry[] = [];
@@ -734,8 +762,10 @@ function readAntigravityNotifyEntries(source: AntigravityNotifySource): Antigrav
 /**
  * 将 Antigravity hook 通知转发给渲染进程，并触发历史快速刷新。
  */
-async function emitAntigravityNotify(entry: AntigravityNotifyEntry, sourcePath?: string): Promise<void> {
+async function emitAntigravityNotify(entry: AntigravityNotifyEntry, sourcePath?: string, generation = antigravityNotifyBridgeGeneration): Promise<void> {
+  if (generation !== antigravityNotifyBridgeGeneration) return;
   entry = await hydrateAntigravityNotifyPreview(entry, sourcePath);
+  if (generation !== antigravityNotifyBridgeGeneration) return;
   const win = antigravityNotifyWindowGetter ? antigravityNotifyWindowGetter() : null;
   try {
     requestHistoryFastRefresh({
@@ -778,15 +808,21 @@ async function emitAntigravityNotify(entry: AntigravityNotifyEntry, sourcePath?:
  */
 async function pollAntigravityNotifyFiles(): Promise<void> {
   if (antigravityNotifyPolling) return;
+  const generation = antigravityNotifyBridgeGeneration;
   antigravityNotifyPolling = true;
   try {
     for (const source of Array.from(antigravityNotifySources.values())) {
-      const entries = readAntigravityNotifyEntries(source);
+      if (generation !== antigravityNotifyBridgeGeneration) return;
+      const entries = await readAntigravityNotifyEntries(source);
+      if (generation !== antigravityNotifyBridgeGeneration) return;
       if (!entries.length) continue;
-      for (const entry of entries) await emitAntigravityNotify(entry, source.filePath);
+      for (const entry of entries) {
+        if (generation !== antigravityNotifyBridgeGeneration) return;
+        await emitAntigravityNotify(entry, source.filePath, generation);
+      }
     }
   } finally {
-    antigravityNotifyPolling = false;
+    if (generation === antigravityNotifyBridgeGeneration) antigravityNotifyPolling = false;
   }
 }
 
@@ -794,11 +830,22 @@ async function pollAntigravityNotifyFiles(): Promise<void> {
  * 启动 Antigravity 通知桥接，重复调用只刷新源列表。
  */
 export async function startAntigravityNotificationBridge(getWindow: () => BrowserWindow | null): Promise<void> {
+  const generation = antigravityNotifyBridgeGeneration;
   antigravityNotifyWindowGetter = getWindow;
   const paths = await listAntigravityNotifyFiles();
-  syncAntigravityNotifySources(paths);
+  if (generation !== antigravityNotifyBridgeGeneration) return;
+  await syncAntigravityNotifySources(paths, generation);
+  if (generation !== antigravityNotifyBridgeGeneration) return;
   try {
-    const watchList = paths.map((p) => `${p}${fs.existsSync(p) ? "" : " (missing)"}`);
+    const watchList = await Promise.all(paths.map(async (p) => {
+      try {
+        const st = await fsp.stat(p);
+        return `${p}${st.isFile() ? "" : " (missing)"}`;
+      } catch {
+        return `${p} (missing)`;
+      }
+    }));
+    if (generation !== antigravityNotifyBridgeGeneration) return;
     logAntigravityNotification(`notify bridge watch=${watchList.join(" | ") || "none"}`);
   } catch {}
   if (antigravityNotifyTimer) return;
@@ -812,6 +859,7 @@ export async function startAntigravityNotificationBridge(getWindow: () => Browse
  * 停止 Antigravity 通知桥接。
  */
 export function stopAntigravityNotificationBridge(): void {
+  antigravityNotifyBridgeGeneration += 1;
   if (antigravityNotifyTimer) {
     try { clearInterval(antigravityNotifyTimer); } catch {}
   }

--- a/electron/claude/notifications.test.ts
+++ b/electron/claude/notifications.test.ts
@@ -60,4 +60,48 @@ describe("electron/claude/notifications（多行预览保真）", () => {
     expect(script).not.toContain("function collapseWs(input)");
     expect(script).not.toContain("const s = collapseWs(input);");
   });
+
+  it("读取 settings.json 失败时不应覆盖现有配置", async () => {
+    const root = createTempDir("claude-notify-read-error-");
+    tempDirs.push(root);
+    const settingsPath = path.join(root, "settings.json");
+    const original = "{\n  \"model\": \"test-model\"\n}\n";
+    fs.writeFileSync(settingsPath, original, "utf8");
+
+    const readFile = fs.promises.readFile.bind(fs.promises);
+    vi.spyOn(fs.promises, "readFile").mockImplementation(async (...args: Parameters<typeof fs.promises.readFile>) => {
+      if (path.resolve(String(args[0])) === path.resolve(settingsPath))
+        throw Object.assign(new Error("read denied"), { code: "EACCES" });
+      return await (readFile as any)(...args);
+    });
+
+    const mod = await loadClaudeNotificationsModule(root);
+    await mod.ensureAllClaudeNotifications();
+
+    expect(fs.readFileSync(settingsPath, "utf8")).toBe(original);
+  });
+
+  it("读取已有 hook 脚本失败时不应改写 settings.json", async () => {
+    const root = createTempDir("claude-notify-script-read-error-");
+    tempDirs.push(root);
+    const settingsPath = path.join(root, "settings.json");
+    const scriptPath = path.join(root, "hooks", "codexflow_stop_notify.js");
+    const originalSettings = "{\n  \"model\": \"test-model\"\n}\n";
+    fs.writeFileSync(settingsPath, originalSettings, "utf8");
+    fs.mkdirSync(path.dirname(scriptPath), { recursive: true });
+    fs.writeFileSync(scriptPath, "user-owned-hook\n", "utf8");
+
+    const readFile = fs.promises.readFile.bind(fs.promises);
+    vi.spyOn(fs.promises, "readFile").mockImplementation(async (...args: Parameters<typeof fs.promises.readFile>) => {
+      if (path.resolve(String(args[0])) === path.resolve(scriptPath))
+        throw Object.assign(new Error("read denied"), { code: "EACCES" });
+      return await (readFile as any)(...args);
+    });
+
+    const mod = await loadClaudeNotificationsModule(root);
+    await mod.ensureAllClaudeNotifications();
+
+    expect(fs.readFileSync(settingsPath, "utf8")).toBe(originalSettings);
+    expect(fs.readFileSync(scriptPath, "utf8")).toBe("user-owned-hook\n");
+  });
 });

--- a/electron/claude/notifications.ts
+++ b/electron/claude/notifications.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
-import fs from "node:fs";
+import { promises as fsp } from "node:fs";
 import path from "node:path";
 import { BrowserWindow } from "electron";
 import { perfLogger } from "../log";
@@ -333,6 +333,7 @@ process.exit(0);
 
 type HookItem = { type?: string; command?: string; timeout?: number };
 type HookGroup = { matcher?: string; hooks?: HookItem[] };
+type WriteFileResult = { ok: boolean; changed: boolean };
 
 /**
  * 中文说明：记录 Claude 通知配置的调试日志。
@@ -344,37 +345,41 @@ function logClaudeNotification(message: string) {
 /**
  * 中文说明：确保目录存在。
  */
-function ensureDir(dirPath: string) {
-  try { fs.mkdirSync(dirPath, { recursive: true }); } catch {}
+async function ensureDir(dirPath: string): Promise<void> {
+  try { await fsp.mkdir(dirPath, { recursive: true }); } catch {}
 }
 
 /**
  * 中文说明：仅在内容变化时写入文件，避免无意义覆盖。
  */
-function writeFileIfChanged(filePath: string, content: string): boolean {
+async function writeFileIfChanged(filePath: string, content: string): Promise<WriteFileResult> {
   try {
-    if (fs.existsSync(filePath)) {
-      const current = fs.readFileSync(filePath, "utf8");
-      if (current === content) return false;
-    }
-  } catch {}
+    const current = await fsp.readFile(filePath, "utf8");
+    if (current === content) return { ok: true, changed: false };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") return { ok: false, changed: false };
+  }
   try {
-    ensureDir(path.dirname(filePath));
-    fs.writeFileSync(filePath, content, "utf8");
-    return true;
+    await ensureDir(path.dirname(filePath));
+    await fsp.writeFile(filePath, content, "utf8");
+    return { ok: true, changed: true };
   } catch (error) {
     logClaudeNotification(`write script failed path=${filePath} error=${String(error)}`);
-    return false;
+    return { ok: false, changed: false };
   }
 }
 
 /**
  * 中文说明：安全读取 JSON 配置；解析失败则返回 null。
  */
-function readJsonFile(filePath: string): any | null {
+async function readJsonFile(filePath: string): Promise<any | null> {
   try {
-    if (!fs.existsSync(filePath)) return {};
-    const raw = fs.readFileSync(filePath, "utf8");
+    let raw = "";
+    try {
+      raw = await fsp.readFile(filePath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") throw error;
+    }
     return raw.trim() ? JSON.parse(raw) : {};
   } catch (error) {
     logClaudeNotification(`read settings failed path=${filePath} error=${String(error)}`);
@@ -385,11 +390,11 @@ function readJsonFile(filePath: string): any | null {
 /**
  * 中文说明：将对象写回 JSON 文件（统一 2 空格缩进）。
  */
-function writeJsonFile(filePath: string, data: any): boolean {
+async function writeJsonFile(filePath: string, data: any): Promise<boolean> {
   try {
-    ensureDir(path.dirname(filePath));
+    await ensureDir(path.dirname(filePath));
     const body = JSON.stringify(data ?? {}, null, 2) + "\n";
-    fs.writeFileSync(filePath, body, "utf8");
+    await fsp.writeFile(filePath, body, "utf8");
     return true;
   } catch (error) {
     logClaudeNotification(`write settings failed path=${filePath} error=${String(error)}`);
@@ -512,12 +517,14 @@ async function ensureClaudeNotificationsAtRoot(candidate: SessionsRootCandidate)
   const command = buildClaudeHookCommand(rootPath, candidate);
   if (!command) return;
 
-  const scriptChanged = writeFileIfChanged(scriptPath, CLAUDE_HOOK_SCRIPT);
-  const current = readJsonFile(settingsPath);
+  const scriptResult = await writeFileIfChanged(scriptPath, CLAUDE_HOOK_SCRIPT);
+  if (!scriptResult.ok) return;
+  const scriptChanged = scriptResult.changed;
+  const current = await readJsonFile(settingsPath);
   if (current == null) return;
 
   const { next, changed } = ensureClaudeSettings(current, command);
-  const settingsChanged = changed ? writeJsonFile(settingsPath, next) : false;
+  const settingsChanged = changed ? await writeJsonFile(settingsPath, next) : false;
 
   if (scriptChanged || settingsChanged) {
     logClaudeNotification(`ensure notifications root=${rootPath} script=${scriptChanged ? "1" : "0"} settings=${settingsChanged ? "1" : "0"}`);
@@ -571,6 +578,7 @@ const claudeNotifySources = new Map<string, ClaudeNotifySource>();
 let claudeNotifyTimer: NodeJS.Timeout | null = null;
 let claudeNotifyPolling = false;
 let claudeNotifyWindowGetter: (() => BrowserWindow | null) | null = null;
+let claudeNotifyBridgeGeneration = 0;
 
 /**
  * 中文说明：列出需要监听的 Claude 通知文件路径（Windows/UNC）。
@@ -588,7 +596,8 @@ async function listClaudeNotifyFiles(): Promise<string[]> {
 /**
  * 中文说明：同步通知源列表，保留已有读取偏移。
  */
-function syncClaudeNotifySources(paths: string[]): void {
+async function syncClaudeNotifySources(paths: string[], generation = claudeNotifyBridgeGeneration): Promise<void> {
+  if (generation !== claudeNotifyBridgeGeneration) return;
   const normalized = new Set<string>();
   for (const p of paths) {
     const key = String(p || "").replace(/\\/g, "/").toLowerCase();
@@ -600,17 +609,18 @@ function syncClaudeNotifySources(paths: string[]): void {
       try { logClaudeNotification(`notify source removed path=${source.filePath}`); } catch {}
     }
   }
-  for (const p of paths) {
+  await Promise.all(paths.map(async (p) => {
     const key = String(p || "").replace(/\\/g, "/").toLowerCase();
-    if (!key || claudeNotifySources.has(key)) continue;
+    if (!key || claudeNotifySources.has(key)) return;
     let offset = 0;
     try {
-      const st = fs.statSync(p);
+      const st = await fsp.stat(p);
       if (st && st.isFile && st.isFile()) offset = typeof st.size === "number" ? st.size : 0;
     } catch {}
+    if (generation !== claudeNotifyBridgeGeneration) return;
     claudeNotifySources.set(key, { filePath: p, offset, remainder: "" });
     try { logClaudeNotification(`notify source added path=${p} offset=${offset}`); } catch {}
-  }
+  }));
 }
 
 /**
@@ -631,9 +641,9 @@ function parseClaudeNotifyLine(line: string): ClaudeNotifyEntry | null {
 /**
  * 中文说明：从通知文件中读取新增内容并解析为事件列表。
  */
-function readClaudeNotifyEntries(source: ClaudeNotifySource): ClaudeNotifyEntry[] {
+async function readClaudeNotifyEntries(source: ClaudeNotifySource): Promise<ClaudeNotifyEntry[]> {
   try {
-    const st = fs.statSync(source.filePath);
+    const st = await fsp.stat(source.filePath);
     if (!st || !st.isFile || !st.isFile()) return [];
     const size = typeof st.size === "number" ? st.size : 0;
     if (size < source.offset) {
@@ -651,12 +661,16 @@ function readClaudeNotifyEntries(source: ClaudeNotifySource): ClaudeNotifyEntry[
       logClaudeNotification(`notify tail read: path=${source.filePath} len=${length}`);
     }
 
-    const fd = fs.openSync(source.filePath, "r");
+    const fd = await fsp.open(source.filePath, "r");
     const buf = Buffer.alloc(length);
-    try { fs.readSync(fd, buf, 0, length, start); } finally { try { fs.closeSync(fd); } catch {} }
-    source.offset = start + length;
+    let bytesRead = 0;
+    try {
+      const result = await fd.read(buf, 0, length, start);
+      bytesRead = result.bytesRead;
+    } finally { try { await fd.close(); } catch {} }
+    source.offset = start + bytesRead;
 
-    const text = source.remainder + buf.toString("utf8");
+    const text = source.remainder + buf.subarray(0, bytesRead).toString("utf8");
     const lines = text.split(/\r?\n/);
     source.remainder = lines.pop() || "";
     const out: ClaudeNotifyEntry[] = [];
@@ -716,15 +730,21 @@ function emitClaudeNotify(entry: ClaudeNotifyEntry, sourcePath?: string): void {
  */
 async function pollClaudeNotifyFiles(): Promise<void> {
   if (claudeNotifyPolling) return;
+  const generation = claudeNotifyBridgeGeneration;
   claudeNotifyPolling = true;
   try {
     for (const source of Array.from(claudeNotifySources.values())) {
-      const entries = readClaudeNotifyEntries(source);
+      if (generation !== claudeNotifyBridgeGeneration) return;
+      const entries = await readClaudeNotifyEntries(source);
+      if (generation !== claudeNotifyBridgeGeneration) return;
       if (!entries.length) continue;
-      for (const entry of entries) emitClaudeNotify(entry, source.filePath);
+      for (const entry of entries) {
+        if (generation !== claudeNotifyBridgeGeneration) return;
+        emitClaudeNotify(entry, source.filePath);
+      }
     }
   } finally {
-    claudeNotifyPolling = false;
+    if (generation === claudeNotifyBridgeGeneration) claudeNotifyPolling = false;
   }
 }
 
@@ -732,11 +752,22 @@ async function pollClaudeNotifyFiles(): Promise<void> {
  * 中文说明：启动 Claude 通知桥接（重复调用只刷新源列表）。
  */
 export async function startClaudeNotificationBridge(getWindow: () => BrowserWindow | null): Promise<void> {
+  const generation = claudeNotifyBridgeGeneration;
   claudeNotifyWindowGetter = getWindow;
   const paths = await listClaudeNotifyFiles();
-  syncClaudeNotifySources(paths);
+  if (generation !== claudeNotifyBridgeGeneration) return;
+  await syncClaudeNotifySources(paths, generation);
+  if (generation !== claudeNotifyBridgeGeneration) return;
   try {
-    const watchList = paths.map((p) => `${p}${fs.existsSync(p) ? "" : " (missing)"}`);
+    const watchList = await Promise.all(paths.map(async (p) => {
+      try {
+        const st = await fsp.stat(p);
+        return `${p}${st.isFile() ? "" : " (missing)"}`;
+      } catch {
+        return `${p} (missing)`;
+      }
+    }));
+    if (generation !== claudeNotifyBridgeGeneration) return;
     logClaudeNotification(`notify bridge watch=${watchList.join(" | ") || "none"}`);
   } catch {}
   if (claudeNotifyTimer) return;
@@ -750,6 +781,7 @@ export async function startClaudeNotificationBridge(getWindow: () => BrowserWind
  * 中文说明：停止 Claude 通知桥接。
  */
 export function stopClaudeNotificationBridge(): void {
+  claudeNotifyBridgeGeneration += 1;
   if (claudeNotifyTimer) {
     try { clearInterval(claudeNotifyTimer); } catch {}
   }

--- a/electron/codex/config.test.ts
+++ b/electron/codex/config.test.ts
@@ -150,6 +150,28 @@ afterEach(() => {
 });
 
 describe("electron/codex/config（tui 通知配置修复）", () => {
+  it("读取 config.toml 失败时不应覆盖现有配置", async () => {
+    const { home, cleanup } = createTempHome();
+    try {
+      const original = "model = \"test-model\"\n";
+      writeCodexConfigToml(home, original);
+      const configPath = path.join(home, ".codex", "config.toml");
+      const readFile = fs.promises.readFile.bind(fs.promises);
+      vi.spyOn(fs.promises, "readFile").mockImplementation(async (...args: Parameters<typeof fs.promises.readFile>) => {
+        if (path.resolve(String(args[0])) === path.resolve(configPath))
+          throw Object.assign(new Error("read denied"), { code: "EACCES" });
+        return await (readFile as any)(...args);
+      });
+
+      const mod = await loadConfigModule("codex 0.133.0");
+      await mod.ensureAllCodexNotifications();
+
+      expect(readCodexConfigToml(home)).toBe(original);
+    } finally {
+      cleanup();
+    }
+  });
+
   it("新版 Codex：使用 Stop/SubagentStop hooks 并移除 CodexFlow 旧 notify", async () => {
     const { home, cleanup } = createTempHome();
     try {

--- a/electron/codex/config.ts
+++ b/electron/codex/config.ts
@@ -1,7 +1,7 @@
 ﻿// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
-import fs from "node:fs";
+import { promises as fsp } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { createHash } from "node:crypto";
@@ -1110,16 +1110,17 @@ function resolveCodexNotifyCommandSpec(configPath: string): CodexNotifyCommandSp
 /**
  * 中文说明：仅在内容变化时写入文本文件，避免无意义覆盖。
  */
-function writeTextFileIfChanged(filePath: string, content: string): { ok: boolean; changed: boolean } {
+async function writeTextFileIfChanged(filePath: string, content: string): Promise<{ ok: boolean; changed: boolean }> {
+  let current: string;
   try {
-    if (fs.existsSync(filePath)) {
-      const current = fs.readFileSync(filePath, "utf8");
-      if (current === content) return { ok: true, changed: false };
-    }
-  } catch {}
+    current = await fsp.readFile(filePath, "utf8");
+    if (current === content) return { ok: true, changed: false };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") return { ok: false, changed: false };
+  }
   try {
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(filePath, content, "utf8");
+    await fsp.mkdir(path.dirname(filePath), { recursive: true });
+    await fsp.writeFile(filePath, content, "utf8");
     return { ok: true, changed: true };
   } catch {
     return { ok: false, changed: false };
@@ -1129,8 +1130,8 @@ function writeTextFileIfChanged(filePath: string, content: string): { ok: boolea
 /**
  * 中文说明：确保 Codex notify hook 脚本存在且内容最新。
  */
-function ensureCodexNotifyScript(spec: CodexNotifyCommandSpec, source?: string): boolean {
-  const result = writeTextFileIfChanged(spec.scriptPath, spec.scriptBody);
+async function ensureCodexNotifyScript(spec: CodexNotifyCommandSpec, source?: string): Promise<boolean> {
+  const result = await writeTextFileIfChanged(spec.scriptPath, spec.scriptBody);
   if (!result.ok) {
     try { perfLogger.log(`[codex.config] write notify script failed path=${spec.scriptPath} source=${source || "n/a"}`); } catch {}
     return false;
@@ -1251,8 +1252,8 @@ function removeCodexFlowRootNotifyCommand(normalized: string): NormalizeResult {
 /**
  * 中文说明：确保 Codex 新 lifecycle hook 脚本存在且内容最新。
  */
-function ensureCodexHookScript(spec: CodexHookCommandSpec, source?: string): boolean {
-  const result = writeTextFileIfChanged(spec.scriptPath, spec.scriptBody);
+async function ensureCodexHookScript(spec: CodexHookCommandSpec, source?: string): Promise<boolean> {
+  const result = await writeTextFileIfChanged(spec.scriptPath, spec.scriptBody);
   if (!result.ok) {
     try { perfLogger.log(`[codex.config] write lifecycle hook script failed path=${spec.scriptPath} source=${source || "n/a"}`); } catch {}
     return false;
@@ -1610,18 +1611,21 @@ async function ensureNotificationsAtConfigTarget(target: CodexConfigTarget): Pro
   const configPath = target.path;
   const source = target.source;
   if (!configPath) return false;
-  try { fs.mkdirSync(path.dirname(configPath), { recursive: true }); } catch {}
+  try { await fsp.mkdir(path.dirname(configPath), { recursive: true }); } catch {}
 
   let original = "";
   let existed = false;
   try {
-    if (fs.existsSync(configPath)) {
-      original = fs.readFileSync(configPath, "utf8");
-      existed = true;
-    }
+    original = await fsp.readFile(configPath, "utf8");
+    existed = true;
   } catch (error) {
-    try { perfLogger.log(`[codex.config] read failed path=${configPath} source=${source || "n/a"} error=${String(error)}`); } catch {}
-    return false;
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+      original = "";
+      existed = false;
+    } else {
+      try { perfLogger.log(`[codex.config] read failed path=${configPath} source=${source || "n/a"} error=${String(error)}`); } catch {}
+      return false;
+    }
   }
 
   const { normalized, newline } = normalizeLineEndings(original);
@@ -1642,7 +1646,7 @@ async function ensureNotificationsAtConfigTarget(target: CodexConfigTarget): Pro
         supportsSubagentStop: installedLifecycleSupport.supportsSubagentStop,
       };
     const hookSpec = resolveCodexHookCommandSpec(configPath);
-    const hookScriptReady = hookSpec ? ensureCodexHookScript(hookSpec, source) : false;
+    const hookScriptReady = hookSpec ? await ensureCodexHookScript(hookSpec, source) : false;
     const notifyCleanup = removeCodexFlowRootNotifyCommand(updated);
     updated = notifyCleanup.updated;
     changed = changed || notifyCleanup.changed;
@@ -1653,7 +1657,7 @@ async function ensureNotificationsAtConfigTarget(target: CodexConfigTarget): Pro
     }
   } else {
     const notifySpec = resolveCodexNotifyCommandSpec(configPath);
-    const notifyScriptReady = notifySpec ? ensureCodexNotifyScript(notifySpec, source) : false;
+    const notifyScriptReady = notifySpec ? await ensureCodexNotifyScript(notifySpec, source) : false;
     const hookCleanup = removeCodexFlowLifecycleHookBlocks(updated.length > 0 ? updated.split("\n") : []);
     const stateCleanup = removeCodexFlowLifecycleHookStateBlocks(hookCleanup.lines, configPath, hookCleanup.stateRefs);
     updated = stateCleanup.lines.join("\n");
@@ -1673,7 +1677,7 @@ async function ensureNotificationsAtConfigTarget(target: CodexConfigTarget): Pro
   if (!finalContent.endsWith("\n")) finalContent += "\n";
   const serialized = newline === "\r\n" ? finalContent.replace(/\n/g, "\r\n") : finalContent;
   try {
-    fs.writeFileSync(configPath, serialized, "utf8");
+    await fsp.writeFile(configPath, serialized, "utf8");
     try {
       perfLogger.log(`[codex.config] ensure notifications path=${configPath} source=${source || "n/a"} mode=${configMode} version=${support.version || "n/a"} changed=${changed ? "1" : "0"}`);
     } catch {}

--- a/electron/codex/notifications.test.ts
+++ b/electron/codex/notifications.test.ts
@@ -178,4 +178,24 @@ describe("electron/codex/notifications（子代理 legacy notify 防重）", () 
     expect(result.dropReason).toBeUndefined();
     expect(result.payload.completionKind).toBe("agent");
   });
+
+  it("WSL UNC 通知不应在主线程同步查询 Codex SQLite 状态", () => {
+    let called = false;
+    __testing.setCodexNotifyStateDecisionReader(() => {
+      called = true;
+      return { dropReason: "unexpected-state-query" };
+    });
+
+    const result = __testing.buildCodexNotifyDispatch({
+      v: 1,
+      providerId: "codex",
+      tabId: "tab-1",
+      envLabel: "WSL",
+      threadId: "thread-wsl",
+      preview: "legacy 完成通知",
+    }, 1_000, "\\\\wsl.localhost\\Ubuntu\\home\\user\\.codex\\codexflow_after_agent_notify.jsonl");
+
+    expect(called).toBe(false);
+    expect(result.dropReason).toBeUndefined();
+  });
 });

--- a/electron/codex/notifications.ts
+++ b/electron/codex/notifications.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
-import fs from "node:fs";
+import { promises as fsp } from "node:fs";
 import path from "node:path";
 import { BrowserWindow } from "electron";
 import { perfLogger } from "../log";
@@ -71,6 +71,7 @@ const recentCodexSubagentNotifies: RecentCodexSubagentNotify[] = [];
 let codexNotifyTimer: NodeJS.Timeout | null = null;
 let codexNotifyPolling = false;
 let codexNotifyWindowGetter: (() => BrowserWindow | null) | null = null;
+let codexNotifyBridgeGeneration = 0;
 let codexNotifyStateDecisionReader: (entry: CodexNotifyStateEntry, sourcePath?: string) => CodexNotifyStateDecision = getCodexNotifyStateDecision;
 
 /**
@@ -121,7 +122,8 @@ async function listCodexNotifyFiles(): Promise<string[]> {
 /**
  * 中文说明：同步通知源列表，保留已有读取偏移。
  */
-function syncCodexNotifySources(paths: string[]): void {
+async function syncCodexNotifySources(paths: string[], generation = codexNotifyBridgeGeneration): Promise<void> {
+  if (generation !== codexNotifyBridgeGeneration) return;
   const normalized = new Set<string>();
   for (const p of paths) {
     const key = String(p || "").replace(/\\/g, "/").toLowerCase();
@@ -135,17 +137,18 @@ function syncCodexNotifySources(paths: string[]): void {
     }
   }
 
-  for (const p of paths) {
+  await Promise.all(paths.map(async (p) => {
     const key = String(p || "").replace(/\\/g, "/").toLowerCase();
-    if (!key || codexNotifySources.has(key)) continue;
+    if (!key || codexNotifySources.has(key)) return;
     let offset = 0;
     try {
-      const st = fs.statSync(p);
+      const st = await fsp.stat(p);
       if (st && st.isFile && st.isFile()) offset = typeof st.size === "number" ? st.size : 0;
     } catch {}
+    if (generation !== codexNotifyBridgeGeneration) return;
     codexNotifySources.set(key, { filePath: p, offset, remainder: "" });
     try { logCodexNotification(`notify source added path=${p} offset=${offset}`); } catch {}
-  }
+  }));
 }
 
 /**
@@ -176,6 +179,12 @@ function normalizeCodexNotifyPreviewForDedupe(preview: string): string {
     .replace(/\s+/g, " ")
     .trim()
     .toLowerCase();
+}
+
+/** 判断通知来源是否来自 Windows 可访问的 WSL UNC 路径。 */
+function isWslNotifySourcePath(sourcePath?: string): boolean {
+  const normalized = String(sourcePath || "").trim().replace(/\//g, "\\");
+  return /^\\\\wsl(?:\.localhost|\$)\\/i.test(normalized);
 }
 
 /**
@@ -281,7 +290,7 @@ function buildCodexNotifyDispatch(entry: CodexNotifyEntry, now = Date.now(), sou
   const explicitAgent = completionKind === "agent" || hookEventName === "Stop";
   const isLegacyNotify = !hookEventName && !completionKind;
   const legacySubagentPreview = isLegacySubagentCompletionPreview(payload.preview);
-  const stateDecision = threadId
+  const stateDecision = threadId && !isWslNotifySourcePath(sourcePath)
     ? codexNotifyStateDecisionReader({ threadId, cwd, sqliteHome }, sourcePath)
     : {};
 
@@ -312,9 +321,9 @@ function buildCodexNotifyDispatch(entry: CodexNotifyEntry, now = Date.now(), sou
 /**
  * 中文说明：从通知文件读取新增内容并解析为事件列表。
  */
-function readCodexNotifyEntries(source: CodexNotifySource): CodexNotifyEntry[] {
+async function readCodexNotifyEntries(source: CodexNotifySource): Promise<CodexNotifyEntry[]> {
   try {
-    const st = fs.statSync(source.filePath);
+    const st = await fsp.stat(source.filePath);
     if (!st || !st.isFile || !st.isFile()) return [];
     const size = typeof st.size === "number" ? st.size : 0;
     if (size < source.offset) {
@@ -332,12 +341,16 @@ function readCodexNotifyEntries(source: CodexNotifySource): CodexNotifyEntry[] {
       logCodexNotification(`notify tail read: path=${source.filePath} len=${length}`);
     }
 
-    const fd = fs.openSync(source.filePath, "r");
+    const fd = await fsp.open(source.filePath, "r");
     const buf = Buffer.alloc(length);
-    try { fs.readSync(fd, buf, 0, length, start); } finally { try { fs.closeSync(fd); } catch {} }
-    source.offset = start + length;
+    let bytesRead = 0;
+    try {
+      const result = await fd.read(buf, 0, length, start);
+      bytesRead = result.bytesRead;
+    } finally { try { await fd.close(); } catch {} }
+    source.offset = start + bytesRead;
 
-    const text = source.remainder + buf.toString("utf8");
+    const text = source.remainder + buf.subarray(0, bytesRead).toString("utf8");
     const lines = text.split(/\r?\n/);
     source.remainder = lines.pop() || "";
     const out: CodexNotifyEntry[] = [];
@@ -357,6 +370,7 @@ function readCodexNotifyEntries(source: CodexNotifySource): CodexNotifyEntry[] {
 function emitCodexNotify(entry: CodexNotifyEntry, sourcePath?: string): void {
   const win = codexNotifyWindowGetter ? codexNotifyWindowGetter() : null;
   try {
+    // 快速刷新只入队并异步扫描近期文件，不会在当前调用栈执行文件 I/O。
     requestHistoryFastRefresh({
       providerId: "codex",
       sourcePath,
@@ -383,15 +397,21 @@ function emitCodexNotify(entry: CodexNotifyEntry, sourcePath?: string): void {
  */
 async function pollCodexNotifyFiles(): Promise<void> {
   if (codexNotifyPolling) return;
+  const generation = codexNotifyBridgeGeneration;
   codexNotifyPolling = true;
   try {
     for (const source of Array.from(codexNotifySources.values())) {
-      const entries = readCodexNotifyEntries(source);
+      if (generation !== codexNotifyBridgeGeneration) return;
+      const entries = await readCodexNotifyEntries(source);
+      if (generation !== codexNotifyBridgeGeneration) return;
       if (!entries.length) continue;
-      for (const entry of entries) emitCodexNotify(entry, source.filePath);
+      for (const entry of entries) {
+        if (generation !== codexNotifyBridgeGeneration) return;
+        emitCodexNotify(entry, source.filePath);
+      }
     }
   } finally {
-    codexNotifyPolling = false;
+    if (generation === codexNotifyBridgeGeneration) codexNotifyPolling = false;
   }
 }
 
@@ -399,11 +419,22 @@ async function pollCodexNotifyFiles(): Promise<void> {
  * 中文说明：启动 Codex 通知桥接（重复调用只刷新源列表）。
  */
 export async function startCodexNotificationBridge(getWindow: () => BrowserWindow | null): Promise<void> {
+  const generation = codexNotifyBridgeGeneration;
   codexNotifyWindowGetter = getWindow;
   const paths = await listCodexNotifyFiles();
-  syncCodexNotifySources(paths);
+  if (generation !== codexNotifyBridgeGeneration) return;
+  await syncCodexNotifySources(paths, generation);
+  if (generation !== codexNotifyBridgeGeneration) return;
   try {
-    const watchList = paths.map((p) => `${p}${fs.existsSync(p) ? "" : " (missing)"}`);
+    const watchList = await Promise.all(paths.map(async (p) => {
+      try {
+        const st = await fsp.stat(p);
+        return `${p}${st.isFile() ? "" : " (missing)"}`;
+      } catch {
+        return `${p} (missing)`;
+      }
+    }));
+    if (generation !== codexNotifyBridgeGeneration) return;
     logCodexNotification(`notify bridge watch=${watchList.join(" | ") || "none"}`);
   } catch {}
   if (codexNotifyTimer) return;
@@ -417,6 +448,7 @@ export async function startCodexNotificationBridge(getWindow: () => BrowserWindo
  * 中文说明：停止 Codex 通知桥接。
  */
 export function stopCodexNotificationBridge(): void {
+  codexNotifyBridgeGeneration += 1;
   if (codexNotifyTimer) {
     try { clearInterval(codexNotifyTimer); } catch {}
   }

--- a/electron/codex/notifyState.ts
+++ b/electron/codex/notifyState.ts
@@ -58,6 +58,12 @@ function normalizeText(value: unknown): string {
   return String(value || "").trim();
 }
 
+/** 判断通知来源是否来自 Windows 可访问的 WSL UNC 路径。 */
+function isWslNotifySourcePath(sourcePath?: string): boolean {
+  const normalized = normalizeText(sourcePath).replace(/\//g, "\\");
+  return /^\\\\wsl(?:\.localhost|\$)\\/i.test(normalized);
+}
+
 /** 判断文件是否存在，失败按不存在处理。 */
 function isExistingFile(filePath: string): boolean {
   try {
@@ -293,6 +299,9 @@ function readThreadGoalStatusFromDb(Database: SqliteCtor, dbPath: string, thread
 export function getCodexNotifyStateDecision(entry: CodexNotifyStateEntry, sourcePath?: string): CodexNotifyStateDecision {
   const threadId = normalizeText(entry.threadId);
   if (!threadId) return {};
+  // WSL UNC 上的 better-sqlite3 是同步调用，访问 \wsl.localhost 还可能触发数秒网络文件系统等待。
+  // WSL hook 已写入显式 completionKind；这里放弃 legacy 状态兜底，避免阻塞 Electron 主事件循环。
+  if (isWslNotifySourcePath(sourcePath)) return {};
   const Database = loadSqlite();
   if (!Database) return {};
 

--- a/electron/gemini/notifications.test.ts
+++ b/electron/gemini/notifications.test.ts
@@ -58,4 +58,30 @@ describe("electron/gemini/notifications（多行预览保真）", () => {
     expect(script).not.toContain("function collapseWs(input)");
     expect(script).not.toContain("const s = collapseWs(input);");
   });
+
+  it("读取已有 hook 脚本失败时不应改写 settings.json", async () => {
+    const root = createTempDir("gemini-notify-script-read-error-");
+    tempDirs.push(root);
+    const tmpRoot = path.join(root, "tmp");
+    const settingsPath = path.join(root, "settings.json");
+    const scriptPath = path.join(root, "hooks", "codexflow_after_agent_notify.js");
+    const originalSettings = "{\n  \"model\": \"test-model\"\n}\n";
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    fs.writeFileSync(settingsPath, originalSettings, "utf8");
+    fs.mkdirSync(path.dirname(scriptPath), { recursive: true });
+    fs.writeFileSync(scriptPath, "user-owned-hook\n", "utf8");
+
+    const readFile = fs.promises.readFile.bind(fs.promises);
+    vi.spyOn(fs.promises, "readFile").mockImplementation(async (...args: Parameters<typeof fs.promises.readFile>) => {
+      if (path.resolve(String(args[0])) === path.resolve(scriptPath))
+        throw Object.assign(new Error("read denied"), { code: "EACCES" });
+      return await (readFile as any)(...args);
+    });
+
+    const mod = await loadGeminiNotificationsModule(root);
+    await mod.ensureAllGeminiNotifications();
+
+    expect(fs.readFileSync(settingsPath, "utf8")).toBe(originalSettings);
+    expect(fs.readFileSync(scriptPath, "utf8")).toBe("user-owned-hook\n");
+  });
 });

--- a/electron/gemini/notifications.ts
+++ b/electron/gemini/notifications.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk)
 
-import fs from "node:fs";
+import { promises as fsp } from "node:fs";
 import path from "node:path";
 import { BrowserWindow } from "electron";
 import { perfLogger } from "../log";
@@ -363,6 +363,7 @@ process.exit(0);
 
 type HookItem = { type?: string; command?: string; timeout?: number };
 type HookGroup = { matcher?: string; hooks?: HookItem[] };
+type WriteFileResult = { ok: boolean; changed: boolean };
 
 /**
  * 中文说明：记录 Gemini 通知配置的调试日志。
@@ -374,37 +375,41 @@ function logGeminiNotification(message: string) {
 /**
  * 中文说明：确保目录存在。
  */
-function ensureDir(dirPath: string) {
-  try { fs.mkdirSync(dirPath, { recursive: true }); } catch {}
+async function ensureDir(dirPath: string): Promise<void> {
+  try { await fsp.mkdir(dirPath, { recursive: true }); } catch {}
 }
 
 /**
  * 中文说明：仅在内容变化时写入文件，避免无意义覆盖。
  */
-function writeFileIfChanged(filePath: string, content: string): boolean {
+async function writeFileIfChanged(filePath: string, content: string): Promise<WriteFileResult> {
   try {
-    if (fs.existsSync(filePath)) {
-      const current = fs.readFileSync(filePath, "utf8");
-      if (current === content) return false;
-    }
-  } catch {}
+    const current = await fsp.readFile(filePath, "utf8");
+    if (current === content) return { ok: true, changed: false };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") return { ok: false, changed: false };
+  }
   try {
-    ensureDir(path.dirname(filePath));
-    fs.writeFileSync(filePath, content, "utf8");
-    return true;
+    await ensureDir(path.dirname(filePath));
+    await fsp.writeFile(filePath, content, "utf8");
+    return { ok: true, changed: true };
   } catch (error) {
     logGeminiNotification(`write script failed path=${filePath} error=${String(error)}`);
-    return false;
+    return { ok: false, changed: false };
   }
 }
 
 /**
  * 中文说明：安全读取 JSON 配置；解析失败则返回 null。
  */
-function readJsonFile(filePath: string): any | null {
+async function readJsonFile(filePath: string): Promise<any | null> {
   try {
-    if (!fs.existsSync(filePath)) return {};
-    const raw = fs.readFileSync(filePath, "utf8");
+    let raw = "";
+    try {
+      raw = await fsp.readFile(filePath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") throw error;
+    }
     return raw.trim() ? JSON.parse(raw) : {};
   } catch (error) {
     logGeminiNotification(`read settings failed path=${filePath} error=${String(error)}`);
@@ -415,11 +420,11 @@ function readJsonFile(filePath: string): any | null {
 /**
  * 中文说明：将对象写回 JSON 文件（统一 2 空格缩进）。
  */
-function writeJsonFile(filePath: string, data: any): boolean {
+async function writeJsonFile(filePath: string, data: any): Promise<boolean> {
   try {
-    ensureDir(path.dirname(filePath));
+    await ensureDir(path.dirname(filePath));
     const body = JSON.stringify(data ?? {}, null, 2) + "\n";
-    fs.writeFileSync(filePath, body, "utf8");
+    await fsp.writeFile(filePath, body, "utf8");
     return true;
   } catch (error) {
     logGeminiNotification(`write settings failed path=${filePath} error=${String(error)}`);
@@ -628,12 +633,14 @@ async function ensureGeminiNotificationsAtRoot(candidate: SessionsRootCandidate)
   const command = buildGeminiHookCommand(rootPath, candidate);
   if (!command) return;
 
-  const scriptChanged = writeFileIfChanged(scriptPath, GEMINI_HOOK_SCRIPT);
-  const current = readJsonFile(settingsPath);
+  const scriptResult = await writeFileIfChanged(scriptPath, GEMINI_HOOK_SCRIPT);
+  if (!scriptResult.ok) return;
+  const scriptChanged = scriptResult.changed;
+  const current = await readJsonFile(settingsPath);
   if (current == null) return;
 
   const { next, changed } = ensureGeminiSettings(current, command);
-  const settingsChanged = changed ? writeJsonFile(settingsPath, next) : false;
+  const settingsChanged = changed ? await writeJsonFile(settingsPath, next) : false;
 
   if (scriptChanged || settingsChanged) {
     logGeminiNotification(`ensure notifications root=${rootPath} script=${scriptChanged ? "1" : "0"} settings=${settingsChanged ? "1" : "0"}`);
@@ -693,6 +700,7 @@ const geminiNotifySources = new Map<string, GeminiNotifySource>();
 let geminiNotifyTimer: NodeJS.Timeout | null = null;
 let geminiNotifyPolling = false;
 let geminiNotifyWindowGetter: (() => BrowserWindow | null) | null = null;
+let geminiNotifyBridgeGeneration = 0;
 
 /**
  * 中文说明：列出需要监听的 Gemini 通知文件路径（Windows/UNC）。
@@ -716,7 +724,8 @@ async function listGeminiNotifyFiles(): Promise<string[]> {
 /**
  * 中文说明：同步通知源列表，保留已有读取偏移。
  */
-function syncGeminiNotifySources(paths: string[]): void {
+async function syncGeminiNotifySources(paths: string[], generation = geminiNotifyBridgeGeneration): Promise<void> {
+  if (generation !== geminiNotifyBridgeGeneration) return;
   const normalized = new Set<string>();
   for (const p of paths) {
     const key = String(p || "").replace(/\\/g, "/").toLowerCase();
@@ -728,17 +737,18 @@ function syncGeminiNotifySources(paths: string[]): void {
       try { logGeminiNotification(`notify source removed path=${source.filePath}`); } catch {}
     }
   }
-  for (const p of paths) {
+  await Promise.all(paths.map(async (p) => {
     const key = String(p || "").replace(/\\/g, "/").toLowerCase();
-    if (!key || geminiNotifySources.has(key)) continue;
+    if (!key || geminiNotifySources.has(key)) return;
     let offset = 0;
     try {
-      const st = fs.statSync(p);
+      const st = await fsp.stat(p);
       if (st && st.isFile && st.isFile()) offset = typeof st.size === "number" ? st.size : 0;
     } catch {}
+    if (generation !== geminiNotifyBridgeGeneration) return;
     geminiNotifySources.set(key, { filePath: p, offset, remainder: "" });
     try { logGeminiNotification(`notify source added path=${p} offset=${offset}`); } catch {}
-  }
+  }));
 }
 
 /**
@@ -759,9 +769,9 @@ function parseGeminiNotifyLine(line: string): GeminiNotifyEntry | null {
 /**
  * 中文说明：从通知文件中读取新增内容并解析为事件列表。
  */
-function readGeminiNotifyEntries(source: GeminiNotifySource): GeminiNotifyEntry[] {
+async function readGeminiNotifyEntries(source: GeminiNotifySource): Promise<GeminiNotifyEntry[]> {
   try {
-    const st = fs.statSync(source.filePath);
+    const st = await fsp.stat(source.filePath);
     if (!st || !st.isFile || !st.isFile()) return [];
     const size = typeof st.size === "number" ? st.size : 0;
     if (size < source.offset) {
@@ -779,12 +789,16 @@ function readGeminiNotifyEntries(source: GeminiNotifySource): GeminiNotifyEntry[
       logGeminiNotification(`notify tail read: path=${source.filePath} len=${length}`);
     }
 
-    const fd = fs.openSync(source.filePath, "r");
+    const fd = await fsp.open(source.filePath, "r");
     const buf = Buffer.alloc(length);
-    try { fs.readSync(fd, buf, 0, length, start); } finally { try { fs.closeSync(fd); } catch {} }
-    source.offset = start + length;
+    let bytesRead = 0;
+    try {
+      const result = await fd.read(buf, 0, length, start);
+      bytesRead = result.bytesRead;
+    } finally { try { await fd.close(); } catch {} }
+    source.offset = start + bytesRead;
 
-    const text = source.remainder + buf.toString("utf8");
+    const text = source.remainder + buf.subarray(0, bytesRead).toString("utf8");
     const lines = text.split(/\r?\n/);
     source.remainder = lines.pop() || "";
     const out: GeminiNotifyEntry[] = [];
@@ -844,15 +858,21 @@ function emitGeminiNotify(entry: GeminiNotifyEntry, sourcePath?: string): void {
  */
 async function pollGeminiNotifyFiles(): Promise<void> {
   if (geminiNotifyPolling) return;
+  const generation = geminiNotifyBridgeGeneration;
   geminiNotifyPolling = true;
   try {
     for (const source of Array.from(geminiNotifySources.values())) {
-      const entries = readGeminiNotifyEntries(source);
+      if (generation !== geminiNotifyBridgeGeneration) return;
+      const entries = await readGeminiNotifyEntries(source);
+      if (generation !== geminiNotifyBridgeGeneration) return;
       if (!entries.length) continue;
-      for (const entry of entries) emitGeminiNotify(entry, source.filePath);
+      for (const entry of entries) {
+        if (generation !== geminiNotifyBridgeGeneration) return;
+        emitGeminiNotify(entry, source.filePath);
+      }
     }
   } finally {
-    geminiNotifyPolling = false;
+    if (generation === geminiNotifyBridgeGeneration) geminiNotifyPolling = false;
   }
 }
 
@@ -860,14 +880,22 @@ async function pollGeminiNotifyFiles(): Promise<void> {
  * 中文说明：启动 Gemini 通知桥接（重复调用只刷新源列表）。
  */
 export async function startGeminiNotificationBridge(getWindow: () => BrowserWindow | null): Promise<void> {
+  const generation = geminiNotifyBridgeGeneration;
   geminiNotifyWindowGetter = getWindow;
   const paths = await listGeminiNotifyFiles();
-  syncGeminiNotifySources(paths);
+  if (generation !== geminiNotifyBridgeGeneration) return;
+  await syncGeminiNotifySources(paths, generation);
+  if (generation !== geminiNotifyBridgeGeneration) return;
   try {
-    const watchList = paths.map((p) => {
-      const exists = fs.existsSync(p);
-      return `${p}${exists ? "" : " (missing)"}`;
-    });
+    const watchList = await Promise.all(paths.map(async (p) => {
+      try {
+        const st = await fsp.stat(p);
+        return `${p}${st.isFile() ? "" : " (missing)"}`;
+      } catch {
+        return `${p} (missing)`;
+      }
+    }));
+    if (generation !== geminiNotifyBridgeGeneration) return;
     logGeminiNotification(`notify bridge watch=${watchList.join(" | ") || "none"}`);
   } catch {}
   if (geminiNotifyTimer) return;
@@ -881,6 +909,7 @@ export async function startGeminiNotificationBridge(getWindow: () => BrowserWind
  * 中文说明：停止 Gemini 通知桥接。
  */
 export function stopGeminiNotificationBridge(): void {
+  geminiNotifyBridgeGeneration += 1;
   if (geminiNotifyTimer) {
     try { clearInterval(geminiNotifyTimer); } catch {}
   }

--- a/electron/indexer.test.ts
+++ b/electron/indexer.test.ts
@@ -91,6 +91,40 @@ async function createCodexSessionFile(lines: unknown[]): Promise<string> {
 }
 
 describe("electron/indexer Codex preview", () => {
+  it("停止索引器前会完成异步缓存刷盘且不持久化消息正文", async () => {
+    const filePath = await createCodexSessionFile([
+      {
+        timestamp: "2026-04-29T03:35:01.000Z",
+        type: "session_meta",
+        payload: {
+          id: "session-index-persist",
+          cwd: "/workspace/project",
+        },
+      },
+      {
+        timestamp: "2026-04-29T03:35:02.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "验证索引缓存异步刷盘" }],
+        },
+      },
+    ]);
+
+    await startHistoryIndexer(() => null);
+    await stopHistoryIndexer();
+
+    const index = JSON.parse(await fsp.readFile(path.join(userDataDir, "history.index.v16.json"), "utf8"));
+    const details = JSON.parse(await fsp.readFile(path.join(userDataDir, "history.details.v16.json"), "utf8"));
+    const detailEntry = Object.values(details.files as Record<string, any>)
+      .find((entry: any) => entry?.details?.filePath === filePath) as any;
+
+    expect(Number.isFinite(index.savedAt)).toBe(true);
+    expect(Number.isFinite(details.savedAt)).toBe(true);
+    expect(detailEntry?.details?.messages).toEqual([]);
+  });
+
   it("索引摘要优先使用 thread_name_updated 并跳过 Files mentioned 模板标题", async () => {
     const filePath = await createCodexSessionFile([
       {

--- a/electron/indexer.ts
+++ b/electron/indexer.ts
@@ -117,6 +117,16 @@ type FastRefreshState = {
   pendingFiles: Map<string, FastRefreshFileEntry>;
   pendingRoots: Map<string, FastRefreshRootEntry>;
 };
+
+type PersistWriteState = {
+  timer: NodeJS.Immediate | null;
+  running: boolean;
+  pendingIndex: boolean;
+  pendingDetails: boolean;
+  index?: PersistIndex;
+  details?: PersistDetails;
+  waiters: Array<() => void>;
+};
 type HistoryFastRefreshRequest = {
   providerId?: ProviderId | string;
   filePath?: string;
@@ -187,6 +197,156 @@ function clearFastRefreshState(): void {
       pendingRoots: new Map<string, FastRefreshRootEntry>(),
     } as FastRefreshState;
   } catch {}
+}
+
+/**
+ * 获取索引缓存持久化队列状态。
+ */
+function getPersistWriteState(): PersistWriteState {
+  if (!g.__indexer) g.__indexer = {};
+  if (!g.__indexer.persistWriteState) {
+    g.__indexer.persistWriteState = {
+      timer: null,
+      running: false,
+      pendingIndex: false,
+      pendingDetails: false,
+      waiters: [],
+    } as PersistWriteState;
+  }
+  return g.__indexer.persistWriteState as PersistWriteState;
+}
+
+/**
+ * 将索引缓存写入任务合并到下一轮事件循环，避免同一批变更重复序列化大文件。
+ */
+function schedulePersistWrite(index?: PersistIndex, details?: PersistDetails): void {
+  const state = getPersistWriteState();
+  if (index) {
+    state.pendingIndex = true;
+    state.index = index;
+  }
+  if (details) {
+    state.pendingDetails = true;
+    state.details = details;
+  }
+  schedulePersistFlush();
+}
+
+/** 安排一次缓存持久化队列处理，不重复创建事件循环任务。 */
+function schedulePersistFlush(): void {
+  const state = getPersistWriteState();
+  if (state.timer || state.running) return;
+  state.timer = setImmediate(() => {
+    state.timer = null;
+    void flushPersistWrites();
+  });
+}
+
+/** 让出一次事件循环，避免缓存序列化连续占用主线程。 */
+function yieldPersistSerialization(): Promise<void> {
+  return new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+/** 分段序列化索引缓存，避免对整个大对象执行一次长时间 JSON.stringify。 */
+async function serializeIndexForPersist(index: PersistIndex): Promise<string> {
+  const parts: string[] = [
+    "{\"version\":",
+    JSON.stringify(String(index.version || VERSION)),
+    ",\"files\":{"
+  ];
+  const entries = Object.entries(index.files || {});
+  let first = true;
+  for (let i = 0; i < entries.length; i += 1) {
+    const [key, value] = entries[i];
+    let serialized = "null";
+    try { serialized = JSON.stringify(value) ?? "null"; } catch {}
+    if (!first) parts.push(",");
+    first = false;
+    parts.push(JSON.stringify(key), ":", serialized);
+    if ((i + 1) % 32 === 0) await yieldPersistSerialization();
+  }
+  const savedAt = Number(index.savedAt);
+  parts.push("},\"savedAt\":", String(Number.isFinite(savedAt) ? savedAt : 0), "}");
+  return parts.join("");
+}
+
+/** 分段序列化详情缓存，并在每个条目内移除完整消息正文。 */
+async function serializeDetailsForPersist(details: PersistDetails): Promise<string> {
+  const parts: string[] = [
+    "{\"version\":",
+    JSON.stringify(VERSION),
+    ",\"files\":{"
+  ];
+  const entries = Object.entries(details.files || {});
+  let first = true;
+  for (let i = 0; i < entries.length; i += 1) {
+    const [key, entry] = entries[i];
+    if (!entry || !entry.details || !entry.sig) continue;
+    const normalizedEntry = { sig: entry.sig, details: stripDetailsForPersist(entry.details) };
+    let serialized = "null";
+    try { serialized = JSON.stringify(normalizedEntry) ?? "null"; } catch {}
+    if (!first) parts.push(",");
+    first = false;
+    parts.push(JSON.stringify(key), ":", serialized);
+    if ((i + 1) % 32 === 0) await yieldPersistSerialization();
+  }
+  const rawSavedAt = Number(details.savedAt);
+  const savedAt = Number.isFinite(rawSavedAt) && rawSavedAt > 0 ? rawSavedAt : Date.now();
+  parts.push("},\"savedAt\":", String(savedAt), "}");
+  return parts.join("");
+}
+
+/**
+ * 串行异步写入索引和详情缓存；调用方可等待该函数确保退出前刷盘完成。
+ */
+async function flushPersistWrites(): Promise<void> {
+  const state = getPersistWriteState();
+  if (state.running) {
+    await new Promise<void>((resolve) => state.waiters.push(resolve));
+    // 当前批次结束时可能又合并了新的变更；等待方必须把后续批次也刷完。
+    if (state.pendingIndex || state.pendingDetails) await flushPersistWrites();
+    return;
+  }
+  if (!state.pendingIndex && !state.pendingDetails) return;
+  if (state.timer) {
+    try { clearImmediate(state.timer); } catch {}
+    state.timer = null;
+  }
+  state.running = true;
+  try {
+    while (state.pendingIndex || state.pendingDetails) {
+      const writeIndex = state.pendingIndex;
+      const writeDetails = state.pendingDetails;
+      state.pendingIndex = false;
+      state.pendingDetails = false;
+
+      // 先让出一次事件循环，确保通知 IPC 和终端输出优先处理。
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const tasks: Promise<unknown>[] = [];
+      if (writeIndex && state.index) {
+        const currentIndex = state.index;
+        tasks.push(serializeIndexForPersist(currentIndex)
+          .then((body) => fsp.mkdir(path.dirname(indexPath()), { recursive: true })
+            .then(() => fsp.writeFile(indexPath(), body, "utf8")))
+          .catch(() => undefined));
+      }
+      if (writeDetails && state.details) {
+        const currentDetails = state.details;
+        tasks.push(serializeDetailsForPersist(currentDetails)
+          .then((body) => fsp.mkdir(path.dirname(detailsPath()), { recursive: true })
+            .then(() => fsp.writeFile(detailsPath(), body, "utf8")))
+          .catch(() => undefined));
+      }
+      if (tasks.length > 0) await Promise.all(tasks);
+    }
+  } finally {
+    state.running = false;
+    const waiters = state.waiters.splice(0, state.waiters.length);
+    for (const resolve of waiters) {
+      try { resolve(); } catch {}
+    }
+    if (state.pendingIndex || state.pendingDetails) schedulePersistFlush();
+  }
 }
 
 /**
@@ -332,54 +492,52 @@ function idxLog(msg: string) {
   } catch {}
 }
 
-function loadIndex(): PersistIndex {
+async function loadIndex(): Promise<PersistIndex> {
   try {
     const p = indexPath();
-    if (!fs.existsSync(p)) return { version: VERSION, files: {}, savedAt: 0 };
-    const obj = JSON.parse(fs.readFileSync(p, "utf8"));
+    const raw = await fsp.readFile(p, "utf8").catch(() => "");
+    if (!raw) return { version: VERSION, files: {}, savedAt: 0 };
+    const obj = JSON.parse(raw);
     return { version: VERSION, files: obj.files || {}, savedAt: Number(obj.savedAt || 0) } as PersistIndex;
   } catch { return { version: VERSION, files: {}, savedAt: 0 }; }
 }
 
-function saveIndex(ix: PersistIndex) {
-  try { fs.writeFileSync(indexPath(), JSON.stringify(ix, null, 2), "utf8"); } catch {}
+/**
+ * 请求异步保存索引缓存，不在当前调用栈执行文件 I/O。
+ */
+function saveIndex(ix: PersistIndex): void {
+  try { schedulePersistWrite(ix, undefined); } catch {}
 }
 
-function loadDetails(): PersistDetails {
+async function loadDetails(): Promise<PersistDetails> {
   try {
     const p = detailsPath();
-    if (!fs.existsSync(p)) return { version: VERSION, files: {}, savedAt: 0 };
-    const obj = JSON.parse(fs.readFileSync(p, "utf8")) as any;
+    const raw = await fsp.readFile(p, "utf8").catch(() => "");
+    if (!raw) return { version: VERSION, files: {}, savedAt: 0 };
+    const obj = JSON.parse(raw) as any;
     const normalized: PersistDetails = { version: VERSION, files: {}, savedAt: Number(obj.savedAt || 0) };
     let trimmed = false;
     const files = (obj && obj.files) ? obj.files as Record<string, { sig: FileSig; details: Details }> : {};
     for (const [k, entry] of Object.entries(files)) {
       if (!entry || !entry.details || !entry.sig) continue;
-      const slim = stripDetailsForPersist(entry.details);
-      if (Array.isArray((entry.details as any).messages) && (entry.details as any).messages.length > 0) {
+      if (Array.isArray((entry.details as any).messages) && (entry.details as any).messages.length > 0)
         trimmed = true;
-      }
+      const slim = stripDetailsForPersist(entry.details);
       normalized.files[k] = { sig: entry.sig, details: slim };
     }
     if (trimmed) {
+      // 兼容旧版含正文的缓存：先在内存裁剪，再异步回写，避免每次启动重复读取大正文。
       try { saveDetails(normalized); } catch {}
     }
     return normalized;
   } catch { return { version: VERSION, files: {}, savedAt: 0 }; }
 }
 
-function saveDetails(d: PersistDetails) {
-  try {
-    const normalized: PersistDetails = { version: VERSION, files: {}, savedAt: Number(d.savedAt || Date.now()) };
-    const entries = d.files || {};
-    for (const [k, entry] of Object.entries(entries)) {
-      if (!entry || !entry.details || !entry.sig) continue;
-      normalized.files[k] = { sig: entry.sig, details: stripDetailsForPersist(entry.details) };
-    }
-    fs.writeFileSync(detailsPath(), JSON.stringify(normalized, null, 2), "utf8");
-    d.files = normalized.files;
-    d.savedAt = normalized.savedAt;
-  } catch {}
+/**
+ * 请求异步保存详情缓存，并在队列中统一去除消息正文。
+ */
+function saveDetails(d: PersistDetails): void {
+  try { schedulePersistWrite(undefined, d); } catch {}
 }
 
 // 并发限制器
@@ -500,7 +658,6 @@ function resolveAccessibleHistoryFilePath(filePath: string, sourcePath?: string)
   try {
     const raw = String(filePath || "").trim();
     if (!raw) return "";
-    if (fs.existsSync(raw)) return raw;
     if (raw.startsWith("/") && sourcePath && isUNCPath(sourcePath)) {
       const info = uncToWsl(sourcePath);
       if (info?.distro) {
@@ -1381,8 +1538,8 @@ export async function startHistoryIndexer(getWindow: () => BrowserWindow | null)
       perfLogger.log(`[indexer] cacheVersion=${VERSION} userData=${JSON.stringify(getUserDataDir())}`);
       if (removedLegacyPersistFiles.length > 0) perfLogger.log(`[indexer] purgedLegacyCaches=${JSON.stringify(removedLegacyPersistFiles)}`);
     }
-    g.__indexer.index = loadIndex();
-    g.__indexer.details = loadDetails();
+    g.__indexer.index = await loadIndex();
+    g.__indexer.details = await loadDetails();
     try { getDetailsCache().clear(); } catch {}
     try { clearFastRefreshState(); } catch {}
 
@@ -1591,8 +1748,9 @@ export async function startHistoryIndexer(getWindow: () => BrowserWindow | null)
     const geminiHashToCwd = new Map<string, string>();
     try {
       const projectsPath = path.join(getUserDataDir(), "projects.json");
-      if (fs.existsSync(projectsPath)) {
-        const raw = JSON.parse(fs.readFileSync(projectsPath, "utf8")) as any;
+      const rawText = await fsp.readFile(projectsPath, "utf8").catch(() => "");
+      if (rawText) {
+        const raw = JSON.parse(rawText) as any;
         const items: any[] = Array.isArray(raw) ? raw : [];
         /**
          * 将项目路径注册进 `hash -> cwd` 映射（用于 Gemini 会话缺失 cwd 时的归属与继续对话）。
@@ -2236,5 +2394,6 @@ export async function stopHistoryIndexer(): Promise<void> {
   try { clearRescanCooldown(); } catch {}
   try { clearWatchQueueState(); } catch {}
   try { clearFastRefreshState(); } catch {}
+  try { await flushPersistWrites(); } catch {}
   try { setIndexerWindowGetter(null); } catch {}
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -245,6 +245,18 @@ let DIAG = false;
 let quitConfirmed = false;
 let quitConfirming = false;
 let gpuFallbackActive = false;
+
+type SettingsMaintenanceRequest = {
+  configureProxy: boolean;
+  notifications: boolean;
+  restartIndexer: boolean;
+  refreshCodexAccount: boolean;
+};
+
+let pendingSettingsMaintenance: SettingsMaintenanceRequest | null = null;
+let settingsMaintenanceTimer: NodeJS.Timeout | null = null;
+let settingsMaintenanceRunning = false;
+let settingsMaintenanceStopping = false;
 const MAIN_APP_WINDOW_ID = "main";
 const appWindowMetaByWindow = new WeakMap<BrowserWindow, { windowId: string; windowMode: AppWindowMode }>();
 const rendererRecoveryClosingWindows = new WeakSet<BrowserWindow>();
@@ -1605,6 +1617,97 @@ async function maybeAutoBackupCodexAuthJsonOnAccountRefresh(info: any, runtime: 
   } catch {}
 }
 
+/**
+ * 合并设置变更后的后台维护请求，避免连续保存设置时重复探测 WSL 和重启索引器。
+ */
+function scheduleSettingsMaintenance(request: Partial<SettingsMaintenanceRequest> = {}): void {
+  if (settingsMaintenanceStopping) return;
+  const previous = pendingSettingsMaintenance || {
+    configureProxy: false,
+    notifications: false,
+    restartIndexer: false,
+    refreshCodexAccount: false,
+  };
+  pendingSettingsMaintenance = {
+    configureProxy: previous.configureProxy || request.configureProxy === true,
+    notifications: previous.notifications || request.notifications === true,
+    restartIndexer: previous.restartIndexer || request.restartIndexer === true,
+    refreshCodexAccount: previous.refreshCodexAccount || request.refreshCodexAccount === true,
+  };
+  if (settingsMaintenanceTimer || settingsMaintenanceRunning) return;
+  settingsMaintenanceTimer = setTimeout(() => {
+    settingsMaintenanceTimer = null;
+    void flushSettingsMaintenance();
+  }, 0);
+}
+
+/**
+ * 停止接收设置维护任务，并清除尚未开始的后台工作。
+ */
+function stopSettingsMaintenance(): void {
+  settingsMaintenanceStopping = true;
+  pendingSettingsMaintenance = null;
+  if (!settingsMaintenanceTimer) return;
+  try { clearTimeout(settingsMaintenanceTimer); } catch {}
+  settingsMaintenanceTimer = null;
+}
+
+/**
+ * 在后台执行代理、通知桥和索引器维护，不让 settings IPC 等待外部文件或 WSL 操作。
+ */
+async function flushSettingsMaintenance(): Promise<void> {
+  if (settingsMaintenanceStopping) return;
+  if (settingsMaintenanceRunning) return;
+  if (!pendingSettingsMaintenance) return;
+  settingsMaintenanceRunning = true;
+  try {
+    while (pendingSettingsMaintenance && !settingsMaintenanceStopping) {
+      const request = pendingSettingsMaintenance;
+      pendingSettingsMaintenance = null;
+      if (request.configureProxy) {
+        try { await configureOrUpdateProxy(); } catch {}
+      }
+      if (request.notifications && !settingsMaintenanceStopping) {
+        await Promise.allSettled([
+          ensureAllCodexNotifications(),
+          ensureAllClaudeNotifications(),
+          ensureAllGeminiNotifications(),
+          ensureAllAntigravityNotifications(),
+        ]);
+        if (!settingsMaintenanceStopping) {
+          await Promise.allSettled([
+            startCodexNotificationBridge(() => mainWindow),
+            startClaudeNotificationBridge(() => mainWindow),
+            startGeminiNotificationBridge(() => mainWindow),
+            startAntigravityNotificationBridge(() => mainWindow),
+          ]);
+        }
+      }
+      if (request.refreshCodexAccount && !settingsMaintenanceStopping) {
+        try {
+          const runtime = deriveCodexBridgeDescriptor(settings.getSettings());
+          const bridge = ensureCodexBridge();
+          const info = await bridge.getAccountInfo(true);
+          await maybeAutoBackupCodexAuthJsonOnAccountRefresh(info, runtime);
+        } catch {}
+      }
+      if (request.restartIndexer && !settingsMaintenanceStopping) {
+        try {
+          await startHistoryIndexer(() => mainWindow);
+          if (settingsMaintenanceStopping) {
+            await stopHistoryIndexer();
+          } else {
+            try { mainWindow?.webContents.send("history:index:invalidate", { reason: "settings" }); } catch {}
+          }
+        } catch {}
+      }
+    }
+  } finally {
+    settingsMaintenanceRunning = false;
+    if (pendingSettingsMaintenance && !settingsMaintenanceStopping) scheduleSettingsMaintenance();
+  }
+}
+
 // 统一配置/更新全局代理（支持：自定义/系统代理；并同步给 CLI 及 WSL 环境变量）
 let appliedProxySig = "";
 function redactProxy(uri: string): string {
@@ -2775,8 +2878,22 @@ if (!gotLock) {
     })();
   });
 
+  let indexerStopPromise: Promise<void> | null = null;
+
+  /** 复用同一个索引器停止任务，确保退出流程等待异步缓存刷盘完成。 */
+  const stopIndexerAndWait = (): Promise<void> => {
+    if (!indexerStopPromise) {
+      try {
+        indexerStopPromise = stopHistoryIndexer().catch(() => {});
+      } catch {
+        indexerStopPromise = Promise.resolve();
+      }
+    }
+    return indexerStopPromise;
+  };
+
   const tryStopIndexer = () => {
-    try { stopHistoryIndexer().catch(() => {}); } catch {}
+    void stopIndexerAndWait();
   };
 
   app.on('before-quit', (event) => {
@@ -2807,6 +2924,7 @@ if (!gotLock) {
         }
       }
     } catch {}
+    stopSettingsMaintenance();
     disposeAllPtys();
     cleanupPastedImages().catch(() => {});
     disposeCodexBridges();
@@ -2819,6 +2937,7 @@ if (!gotLock) {
   });
 
   app.on('will-quit', () => {
+    stopSettingsMaintenance();
     try { stopCodexNotificationBridge(); } catch {}
     try { stopClaudeNotificationBridge(); } catch {}
     try { stopGeminiNotificationBridge(); } catch {}
@@ -2834,19 +2953,38 @@ if (!gotLock) {
   });
 
   // Also hook process-level events so that when Node receives termination signals we attempt cleanup.
-  process.on('exit', () => { disposeAllPtys(); disposeCodexBridges(); try { unregisterNotificationIPC({ closeNotifications: true }); } catch {}; tryStopIndexer(); try { unwatchDebugConfig(); } catch {}; });
-  process.on('SIGINT', () => { disposeAllPtys(); cleanupPastedImages().catch(() => {}); disposeCodexBridges(); try { unregisterNotificationIPC({ closeNotifications: true }); } catch {}; tryStopIndexer(); try { unwatchDebugConfig(); } catch {}; process.exit(0); });
-  process.on('SIGTERM', () => { disposeAllPtys(); cleanupPastedImages().catch(() => {}); disposeCodexBridges(); try { unregisterNotificationIPC({ closeNotifications: true }); } catch {}; tryStopIndexer(); try { unwatchDebugConfig(); } catch {}; process.exit(0); });
+  process.on('exit', () => { stopSettingsMaintenance(); disposeAllPtys(); disposeCodexBridges(); try { unregisterNotificationIPC({ closeNotifications: true }); } catch {}; tryStopIndexer(); try { unwatchDebugConfig(); } catch {}; });
+  process.on('SIGINT', () => {
+    stopSettingsMaintenance();
+    disposeAllPtys();
+    cleanupPastedImages().catch(() => {});
+    disposeCodexBridges();
+    try { unregisterNotificationIPC({ closeNotifications: true }); } catch {}
+    try { unwatchDebugConfig(); } catch {}
+    void stopIndexerAndWait().finally(() => process.exit(0));
+  });
+  process.on('SIGTERM', () => {
+    stopSettingsMaintenance();
+    disposeAllPtys();
+    cleanupPastedImages().catch(() => {});
+    disposeCodexBridges();
+    try { unregisterNotificationIPC({ closeNotifications: true }); } catch {}
+    try { unwatchDebugConfig(); } catch {}
+    void stopIndexerAndWait().finally(() => process.exit(0));
+  });
   process.on('uncaughtException', (err) => {
     try { console.error('uncaughtException', err); } catch {}
     if (DIAG) { try { perfLogger.log(`[PROC] uncaughtException ${String((err as any)?.stack || err)}`); } catch {} }
+    stopSettingsMaintenance();
     disposeAllPtys();
     disposeCodexBridges();
     try { unregisterNotificationIPC({ closeNotifications: true }); } catch {}
     try { unwatchDebugConfig(); } catch {}
-    // 为避免再次被当前监听器拦截，移除所有 uncaughtException 监听后在下一轮事件循环抛出
+    // 为避免再次被当前监听器拦截，移除所有 uncaughtException 监听后等待缓存刷盘再抛出
     try { process.removeAllListeners('uncaughtException'); } catch {}
-    try { setImmediate(() => { throw err; }); } catch {}
+    void stopIndexerAndWait().finally(() => {
+      try { setImmediate(() => { throw err; }); } catch {}
+    });
   });
   if (DIAG) process.on('unhandledRejection', (reason: any) => {
     try { perfLogger.log(`[PROC] unhandledRejection ${String((reason as any)?.stack || reason)}`); } catch {}
@@ -6871,14 +7009,7 @@ ipcMain.handle('settings.get', async () => {
   const notifyRuntimeRepair = hasSavedRuntimeEnvSelection();
   try { await ensureFirstRunTerminalSelection(); } catch {}
   try { await ensureSettingsAutodetect(); } catch {}
-  try { await ensureAllCodexNotifications(); } catch {}
-  try { await ensureAllClaudeNotifications(); } catch {}
-  try { await ensureAllGeminiNotifications(); } catch {}
-  try { await ensureAllAntigravityNotifications(); } catch {}
-  try { await startCodexNotificationBridge(() => mainWindow); } catch {}
-  try { await startClaudeNotificationBridge(() => mainWindow); } catch {}
-  try { await startGeminiNotificationBridge(() => mainWindow); } catch {}
-  try { await startAntigravityNotificationBridge(() => mainWindow); } catch {}
+  scheduleSettingsMaintenance({ configureProxy: true, notifications: true });
   let cfg = settings.getSettings() as any;
   try {
     const flags = getFeatureFlags();
@@ -6990,32 +7121,13 @@ ipcMain.handle('settings.update', async (_e, partial: any) => {
       disposeCodexBridgesExcept(nextDescriptor.key);
     }
   } catch {}
-  // 设置更新后尝试刷新代理
-  try { await configureOrUpdateProxy(); } catch {}
-  try { await ensureAllCodexNotifications(); } catch {}
-  try { await ensureAllClaudeNotifications(); } catch {}
-  try { await ensureAllGeminiNotifications(); } catch {}
-  try { await ensureAllAntigravityNotifications(); } catch {}
-  try { await startCodexNotificationBridge(() => mainWindow); } catch {}
-  try { await startClaudeNotificationBridge(() => mainWindow); } catch {}
-  try { await startGeminiNotificationBridge(() => mainWindow); } catch {}
-  try { await startAntigravityNotificationBridge(() => mainWindow); } catch {}
-  // 若刚开启“记录账号”，立即刷新一次账号信息并触发初始备份（便于立刻出现在备份列表）
-  try {
-    if (!prevCodexAccountRecordEnabled && nextCodexAccountRecordEnabled) {
-      const runtime = deriveCodexBridgeDescriptor(next);
-      const bridge = ensureCodexBridge();
-      const info = await bridge.getAccountInfo(true);
-      await maybeAutoBackupCodexAuthJsonOnAccountRefresh(info, runtime);
-    }
-  } catch {}
-  // Claude Code 过滤开关变更：重启历史索引器以立即生效（包含增量移除/新增）。
-  try {
-    if (prevClaudeAgentHistory !== nextClaudeAgentHistory) {
-      startHistoryIndexer(() => mainWindow).catch(() => {});
-      try { mainWindow?.webContents.send('history:index:invalidate', { reason: 'settings' }); } catch {}
-    }
-  } catch {}
+  // 设置维护涉及 WSL/UNC 文件与外部命令，合并后放到后台执行，先返回新的设置快照。
+  scheduleSettingsMaintenance({
+    configureProxy: true,
+    notifications: true,
+    refreshCodexAccount: !prevCodexAccountRecordEnabled && nextCodexAccountRecordEnabled,
+    restartIndexer: prevClaudeAgentHistory !== nextClaudeAgentHistory,
+  });
   let merged = next as any;
   try {
     merged = await resolveVisibleSettingsRuntimeEnvs(merged);


### PR DESCRIPTION
主要修复：
- 避免 Codex 在 WSL/UNC 通知链路中同步查询 SQLite，解决回复过程卡顿。
- 异步化 Claude Code WSL hook 与通知桥读取，修复完成事件未送达导致界面不回复。
- 恢复完成通知触发历史快速刷新，减少历史侧栏更新延迟。
- 合并通知、历史缓存和设置维护任务，降低主线程阻塞。
- 增加缓存退出刷盘和配置读取失败保护，避免数据丢失或覆盖用户配置。
- 补充 Codex、Claude Code、Gemini、Antigravity 相关回归测试。

验证：
- npm run test
- npm run i18n:check
- npm run build:electron