### PR TITLE
fix(worktree): 阻止无首次提交工作树并清理 CONOUT$ 遗留文件

### DIFF
--- a/electron/claude/notifications.test.ts
+++ b/electron/claude/notifications.test.ts
@@ -59,6 +59,7 @@ describe("electron/claude/notifications（多行预览保真）", () => {
     expect(script).toContain('return s.replace(/[\\u0000-\\u0008\\u000b\\u000c\\u000e-\\u001f\\u007f-\\u009f]/g, " ");');
     expect(script).not.toContain("function collapseWs(input)");
     expect(script).not.toContain("const s = collapseWs(input);");
+    expect(script).not.toContain('"CONOUT$"');
   });
 
   it("读取 settings.json 失败时不应覆盖现有配置", async () => {

--- a/electron/claude/notifications.ts
+++ b/electron/claude/notifications.ts
@@ -275,7 +275,8 @@ function writeOscToControllingTty(oscText) {
   if (!text) return false;
 
   if (process.platform === "win32") {
-    const targets = ["\\\\.\\CONOUT$", "CONOUT$"];
+    // 裸 CONOUT$ 在新版 Node.js 中可能被当作普通文件写入当前项目目录。
+    const targets = ["\\\\.\\CONOUT$"];
     for (const p of targets) {
       try {
         const fd = fs.openSync(p, "w");

--- a/electron/gemini/notifications.test.ts
+++ b/electron/gemini/notifications.test.ts
@@ -57,6 +57,7 @@ describe("electron/gemini/notifications（多行预览保真）", () => {
     expect(script).toContain('return s.replace(/[\\u0000-\\u0008\\u000b\\u000c\\u000e-\\u001f\\u007f-\\u009f]/g, " ");');
     expect(script).not.toContain("function collapseWs(input)");
     expect(script).not.toContain("const s = collapseWs(input);");
+    expect(script).not.toContain('"CONOUT$"');
   });
 
   it("读取已有 hook 脚本失败时不应改写 settings.json", async () => {

--- a/electron/gemini/notifications.ts
+++ b/electron/gemini/notifications.ts
@@ -303,7 +303,8 @@ function writeOscToControllingTty(oscText) {
 
   const errors = [];
   if (process.platform === "win32") {
-    const targets = ["\\\\.\\CONOUT$", "CONOUT$"];
+    // 裸 CONOUT$ 在新版 Node.js 中可能被当作普通文件写入当前项目目录。
+    const targets = ["\\\\.\\CONOUT$"];
     const modes = ["w", "r+"];
     for (const p of targets) {
       for (const mode of modes) {

--- a/electron/git/worktreeCreateUnborn.test.ts
+++ b/electron/git/worktreeCreateUnborn.test.ts
@@ -1,0 +1,97 @@
+import { promises as fsp } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { execGitAsync } from "./exec";
+
+let userDataDir = "";
+vi.mock("electron", () => ({
+  app: {
+    getPath: () => userDataDir,
+  },
+}));
+
+import { autoCommitWorktreeIfDirtyAsync, createWorktreesAsync, listLocalBranchesAsync } from "./worktreeOps";
+
+/**
+ * 在临时仓库中执行 Git 命令，并在失败时输出完整诊断。
+ */
+async function gitAsync(repo: string, argv: string[]): Promise<string> {
+  const result = await execGitAsync({ argv: ["-C", repo, ...argv], timeoutMs: 12_000 });
+  expect(result.ok, `git ${argv.join(" ")} failed: ${result.stderr || result.error || result.stdout}`).toBe(true);
+  return String(result.stdout || "");
+}
+
+describe("尚无首次提交的仓库创建 worktree", () => {
+  it("应提示先完成首次提交并拒绝创建孤立 worktree", async () => {
+    const sandbox = await fsp.mkdtemp(path.join(os.tmpdir(), "codexflow-wt-unborn-"));
+    const repo = path.join(sandbox, "repo");
+    userDataDir = path.join(sandbox, "userdata");
+    await fsp.mkdir(repo, { recursive: true });
+    await fsp.mkdir(userDataDir, { recursive: true });
+
+    try {
+      await gitAsync(repo, ["init", "-b", "main"]);
+      await fsp.writeFile(path.join(repo, "untracked.txt"), "尚未提交\n", "utf8");
+
+      const branches = await listLocalBranchesAsync({ repoDir: repo });
+      expect(branches.ok).toBe(true);
+      expect(branches.current).toBe("main");
+      expect(branches.branches).toEqual([]);
+      expect(branches.unborn).toBe(true);
+
+      const result = await createWorktreesAsync({
+        repoDir: repo,
+        baseBranch: "main",
+        instances: [{ providerId: "codex", count: 1 }],
+        copyRules: false,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe("Initial commit required before creating a worktree");
+      expect(await fsp.stat(path.join(sandbox, "repo_wt")).catch(() => null)).toBeNull();
+    } finally {
+      try { await fsp.rm(sandbox, { recursive: true, force: true }); } catch {}
+    }
+  }, { timeout: 120_000 });
+
+  it.runIf(process.platform === "win32")("自动提交前应清理由旧通知 hook 生成的 CONOUT$ 文件", async () => {
+    const sandbox = await fsp.mkdtemp(path.join(os.tmpdir(), "codexflow-wt-conout-"));
+    const repo = path.join(sandbox, "repo");
+    userDataDir = path.join(sandbox, "userdata");
+    await fsp.mkdir(repo, { recursive: true });
+    await fsp.mkdir(userDataDir, { recursive: true });
+
+    try {
+      await gitAsync(repo, ["init", "-b", "main"]);
+      await gitAsync(repo, ["config", "user.name", "CodexFlow"]);
+      await gitAsync(repo, ["config", "user.email", "codexflow@example.com"]);
+      await fsp.writeFile(path.join(repo, "README.md"), "initial\n", "utf8");
+      await gitAsync(repo, ["add", "README.md"]);
+      await gitAsync(repo, ["commit", "-m", "initial"]);
+
+      const created = await createWorktreesAsync({
+        repoDir: repo,
+        baseBranch: "main",
+        instances: [{ providerId: "gemini", count: 1 }],
+        copyRules: false,
+      });
+      expect(created.ok).toBe(true);
+      const worktreePath = String(created.items?.[0]?.worktreePath || "");
+      await fsp.writeFile(path.join(worktreePath, "CONOUT$"), "\u001b]9;agent-turn-complete\u0007", "utf8");
+      await fsp.writeFile(path.join(worktreePath, "change.txt"), "change\n", "utf8");
+
+      const committed = await autoCommitWorktreeIfDirtyAsync({
+        worktreePath,
+        message: "test: auto commit",
+        timeoutMs: 12_000,
+      });
+
+      expect(committed).toEqual({ ok: true, committed: true });
+      expect((await fsp.readdir(worktreePath)).some((name) => name.toUpperCase() === "CONOUT$")).toBe(false);
+      expect((await gitAsync(worktreePath, ["log", "-1", "--format=%s"])).trim()).toBe("test: auto commit");
+    } finally {
+      try { await fsp.rm(sandbox, { recursive: true, force: true }); } catch {}
+    }
+  }, { timeout: 120_000 });
+});

--- a/electron/git/worktreeOps.ts
+++ b/electron/git/worktreeOps.ts
@@ -21,6 +21,8 @@ export type GitWorktreeBranchInfo = {
   repoRoot?: string;
   branches?: string[];
   current?: string;
+  /** 当前分支是否尚未产生首次提交。 */
+  unborn?: boolean;
   detached?: boolean;
   headSha?: string;
   error?: string;
@@ -376,6 +378,8 @@ export async function listLocalBranchesAsync(args: { repoDir: string; gitPath?: 
   const cur = await execGitAsync({ gitPath, argv: ["-C", repoRoot, "symbolic-ref", "--short", "-q", "HEAD"], timeoutMs });
   const current = String(cur.stdout || "").trim();
   const detached = !(cur.ok && current);
+  const headCommit = await execGitAsync({ gitPath, argv: ["-C", repoRoot, "rev-parse", "-q", "--verify", "HEAD^{commit}"], timeoutMs });
+  const unborn = !!current && !headCommit.ok;
   const headSha = detached
     ? (() => {
         // detached 时给一个完整 HEAD hash 兜底，展示层再决定是否缩写
@@ -387,7 +391,7 @@ export async function listLocalBranchesAsync(args: { repoDir: string; gitPath?: 
   const sha = detached ? await execGitAsync({ gitPath, argv: ["-C", repoRoot, "rev-parse", "HEAD"], timeoutMs }) : null;
   const resolvedSha = sha && sha.ok ? String(sha.stdout || "").trim() : headSha;
 
-  return { ok: true, repoRoot, branches, current: current || undefined, detached, headSha: resolvedSha || undefined };
+  return { ok: true, repoRoot, branches, current: current || undefined, unborn, detached, headSha: resolvedSha || undefined };
 }
 
 /**
@@ -453,10 +457,29 @@ export async function createWorktreesAsync(req: CreateWorktreesRequest): Promise
 
   /**
    * 记录“创建时基分支 HEAD（提交号）”作为后续回收的默认分叉点边界。
-   * - 失败不影响创建主流程（回收时会回退到 merge-base 推断）。
+   * - 未产生首次提交时拒绝创建，避免生成无共同祖先、无法安全回收的孤立分支。
    */
-  const baseRefAtCreate = await execGitAsync({ gitPath, argv: ["-C", repoRoot, "rev-parse", baseBranch], timeoutMs: 8000 });
+  const baseRefAtCreate = await execGitAsync({
+    gitPath,
+    argv: ["-C", repoRoot, "rev-parse", "-q", "--verify", `${baseBranch}^{commit}`],
+    timeoutMs: 8000,
+  });
   const baseRefAtCreateSha = baseRefAtCreate.ok ? String(baseRefAtCreate.stdout || "").trim() : "";
+
+  if (!baseRefAtCreate.ok) {
+    const current = await execGitAsync({ gitPath, argv: ["-C", repoRoot, "symbolic-ref", "--short", "-q", "HEAD"], timeoutMs: 8000 });
+    if (current.ok && String(current.stdout || "").trim() === baseBranch) {
+      const head = await execGitAsync({ gitPath, argv: ["-C", repoRoot, "rev-parse", "-q", "--verify", "HEAD^{commit}"], timeoutMs: 8000 });
+      if (!head.ok) {
+        const msg = "Initial commit required before creating a worktree";
+        log(`失败：${msg}\n`);
+        return { ok: false, error: msg };
+      }
+    }
+    const msg = formatGitFailure(baseRefAtCreate, `base branch not found: ${baseBranch}`);
+    log(`失败：${msg}\n`);
+    return { ok: false, error: msg };
+  }
 
   const wtListRes = await execGitAsync({ gitPath, argv: ["-C", repoRoot, "worktree", "list", "--porcelain"], timeoutMs: listTimeoutMs });
   if (!wtListRes.ok) {
@@ -671,10 +694,11 @@ export async function createWorktreesAsync(req: CreateWorktreesRequest): Promise
       const abortedBeforeRun = checkAborted();
       if (abortedBeforeRun) return abortedBeforeRun;
 
-      log(`\n[${plan.providerId}#${plan.index}] $ git -C "${repoRoot}" worktree add -b "${plan.wtBranch}" "${plan.targetDir}" "${String(req.baseBranch || "").trim()}"\n`);
+      const worktreeAddArgs = ["-C", repoRoot, "worktree", "add", "-b", plan.wtBranch, plan.targetDir, baseBranch];
+      log(`\n[${plan.providerId}#${plan.index}] $ git -C "${repoRoot}" worktree add -b "${plan.wtBranch}" "${plan.targetDir}" "${baseBranch}"\n`);
       const add = await spawnGitAsync({
         gitPath,
-        argv: ["-C", repoRoot, "worktree", "add", "-b", plan.wtBranch, plan.targetDir, req.baseBranch],
+        argv: worktreeAddArgs,
         timeoutMs: worktreeAddTimeoutMs,
         allowLongTimeout: true,
         onStdout: (chunk) => log(`[${plan.providerId}#${plan.index}] ${chunk}`),
@@ -858,6 +882,36 @@ async function isNonMainWorktreeRootAsync(args: { dir: string; gitPath?: string;
 }
 
 /**
+ * 清理由旧版通知 hook 在 Windows worktree 根目录误建的 CONOUT$ 文件。
+ *
+ * 仅删除未被 Git 跟踪、内容为空或符合 OSC 9 通知格式的文件，避免触碰用户数据。
+ */
+async function cleanupLegacyConoutNotificationFileAsync(args: { dir: string; gitPath?: string; timeoutMs: number }): Promise<void> {
+  if (process.platform !== "win32") return;
+  let artifactName = "";
+  try {
+    const names = await fsp.readdir(args.dir);
+    artifactName = names.find((name) => name.toUpperCase() === "CONOUT$") || "";
+  } catch {}
+  if (!artifactName) return;
+
+  const tracked = await execGitAsync({
+    gitPath: args.gitPath,
+    argv: ["-C", args.dir, "ls-files", "--cached", "--", artifactName],
+    timeoutMs: args.timeoutMs,
+  });
+  if (!tracked.ok || String(tracked.stdout || "").trim()) return;
+
+  const artifactPath = path.join(args.dir, artifactName);
+  try {
+    const content = await fsp.readFile(artifactPath);
+    const isGeneratedNotification = content.length === 0 || content.subarray(0, 4).equals(Buffer.from("\u001b]9;", "utf8"));
+    if (!isGeneratedNotification) return;
+    await fsp.rm(artifactPath, { force: true });
+  } catch {}
+}
+
+/**
  * 若 worktree 有变更，则执行 add -A 并提交一次（无变更则不提交）。
  *
  * 规则：仅对“非主 worktree 根目录”生效；其它目录按 no-op 处理（ok=true, committed=false）。
@@ -877,6 +931,8 @@ export async function autoCommitWorktreeIfDirtyAsync(args: {
   const eligible = await isNonMainWorktreeRootAsync({ dir: wt, gitPath, timeoutMs });
   if (!eligible.ok) return { ok: false, committed: false, error: eligible.error || "autoCommit eligibility check failed" };
   if (!eligible.eligible) return { ok: true, committed: false };
+
+  await cleanupLegacyConoutNotificationFileAsync({ dir: wt, gitPath, timeoutMs });
 
   const st = await execGitAsync({ gitPath, argv: ["-C", wt, "status", "--porcelain"], timeoutMs });
   if (st.ok && String(st.stdout || "").trim().length === 0) return { ok: true, committed: false };

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1071,6 +1071,7 @@ export default function CodexFlowManagerUI() {
 	    branches: [],
 	    baseBranch: "",
 	    loadingBranches: false,
+	    requiresInitialCommit: false,
 	    remarkBaseName: "",
 	    selectedChildWorktreeIds: [],
 	    promptChips: [],
@@ -9421,6 +9422,7 @@ export default function CodexFlowManagerUI() {
 	      branches: [],
 	      baseBranch: restored?.baseBranch || "",
 	      loadingBranches: true,
+	      requiresInitialCommit: false,
 	      remarkBaseName,
 	      selectedChildWorktreeIds: restored?.selectedChildWorktreeIds || [],
 	      promptChips: restored?.promptChips || [],
@@ -9438,6 +9440,7 @@ export default function CodexFlowManagerUI() {
 	      if (!(res && res.ok)) throw new Error(res?.error || "failed");
 	      const branches = Array.isArray(res.branches) ? res.branches.map((x: any) => String(x || "").trim()).filter(Boolean) : [];
 	      const current = String(res.current || "").trim();
+	      const unborn = res.unborn === true;
 	      setWorktreeCreateDialog((prev) => {
 	        if (!prev.open || prev.repoProjectId !== repoId) return prev;
 	        const preferred = String(prev.baseBranch || "").trim();
@@ -9447,13 +9450,16 @@ export default function CodexFlowManagerUI() {
 	          branches,
 	          baseBranch,
           loadingBranches: false,
-          error: baseBranch ? undefined : (t("projects:worktreeMissingBaseBranch", "未能读取到基分支") as string),
+          requiresInitialCommit: unborn,
+          error: unborn
+            ? (t("projects:worktreeInitialCommitRequired", "当前仓库尚无首次提交。请先在主工作区完成首次提交，再创建工作树。") as string)
+            : (baseBranch ? undefined : (t("projects:worktreeMissingBaseBranch", "未能读取到基分支") as string)),
         };
       });
     } catch (e: any) {
       setWorktreeCreateDialog((prev) => {
         if (!prev.open || prev.repoProjectId !== repoId) return prev;
-        return { ...prev, branches: [], baseBranch: "", loadingBranches: false, error: String(e?.message || e) };
+        return { ...prev, branches: [], baseBranch: "", loadingBranches: false, requiresInitialCommit: false, error: String(e?.message || e) };
       });
     }
 	  }, [activeProviderId, resolveDefaultWorktreeRemarkBaseName, resolveWorktreeManagementParentProjectId, restoreWorktreePromptChips, t]);
@@ -10005,16 +10011,20 @@ export default function CodexFlowManagerUI() {
 
     const defaultProvider = normalizeWorktreeProviderId(activeProviderId);
 
-    // 优先使用已缓存的分支信息，失败则回退到分支列表
+    // 快速创建仍需读取最新分支状态，避免绕过“首次提交”安全检查。
     const git = gitInfoByProjectId[repoId];
     let baseBranch = String(git?.branch || "").trim();
-    if (!baseBranch) {
-      try {
-        const res: any = await (window as any).host?.gitWorktree?.listBranches?.(repoProject.winPath);
+    try {
+      const res: any = await (window as any).host?.gitWorktree?.listBranches?.(repoProject.winPath);
+      if (res?.unborn === true) {
+        await openWorktreeCreateDialog(repoProject);
+        return;
+      }
+      if (!baseBranch) {
         const branches = Array.isArray(res?.branches) ? res.branches.map((x: any) => String(x || "").trim()).filter(Boolean) : [];
         baseBranch = String(res?.current || "").trim() || branches[0] || "";
-      } catch {}
-    }
+      }
+    } catch {}
     if (!baseBranch) {
       // 无法自动解析基分支时回退到创建面板（保持 UI 风格一致，并让用户可手动选择）
       void openWorktreeCreateDialog(repoProject);
@@ -14680,13 +14690,15 @@ export default function CodexFlowManagerUI() {
                   <div className="space-y-2.5 py-1">
                 {worktreeCreateDialog.error ? (
                   <div
+                    role="alert"
+                    aria-live="polite"
                     className={`rounded-md border px-3 py-1.5 text-[11px] font-medium flex items-center gap-2 ${
                       createCount > 0
                         ? "border-red-200 bg-red-50 text-red-800"
                         : "border-amber-200 bg-amber-50 text-amber-900"
                     }`}
                   >
-                    <TriangleAlert className="h-3.5 w-3.5" />
+                    <TriangleAlert className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
                     <span className="break-words">
                       {worktreeCreateDialog.error}
                       {createCount === 0 ? (t("projects:worktreeCreateErrorCreateOnly", "（仅影响新建）") as string) : null}
@@ -14969,6 +14981,18 @@ export default function CodexFlowManagerUI() {
                 </ScrollArea>
 
                 <div className="flex justify-end gap-2 pt-2 border-t border-slate-100 dark:border-slate-800/50 mt-2 shrink-0">
+                  {worktreeCreateDialog.requiresInitialCommit ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 text-xs"
+                      onClick={async () => {
+                        try { await (window as any).host?.gitWorktree?.openExternalTool?.(repo.winPath); } catch {}
+                      }}
+                    >
+                      {t("projects:gitOpenExternalTool", "打开外部 Git 工具") as string}
+                    </Button>
+                  ) : null}
                   <Button variant="outline" size="sm" className="h-8 text-xs" onClick={closeWorktreeCreateDialog} disabled={worktreeCreateDialog.creating}>
                     {t("common:cancel", "取消") as string}
                   </Button>

--- a/web/src/app/app-shared.tsx
+++ b/web/src/app/app-shared.tsx
@@ -162,6 +162,8 @@ type WorktreeCreateDialogState = {
   baseBranch: string;
   /** 是否正在加载分支列表 */
   loadingBranches: boolean;
+  /** 是否因仓库尚无首次提交而禁止新建 worktree。 */
+  requiresInitialCommit: boolean;
   /** 新建子 worktree 的备注基名（用于自动生成 `1.xxx`、`2.xxx`）。 */
   remarkBaseName: string;
   /** 复用的子 worktree（projectId，多选；默认不选） */

--- a/web/src/locales/en/projects.json
+++ b/web/src/locales/en/projects.json
@@ -148,6 +148,7 @@
   "worktreeReuseEmpty": "No reusable child worktrees.",
   "worktreeReuseSummary": "Reuse {reuse}, create {create}",
   "worktreeMissingBaseBranch": "Failed to read base branch",
+  "worktreeInitialCommitRequired": "This repository has no initial commit. Create the initial commit in the main workspace before creating a worktree.",
   "grokInitialPromptNotReady": "Grok did not reach an input-ready screen, so the initial attachments were not sent.",
   "worktreeCreateFailed": "Failed to create worktree: {{error}}",
   "worktreeCreateWarnings": "Completed, but warnings occurred:\n{{warnings}}",

--- a/web/src/locales/zh/projects.json
+++ b/web/src/locales/zh/projects.json
@@ -148,6 +148,7 @@
   "worktreeReuseEmpty": "暂无可复用的子 worktree",
   "worktreeReuseSummary": "复用 {reuse}，新建 {create}",
   "worktreeMissingBaseBranch": "未能读取到基分支",
+  "worktreeInitialCommitRequired": "当前仓库尚无首次提交。请先在主工作区完成首次提交，再创建工作树。",
   "grokInitialPromptNotReady": "Grok 未进入可输入界面，因此尚未发送初始图片附件。",
   "worktreeCreateFailed": "创建 worktree 失败：{{error}}",
   "worktreeCreateWarnings": "操作已完成，但存在警告：\n{{warnings}}",

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -702,7 +702,7 @@ export type InitGitRepositoryResult = {
 
 export interface GitWorktreeAPI {
   statusBatch(dirs: string[]): Promise<{ ok: boolean; items?: GitDirInfo[]; error?: string }>;
-  listBranches(repoDir: string): Promise<{ ok: boolean; repoRoot?: string; branches?: string[]; current?: string; detached?: boolean; headSha?: string; error?: string }>;
+  listBranches(repoDir: string): Promise<{ ok: boolean; repoRoot?: string; branches?: string[]; current?: string; unborn?: boolean; detached?: boolean; headSha?: string; error?: string }>;
   initRepo(args: { dir: string }): Promise<InitGitRepositoryResult>;
   getMeta(worktreePath: string): Promise<{ ok: boolean; meta?: WorktreeMeta | null; error?: string }>;
   create(args: { repoDir: string; baseBranch: string; instances: Array<{ providerId: "codex" | "claude" | "gemini" | "antigravity" | "grok"; count: number }>; copyRules?: boolean; postSetup?: WorktreePostSetupConfig }): Promise<{ ok: boolean; items?: CreatedWorktree[]; error?: string }>;


### PR DESCRIPTION
Git 在尚无首次提交的仓库中无法为 worktree 建立可回收的共同祖先，之前的创建流程可能生成孤立分支并破坏后续回收；旧版通知 hook 还可能在 Windows worktree 根目录生成 `CONOUT$` 文件并被误提交。此次改动：

- 在主进程识别尚未产生首次提交的分支，拒绝创建并返回明确错误。
- 在前端创建与快速创建入口展示首次提交提示，并提供外部 Git 工具入口。
- 自动提交前清理由旧通知 hook 误生成的 Windows `CONOUT$` 文件，避免把通知产物提交进 worktree。
- 移除通知 hook 的裸 `CONOUT$` 回退写入，并补充对应测试。
- 同步中英文界面文案和 Host API 类型定义。

验证：

- `npm run test`
- `npm run i18n:check`
- `npm run build:electron`
- `npm run build:web`