### PR TITLE
fix(terminal): 稳定输入区布局与滚动锚点

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3299,8 +3299,8 @@ export default function CodexFlowManagerUI() {
         <div className="relative group/agent-timer inline-block">
           <div
             className={working
-              ? "text-[10px] sm:text-xs text-slate-500/80 dark:text-slate-400/70 px-2 py-0.5 flex items-center gap-2 select-none cursor-default hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
-              : "text-[10px] sm:text-xs text-slate-500/80 dark:text-slate-400/70 px-2 py-0.5 flex items-center gap-2 select-none cursor-default transition-colors"}
+              ? "-translate-y-[6px] text-[10px] sm:text-xs text-slate-500/80 dark:text-slate-400/70 px-2 py-0.5 flex items-center gap-2 select-none cursor-default hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+              : "-translate-y-[6px] text-[10px] sm:text-xs text-slate-500/80 dark:text-slate-400/70 px-2 py-0.5 flex items-center gap-2 select-none cursor-default transition-colors"}
             onContextMenu={(event) => {
               openAgentTurnContextMenu(event, id);
             }}
@@ -12528,7 +12528,6 @@ export default function CodexFlowManagerUI() {
             const isInputFullscreen = !!inputFullscreenByTab[tab.id];
             const isInputClosing = !!inputFullscreenClosingTabs[tab.id];
             const showFullscreenInput = isInputFullscreen || isInputClosing;
-            const hasAgentTimer = !!agentTurnTimerByTab[tab.id];
             const fullscreenState = isInputClosing ? "closing" : "open";
             const inputPlaceholder = t('terminal:inputPlaceholder') as string;
             const sendLabel = t('terminal:send') as string;
@@ -12570,7 +12569,9 @@ export default function CodexFlowManagerUI() {
                             data-state={fullscreenState}
                           className="relative flex flex-1 flex-col rounded-[26px] bg-[var(--cf-surface-solid)] shadow-apple-lg animate-[cfFullscreenPanelEnter_260ms_cubic-bezier(0.4,0,0.2,1)_both] data-[state=closing]:animate-[cfFullscreenPanelExit_220ms_cubic-bezier(0.4,0,0.2,1)_forwards]"
                           >
-                            {renderAgentTurnStatusBar(tab.id, "px-4 pt-0.5 pb-0.5")}
+                            <div className="h-5 shrink-0">
+                              {renderAgentTurnStatusBar(tab.id, "px-4 pt-0.5 pb-0.5")}
+                            </div>
                             <PathChipsInput
                               placeholder={inputPlaceholder}
                               chips={chipsByTab[tab.id] || []}
@@ -12618,9 +12619,11 @@ export default function CodexFlowManagerUI() {
                       </div>
                     ) : null}
                     {!isInputFullscreen ? (
-                      <div className={`${hasAgentTimer ? "mt-0.5" : "mt-3"} w-full`}>
-                        <div className="relative w-full">
-                          {renderAgentTurnStatusBar(tab.id)}
+                      <div className="relative z-30 mt-0.5 h-[8.75rem] shrink-0 w-full">
+                        <div className="relative flex h-full min-h-0 w-full flex-col">
+                          <div className="relative z-30 h-5 shrink-0 overflow-visible">
+                            {renderAgentTurnStatusBar(tab.id, "mb-0.5 px-1")}
+                          </div>
                           <PathChipsInput
                             placeholder={inputPlaceholder}
                             chips={chipsByTab[tab.id] || []}
@@ -12638,7 +12641,8 @@ export default function CodexFlowManagerUI() {
                             runEnv={tabExecEnv.terminal}
                             multiline
                             onKeyDown={(e: any) => { if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { void sendCommand(); e.preventDefault(); } }}
-                            className=""
+                            stableLayout
+                            className="flex flex-1 min-h-0 flex-col overflow-hidden"
                           />
 
                           <div className="absolute right-2 bottom-2 flex flex-row gap-2">

--- a/web/src/components/ui/path-chips-input.test.tsx
+++ b/web/src/components/ui/path-chips-input.test.tsx
@@ -170,6 +170,26 @@ function Harness(props: { initialDraft?: string; initialChips?: PathChip[] }): R
 }
 
 /**
+ * 中文说明：固定布局需将附件和文本限制在输入区内部，避免影响外部终端尺寸。
+ */
+function StableLayoutHarness(props: { initialChips?: PathChip[] }): React.ReactElement {
+  const [draft, setDraft] = useState("");
+  const [chips, setChips] = useState<PathChip[]>(props.initialChips ?? []);
+  return (
+    <div className="h-[7.5rem]">
+      <PathChipsInput
+        draft={draft}
+        onDraftChange={setDraft}
+        chips={chips}
+        onChipsChange={setChips}
+        multiline
+        stableLayout
+      />
+    </div>
+  );
+}
+
+/**
  * 中文说明：从容器中获取实际编辑器（当前组件在测试里使用 textarea）。
  */
 function getEditor(host: HTMLElement): HTMLTextAreaElement | HTMLInputElement {
@@ -295,6 +315,41 @@ describe("PathChipsInput 路径 Chip 构造", () => {
 
     expect(merged).toHaveLength(1);
     expect(merged[0].id).toBe(first?.id);
+  });
+});
+
+describe("PathChipsInput 固定布局", () => {
+  let cleanup: (() => void) | null = null;
+
+  afterEach(() => {
+    try { cleanup?.(); } catch {}
+    cleanup = null;
+  });
+
+  it("多附件时应把滚动限制在附件托盘内", async () => {
+    const mounted = createMountedRoot();
+    cleanup = mounted.unmount;
+    const chips = Array.from({ length: 12 }, (_, index) => createPathChip({
+      id: `stable-chip-${index}`,
+      fileName: `attachment-${index}.txt`,
+      winPath: `C:\\Example\\attachment-${index}.txt`,
+    }));
+
+    await act(async () => {
+      mounted.root.render(<StableLayoutHarness initialChips={chips} />);
+    });
+
+    const root = mounted.host.querySelector('[data-path-chips-input="true"]');
+    const tray = mounted.host.querySelector('[data-attachment-tray="true"]');
+    const editor = getEditor(mounted.host);
+
+    expect(root?.getAttribute("data-stable-layout")).toBe("true");
+    expect(root?.className).toContain("h-full");
+    expect(root?.className).toContain("overflow-hidden");
+    expect(tray?.className).toContain("max-h-12");
+    expect(tray?.className).toContain("overflow-y-auto");
+    expect(editor.className).toContain("min-h-0");
+    expect(editor.className).toContain("overflow-y-auto");
   });
 });
 

--- a/web/src/components/ui/path-chips-input.tsx
+++ b/web/src/components/ui/path-chips-input.tsx
@@ -62,6 +62,8 @@ export interface PathChipsInputProps extends Omit<React.InputHTMLAttributes<HTML
   draftInputClassName?: string;
   /** 是否为滚动条预留左右对称边距，仅在全屏输入时开启以保持视觉等宽 */
   balancedScrollbarGutter?: boolean;
+  /** 是否使用固定高度布局；附件和长文本仅在输入区内部滚动，避免挤压外部内容。 */
+  stableLayout?: boolean;
   /** 拖拽添加的资源不在当前项目目录时提醒（默认开启） */
   warnOutsideProjectDrop?: boolean;
   /** 更新“目录外资源提醒”开关（用于弹窗内“一键不再提醒”即时生效） */
@@ -566,6 +568,7 @@ export default function PathChipsInput({
   onKeyDown: externalOnKeyDown,
   draftInputClassName,
   balancedScrollbarGutter = false,
+  stableLayout = false,
   warnOutsideProjectDrop = true,
   onWarnOutsideProjectDropChange,
   ...rest
@@ -623,7 +626,9 @@ export default function PathChipsInput({
     base,
     "transition-all duration-apple ease-apple select-none hover:border-[var(--cf-border-strong)] text-[var(--cf-text-primary)]",
     // 减小顶部内边距，靠近容器上边缘；保留底部内边距保证输入区呼吸感
-    multiline ? "flex flex-col min-h-[7.5rem] pt-0.5 pb-2" : "min-h-10 pt-0.5 pb-1",
+    multiline
+      ? (stableLayout ? "flex h-full min-h-0 flex-col overflow-hidden pt-0.5 pb-2" : "flex flex-col min-h-[7.5rem] pt-0.5 pb-2")
+      : "min-h-10 pt-0.5 pb-1",
     className
   );
 
@@ -1501,6 +1506,8 @@ export default function PathChipsInput({
     <>
       <div
         ref={rootRef}
+        data-path-chips-input="true"
+        data-stable-layout={stableLayout ? "true" : "false"}
         className={containerClass}
         onClick={() => { try { inputRef.current?.focus(); } catch {} }}
 	        onDragOver={(e) => { try { e.preventDefault(); e.dataTransfer!.dropEffect = 'copy'; } catch {} }}
@@ -1541,8 +1548,15 @@ export default function PathChipsInput({
 		        }}
 		        {...rest}
 	      >
-        {/* Chips 采用常规文档流放置在输入区上方，最小可见间隙 2px */}
-        <div ref={chipsRef} className="mt-px mb-0.5 flex flex-wrap items-start gap-0.5">
+        {/* 固定布局下，附件托盘在输入区内部滚动，避免多个附件改变外部终端尺寸。 */}
+        <div
+          ref={chipsRef}
+          data-attachment-tray="true"
+          className={cn(
+            "mt-px mb-0.5 flex flex-wrap items-start gap-0.5",
+            stableLayout ? "max-h-12 shrink-0 overflow-y-auto overscroll-contain pr-1" : "",
+          )}
+        >
           {chips.map((chip, idx) => {
             const chipKey = buildChipStableKey(chip, `${idx}`);
             const chipAny = chip as PathChip;
@@ -1690,11 +1704,11 @@ export default function PathChipsInput({
             rows={3}
             // 说明：
             // - resize-none 禁用手动拖拽；whitespace-pre-wrap + break-words 实现中文/长词自动换行；
-            // - leading-5 提升可读性；min-h 保持与容器协调；pb-10 给右下角发送按钮留出垂直空间；
+            // - leading-5 提升可读性；固定布局时文本只在自身区域滚动；pb-10 给右下角发送按钮留出垂直空间；
             style={balancedScrollbarGutter ? ({ scrollbarGutter: 'stable both-edges' } as any) : undefined}
             className={cn(
               "block flex-1 w-full min-w-[8rem] outline-none bg-[var(--cf-surface-solid)] placeholder:text-[var(--cf-text-muted)] text-[var(--cf-text-primary)] select-text resize-none whitespace-pre-wrap break-words leading-5",
-              "py-0.5 pb-10 min-h-[1.5rem]",
+              stableLayout ? "min-h-0 overflow-y-auto py-0.5 pb-10" : "py-0.5 pb-10 min-h-[1.5rem]",
               draftInputClassName,
             )}
             placeholder={chips.length === 0 ? (rest as any)?.placeholder : undefined}

--- a/web/src/lib/TerminalManager.ts
+++ b/web/src/lib/TerminalManager.ts
@@ -3124,6 +3124,13 @@ export default class TerminalManager {
             this.logScrollDiagnostic(`ro.cb tab=${tabId} host=${Math.round(r.width)}x${Math.round(r.height)} parent=${pr ? `${Math.round(pr.width)}x${Math.round(pr.height)}` : 'n/a'} ${this.formatHostRect(tabId)}`);
             if (this.isWindowResizeSessionActive(tabId)) {
               this.markWindowResizeActivity(tabId, "ro");
+            } else {
+              const previousRect = this.lastHostRectByTab[tabId];
+              const nextRect = this.readHostRectSnapshot(tabId);
+              if (!this.isSameHostRectSnapshot(previousRect, nextRect)) {
+                this.notifyAdapterLayoutResizeStart(tabId, "ro-layout");
+              }
+              if (nextRect) this.lastHostRectByTab[tabId] = nextRect;
             }
           }
         } catch {}

--- a/web/src/lib/terminal-manager-scroll.test.ts
+++ b/web/src/lib/terminal-manager-scroll.test.ts
@@ -13,6 +13,7 @@ import TerminalManager from "./TerminalManager";
 describe("TerminalManager（终端滚动快照）", () => {
   afterEach(() => {
     try { createTerminalAdapterMock.mockReset(); } catch {}
+    vi.unstubAllGlobals();
   });
 
   /**
@@ -161,5 +162,83 @@ describe("TerminalManager（终端滚动快照）", () => {
     host.remove();
     input.remove();
     tm.disposeAll(false);
+  });
+
+  it("普通布局尺寸变化时会提前保存底部锚点，尺寸未变时不会重复通知", () => {
+    const notifyLayoutResizeStart = vi.fn();
+    const adapter: any = createAdapterStub({ notifyLayoutResizeStart });
+    createTerminalAdapterMock.mockReturnValue(adapter);
+
+    let triggerResizeObserver: (() => void) | undefined;
+    class ResizeObserverMock {
+      private readonly callback: ResizeObserverCallback;
+
+      /**
+       * 保存观察回调，供测试模拟普通布局尺寸变化。
+       * @param callback 尺寸观察回调
+       */
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+        triggerResizeObserver = () => this.callback([], this as unknown as ResizeObserver);
+      }
+
+      /** 开始观察测试元素。 */
+      observe(): void {}
+
+      /** 停止观察单个测试元素。 */
+      unobserve(): void {}
+
+      /** 停止全部测试观察。 */
+      disconnect(): void {}
+    }
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    vi.stubGlobal("requestAnimationFrame", vi.fn(() => 1));
+
+    let hostHeight = 600;
+    let parentHeight = 600;
+    const parent = document.createElement("div");
+    const host = document.createElement("div");
+    parent.appendChild(host);
+    document.body.appendChild(parent);
+    vi.spyOn(host, "getBoundingClientRect").mockImplementation(() => ({
+      x: 0,
+      y: 0,
+      top: 0,
+      right: 800,
+      bottom: hostHeight,
+      left: 0,
+      width: 800,
+      height: hostHeight,
+      toJSON: () => ({}),
+    }));
+    vi.spyOn(parent, "getBoundingClientRect").mockImplementation(() => ({
+      x: 0,
+      y: 0,
+      top: 0,
+      right: 800,
+      bottom: parentHeight,
+      left: 0,
+      width: 800,
+      height: parentHeight,
+      toJSON: () => ({}),
+    }));
+
+    const tm = new TerminalManager(() => undefined, createHostPtyStub() as any, {});
+    tm.attachToHost("tab-layout", host);
+
+    triggerResizeObserver?.();
+    expect(notifyLayoutResizeStart).not.toHaveBeenCalled();
+
+    hostHeight = 480;
+    parentHeight = 480;
+    triggerResizeObserver?.();
+    expect(notifyLayoutResizeStart).toHaveBeenCalledTimes(1);
+    expect(notifyLayoutResizeStart).toHaveBeenCalledWith("ro-layout");
+
+    triggerResizeObserver?.();
+    expect(notifyLayoutResizeStart).toHaveBeenCalledTimes(1);
+
+    tm.disposeAll(false);
+    parent.remove();
   });
 });


### PR DESCRIPTION
固定普通模式输入区高度，避免计时状态、附件和草稿变化挤压终端区域。

- 为普通输入区预留稳定状态行，并将附件和长文本限制为内部滚动
- 为全屏输入区保留状态栏占位，减少状态切换引起的布局跳动
- 在终端宿主普通布局变化前保存底部跟随意图，避免滚动锚点丢失
- 补充固定输入布局与终端滚动锚点的回归测试