### PR TITLE
fix(history): 修复历史详情图片出现裂图

### DIFF
--- a/electron/agentSessions/shared/historyImage.test.ts
+++ b/electron/agentSessions/shared/historyImage.test.ts
@@ -32,6 +32,14 @@ describe("electron/agentSessions/shared/historyImage", () => {
     expect(extractImagePathCandidatesFromText(text)).toEqual(["C:/demo/assets/example-image.png"]);
   });
 
+  it("提取多路径工具参数时不会把前面的非图片路径拼进图片路径", () => {
+    const text = "Get-Item -LiteralPath 'C:\\workspace\\fixtures\\notes.txt','C:\\workspace\\fixtures\\image-a.png','C:\\workspace\\fixtures\\image-b.png'";
+    expect(extractImagePathCandidatesFromText(text)).toEqual([
+      "C:\\workspace\\fixtures\\image-a.png",
+      "C:\\workspace\\fixtures\\image-b.png",
+    ]);
+  });
+
   (process.platform === "win32" ? it : it.skip)("会把 /mnt 形式的 Windows 图片路径识别为本地文件并生成 Windows 预览地址", async () => {
     const localImagePath = await createTempImageFile("mnt-history-image.png");
     const posixWinPath = localImagePath.replace(/\\/g, "/");

--- a/electron/agentSessions/shared/historyImage.ts
+++ b/electron/agentSessions/shared/historyImage.ts
@@ -16,7 +16,7 @@ export type HistoryImageContentOptions = {
   preferDataUrl?: boolean;
 };
 
-const IMAGE_PATH_PATTERN = /@?((?:[A-Za-z]:(?:\\|\/)|\/mnt\/[A-Za-z]\/|\/(?:home|root|Users)\/|\\\\[^\\\/\r\n]+\\[^\\\/\r\n]+\\)[^\r\n]*?\.(?:png|jpe?g|webp|gif|bmp|svg))/gi;
+const IMAGE_PATH_PATTERN = /@?((?:[A-Za-z]:(?:\\|\/)|\/mnt\/[A-Za-z]\/|\/(?:home|root|Users)\/|\\\\[^\\\/\r\n]+\\[^\\\/\r\n]+\\)[^\r\n"'`]*?\.(?:png|jpe?g|webp|gif|bmp|svg))/gi;
 
 /**
  * 中文说明：从文本中提取图片绝对路径候选。

--- a/electron/history.test.ts
+++ b/electron/history.test.ts
@@ -627,6 +627,61 @@ describe("electron/history.readHistoryFile", () => {
     ]);
   });
 
+  it("新版 custom_tool_call_output 会按图片顺序恢复缺失路径对应的会话图片", async () => {
+    const localImagePathA = "C:\\workspace\\fixtures\\missing-image-a.png";
+    const localImagePathB = "C:\\workspace\\fixtures\\missing-image-b.png";
+    const dataUrlA = "data:image/png;base64,QUFB";
+    const dataUrlB = "data:image/png;base64,QkJC";
+    const callId = "call-custom-image-output";
+    const escapedImagePathA = localImagePathA.replace(/\\/g, "\\\\");
+    const escapedImagePathB = localImagePathB.replace(/\\/g, "\\\\");
+    const filePath = await createHistoryJsonlFile([
+      {
+        timestamp: "2026-07-21T01:00:00.000Z",
+        type: "session_meta",
+        payload: {
+          id: "session-custom-image-output",
+          cwd: "C:\\workspace\\project",
+        },
+      },
+      {
+        timestamp: "2026-07-21T01:00:01.000Z",
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call",
+          call_id: callId,
+          name: "exec",
+          input: `Get-Item -LiteralPath 'C:\\\\workspace\\\\fixtures\\\\notes.txt','${escapedImagePathA}','${escapedImagePathB}'`,
+        },
+      },
+      {
+        timestamp: "2026-07-21T01:00:02.000Z",
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call_output",
+          call_id: callId,
+          output: [
+            { type: "input_text", text: "工具调用已完成" },
+            { type: "input_image", image_url: dataUrlA },
+            { type: "input_image", image_url: dataUrlB },
+          ],
+        },
+      },
+    ]);
+
+    const parsed = await readHistoryFile(filePath, { maxLines: 0 });
+    const imageItems = parsed.messages
+      .flatMap((message) => message.content || [])
+      .filter((item) => item.type === "image");
+    const normalizedLocalPaths = imageItems.map((item) => String(item.localPath || "").replace(/\\+/g, "\\"));
+
+    expect(imageItems).toHaveLength(2);
+    expect(normalizedLocalPaths).toEqual([localImagePathA, localImagePathB]);
+    expect(imageItems.map((item) => item.src)).toEqual([dataUrlA, dataUrlB]);
+    expect(collectTexts(parsed.messages).join("\n")).not.toContain("base64,QUFB");
+    expect(collectTexts(parsed.messages).join("\n")).not.toContain("base64,QkJC");
+  });
+
   it("会把重复的 event_msg.user_message 合并到上一条等价 user 消息，避免详情块重复", async () => {
     const localImagePath = await createTempImageFile("history-image-merged.png");
     const wslImagePath = toWslImagePath(localImagePath);

--- a/electron/history.ts
+++ b/electron/history.ts
@@ -2141,35 +2141,47 @@ export async function readHistoryFile(filePath: string, opts?: { chunkSize?: num
         } catch {}
         if (!mergePathOnlyUserMessageIntoPreviousUserMessage(userMessageEventContent))
           messages.push({ role: 'user', content: userMessageEventContent });
-      } else if (obj.type === 'function_call' || (obj.type === 'response_item' && obj.payload && obj.payload.type === 'function_call')) {
+      } else if (
+        obj.type === 'function_call'
+        || obj.type === 'custom_tool_call'
+        || (obj.type === 'response_item' && obj.payload && (obj.payload.type === 'function_call' || obj.payload.type === 'custom_tool_call'))
+      ) {
         // 工具/函数调用
         const src: any = (obj.type === 'response_item' && obj.payload) ? obj.payload : obj;
         const name = src.name || src.tool || src.function || 'function';
+        const callArguments = src.type === 'custom_tool_call' ? src.input : src.arguments;
         let argsPretty = '';
         try {
-          if (typeof src.arguments === 'string') {
-            try { argsPretty = JSON.stringify(JSON.parse(src.arguments), null, 2); }
-            catch { argsPretty = src.arguments; }
-          } else if (src.arguments) {
-            argsPretty = JSON.stringify(src.arguments, null, 2);
+          if (typeof callArguments === 'string') {
+            try { argsPretty = JSON.stringify(JSON.parse(callArguments), null, 2); }
+            catch { argsPretty = callArguments; }
+          } else if (callArguments) {
+            argsPretty = JSON.stringify(callArguments, null, 2);
           }
         } catch {}
         const text = `name: ${name}\n${argsPretty ? 'arguments:\n' + argsPretty : ''}${(src as any).call_id ? `\ncall_id: ${(src as any).call_id}` : ''}`.trim();
         rememberImagePathsFromText(text);
-        const imagePathCandidates = extractImagePathCandidatesFromFunctionCallArguments((src as any).arguments, text);
+        const imagePathCandidates = extractImagePathCandidatesFromFunctionCallArguments(callArguments, text);
         rememberImagePathsForCallId((src as any).call_id, imagePathCandidates);
         messages.push({ role: 'tool', content: [{ type: 'function_call', text, tags: ['function_call'] }] });
-      } else if (obj.type === 'function_call_output' || (obj.type === 'response_item' && obj.payload && obj.payload.type === 'function_call_output')) {
+      } else if (
+        obj.type === 'function_call_output'
+        || obj.type === 'custom_tool_call_output'
+        || (obj.type === 'response_item' && obj.payload && (obj.payload.type === 'function_call_output' || obj.payload.type === 'custom_tool_call_output'))
+      ) {
         // 工具输出
         const src: any = (obj.type === 'response_item' && obj.payload) ? obj.payload : obj;
         const contentArr: MessageContent[] = [];
         try {
           const outputItems = Array.isArray(src.output) ? src.output : [];
           const callId = String((src as any).call_id || '');
-          for (let index = 0; index < outputItems.length; index += 1) {
-            const item = outputItems[index];
-            const imageItem = createCodexImageContent(item, resolveImagePathHintForCallOutput(callId, index));
-            if (imageItem) contentArr.push(imageItem);
+          let imageIndex = 0;
+          for (const item of outputItems) {
+            const imageItem = createCodexImageContent(item, resolveImagePathHintForCallOutput(callId, imageIndex));
+            if (imageItem) {
+              contentArr.push(imageItem);
+              imageIndex += 1;
+            }
           }
         } catch {}
         let out = '';

--- a/web/src/features/history/history-inline-images.test.ts
+++ b/web/src/features/history/history-inline-images.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { toHistoryInlineImageFallbackSrc, toHistoryInlineImagePreviewSrc } from "./history-inline-images";
+import {
+  mergeHistoryInlineImageWithPathFallback,
+  toHistoryInlineImageFallbackSrc,
+  toHistoryInlineImagePreviewSrc,
+} from "./history-inline-images";
 
 describe("web/features/history/history-inline-images", () => {
   it("Windows 盘符路径会稳定映射为本地 file:///C:/ 预览地址", () => {
@@ -13,5 +17,21 @@ describe("web/features/history/history-inline-images", () => {
     const input = "/mnt/c/Users/demo/image-example.png";
     expect(toHistoryInlineImagePreviewSrc(input)).toBe("file:///mnt/c/Users/demo/image-example.png");
     expect(toHistoryInlineImageFallbackSrc(input)).toBe("file:///C:/Users/demo/image-example.png");
+  });
+
+  it("本地图片失效时会优先回退到会话内图片数据", () => {
+    const localPath = "C:\\workspace\\fixtures\\missing-image.png";
+    const dataUrl = "data:image/png;base64,QUFB";
+    const merged = mergeHistoryInlineImageWithPathFallback({
+      type: "image",
+      text: `图片\n路径: ${localPath}`,
+      src: "file:///C:/workspace/fixtures/missing-image.png",
+      fallbackSrc: dataUrl,
+      localPath,
+      mimeType: "image/png",
+    }, localPath);
+
+    expect(merged.src).toBe("file:///C:/workspace/fixtures/missing-image.png");
+    expect(merged.fallbackSrc).toBe(dataUrl);
   });
 });

--- a/web/src/features/history/history-inline-images.tsx
+++ b/web/src/features/history/history-inline-images.tsx
@@ -7,7 +7,7 @@ import { useHistoryImageContextMenu } from "@/components/history/history-image-c
 import InteractiveImagePreview from "@/components/ui/interactive-image-preview";
 import { HistoryMarkdown } from "@/features/history/renderers/history-markdown";
 
-const IMAGE_PATH_PATTERN = /@?((?:[A-Za-z]:[\\/]|\/mnt\/[A-Za-z]\/|\/(?:home|root|Users)\/|\\\\[^\\\/\r\n]+\\[^\\\/\r\n]+\\)[^\r\n]*?\.(?:png|jpe?g|webp|gif|bmp|svg))/gi;
+const IMAGE_PATH_PATTERN = /@?((?:[A-Za-z]:[\\/]|\/mnt\/[A-Za-z]\/|\/(?:home|root|Users)\/|\\\\[^\\\/\r\n]+\\[^\\\/\r\n]+\\)[^\r\n"'`]*?\.(?:png|jpe?g|webp|gif|bmp|svg))/gi;
 const IMAGE_OPEN_TAG_PATTERN = /<image\s+name=\[([^\]]+)\]>/gi;
 const IMAGE_CLOSE_TAG_PATTERN = /<\/image>/gi;
 const IMAGE_PLACEHOLDER_PATTERN = /\[(image\s+\d+[^\]]*)\]/gi;
@@ -1107,10 +1107,10 @@ function buildHistoryInlineImageContentFromPath(value?: string): MessageContent 
 /**
  * 中文说明：为路径型 token 合并“后端图片项 + 路径直连预览”的双保险结果。
  * - 若已命中旧缓存中的图片项，优先保留其主图地址；
- * - 同时把当前路径生成的本地预览地址挂成回退，避免旧缓存中的坏图地址导致裂图；
+ * - 优先保留会话内图片数据作为回退，再补充路径兼容地址，避免本地文件失效后出现裂图；
  * - 文本里的真实路径优先作为 `localPath` 展示，保证详情信息稳定。
  */
-function mergeHistoryInlineImageWithPathFallback(
+export function mergeHistoryInlineImageWithPathFallback(
   image: MessageContent,
   pathValue?: string,
 ): MessageContent {
@@ -1119,9 +1119,9 @@ function mergeHistoryInlineImageWithPathFallback(
 
   const primarySrc = String(image?.src || "").trim() || String(pathImage.src || "").trim();
   const fallbackCandidates = [
+    String(image?.fallbackSrc || "").trim(),
     String(pathImage.src || "").trim(),
     String(pathImage.fallbackSrc || "").trim(),
-    String(image?.fallbackSrc || "").trim(),
   ].filter((candidate, index, list) => candidate.length > 0 && candidate !== primarySrc && list.indexOf(candidate) === index);
 
   return {


### PR DESCRIPTION
解析新版 custom_tool_call 与 custom_tool_call_output 事件，将调用参数中的图片路径按 call_id 与输出图片关联。 收紧多路径命令中的图片路径提取边界，避免非图片路径串入候选结果。
本地图片失效时优先保留会话内图片数据作为回退，避免历史详情出现裂图。
补充后端历史解析、路径提取和前端回退顺序的回归测试。