### PR TITLE
fix(history): 应用重启后立即加载历史索引

### DIFF
--- a/electron/indexer.test.ts
+++ b/electron/indexer.test.ts
@@ -49,7 +49,7 @@ vi.mock("./agentSessions/grok/discovery", async (importOriginal) => {
   };
 });
 
-import { getIndexedSummaries, startHistoryIndexer, stopHistoryIndexer } from "./indexer";
+import { ensureHistoryIndexLoaded, getIndexedSummaries, startHistoryIndexer, stopHistoryIndexer } from "./indexer";
 
 const originalCwd = process.cwd();
 const tempDirs: string[] = [];
@@ -99,6 +99,32 @@ async function createCodexSessionFile(lines: unknown[]): Promise<string> {
 }
 
 describe("electron/indexer Codex preview", () => {
+  it("首次列表请求可直接加载持久化摘要索引", async () => {
+    const cachedFilePath = path.join(os.tmpdir(), "codexflow-cached-session.jsonl");
+    const cacheKey = cachedFilePath.replace(/\\/g, "/").toLowerCase();
+    await fsp.writeFile(path.join(userDataDir, "history.index.v17.json"), JSON.stringify({
+      version: "v17",
+      savedAt: Date.now(),
+      files: {
+        [cacheKey]: {
+          sig: { mtimeMs: 2, size: 1 },
+          summary: {
+            providerId: "codex",
+            id: "cached-session",
+            title: "缓存会话",
+            date: 2,
+            filePath: cachedFilePath,
+            dirKey: "/workspace/project",
+          },
+        },
+      },
+    }), "utf8");
+
+    await ensureHistoryIndexLoaded();
+
+    expect(getIndexedSummaries().map((item) => item.id)).toEqual(["cached-session"]);
+  });
+
   it("停止索引器前会完成异步缓存刷盘且不持久化消息正文", async () => {
     const filePath = await createCodexSessionFile([
       {

--- a/electron/indexer.ts
+++ b/electron/indexer.ts
@@ -505,6 +505,26 @@ async function loadIndex(): Promise<PersistIndex> {
 }
 
 /**
+ * 预读持久化历史索引，并让并发请求复用同一次磁盘读取。
+ *
+ * 该方法只加载列表摘要，不扫描会话目录；因此可在窗口创建前启动，
+ * 也可由 history.list 在首次请求时短暂等待，避免错误进入重型回退扫描。
+ */
+export async function ensureHistoryIndexLoaded(): Promise<void> {
+  if (!g.__indexer) g.__indexer = {};
+  if (g.__indexer.indexLoaded === true) return;
+  if (!g.__indexer.indexLoadPromise) {
+    g.__indexer.indexLoadPromise = (async () => {
+      g.__indexer.index = await loadIndex();
+      g.__indexer.indexLoaded = true;
+    })().finally(() => {
+      g.__indexer.indexLoadPromise = null;
+    });
+  }
+  await g.__indexer.indexLoadPromise;
+}
+
+/**
  * 请求异步保存索引缓存，不在当前调用栈执行文件 I/O。
  */
 function saveIndex(ix: PersistIndex): void {
@@ -1552,7 +1572,7 @@ export async function startHistoryIndexer(getWindow: () => BrowserWindow | null)
       perfLogger.log(`[indexer] cacheVersion=${VERSION} userData=${JSON.stringify(getUserDataDir())}`);
       if (removedLegacyPersistFiles.length > 0) perfLogger.log(`[indexer] purgedLegacyCaches=${JSON.stringify(removedLegacyPersistFiles)}`);
     }
-    g.__indexer.index = await loadIndex();
+    await ensureHistoryIndexLoaded();
     g.__indexer.details = await loadDetails();
     try { getDetailsCache().clear(); } catch {}
     try { clearFastRefreshState(); } catch {}
@@ -1856,6 +1876,15 @@ export async function startHistoryIndexer(getWindow: () => BrowserWindow | null)
       }
       return Array.from(mp.values());
     })();
+    // 先按文件更新时间倒序排队：冷启动没有缓存时，也应优先解析并展示最新会话。
+    // stat 结果在后续解析中直接复用，避免为排序重复读取文件元数据。
+    const statLimit = pLimit(16);
+    const recentFirstFiles = (await Promise.all(uniqFiles.map((item) => statLimit(async () => {
+      const stat = await fsp.stat(item.filePath).catch(() => null as any);
+      return stat ? { ...item, stat } : null;
+    }))))
+      .filter((item): item is ProviderFile & { stat: fs.Stats } => !!item)
+      .sort((a, b) => b.stat.mtimeMs - a.stat.mtimeMs);
 
     const workLimit = pLimit(8);
     let updatedSummaries = 0;
@@ -1863,7 +1892,7 @@ export async function startHistoryIndexer(getWindow: () => BrowserWindow | null)
     const batch: IndexSummary[] = [];
     const flush = () => {
       if (batch.length === 0) return;
-      const items = batch.splice(0, batch.length);
+      const items = batch.splice(0, batch.length).sort((a, b) => b.date - a.date);
       safeWindowSend(win, "history:index:add", { items }, { tag: "indexer", suppressMs: 1000 });
     };
 
@@ -1945,11 +1974,9 @@ export async function startHistoryIndexer(getWindow: () => BrowserWindow | null)
       } catch {}
     }
 
-    await Promise.all(uniqFiles.map(({ providerId, filePath: fp }) => workLimit(async () => {
+    await Promise.all(recentFirstFiles.map(({ providerId, filePath: fp, stat }) => workLimit(async () => {
       try {
         if (!shouldIndexFile(providerId, fp)) return;
-        const stat = await fsp.stat(fp).catch(() => null as any);
-        if (!stat) return;
         const k = canonicalKey(fp);
         const sig: FileSig = { mtimeMs: stat.mtimeMs, size: stat.size };
         const prev = ix.files[k]?.sig;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -14,7 +14,7 @@ import opentype from 'opentype.js';
 import iconv from 'iconv-lite';
 import projects, { IMPLEMENTATION_NAME as PROJECTS_IMPL } from "./projects/index";
 import history, { purgeHistoryCacheIfOutdated } from "./history";
-import { startHistoryIndexer, getIndexedSummaries, getIndexedDetails, getLastIndexerRoots, getLastIndexerRootsByProvider, stopHistoryIndexer, cacheDetails, getCachedDetails } from "./indexer";
+import { ensureHistoryIndexLoaded, startHistoryIndexer, getIndexedSummaries, getIndexedDetails, getLastIndexerRoots, getLastIndexerRootsByProvider, stopHistoryIndexer, cacheDetails, getCachedDetails } from "./indexer";
 import { getSessionsRootsFastAsync } from "./wsl";
 import { getClaudeRootCandidatesFastAsync, discoverClaudeSessionFiles } from "./agentSessions/claude/discovery";
 import { getGeminiRootCandidatesFastAsync, discoverGeminiSessionFiles } from "./agentSessions/gemini/discovery";
@@ -2832,6 +2832,8 @@ if (!gotLock) {
     try { i18n.registerI18nIPC(); } catch {}
     // 构建应用菜单（包含 Toggle Developer Tools）
     try { setupAppMenu(); } catch {}
+    // 尽早预读持久化历史摘要；不等待结果，避免延迟窗口创建。
+    void ensureHistoryIndexLoaded().catch(() => undefined);
     // 启动时清理上一次会话遗留的粘贴临时图片（崩溃/强杀兜底）
     try { await cleanupPastedImagesFromPreviousSessionOnBoot(); } catch {}
     try { createWindow(); } catch (e) { if (DIAG) { try { perfLogger.log(`[BOOT] createWindow error: ${String(e)}`); } catch {} } }
@@ -4447,6 +4449,9 @@ ipcMain.handle('history.list', async (_e, args: {
   historyRoot?: string;
 }) => {
   try {
+    // 首次列表请求只等待持久化摘要索引，不等待后台目录扫描。
+    // 这样应用重开后可立即显示上次缓存，再由索引器增量修正。
+    await ensureHistoryIndexLoaded();
     const scope = args?.scope === 'project_group' || args?.scope === 'all_sessions' ? args.scope : 'current_project';
     // 尝试优先使用索引器（不阻塞 UI）
     const canon = (p?: string): string => {


### PR DESCRIPTION
应用启动阶段预读取持久化的历史摘要索引，并由首次列表请求复用加载任务，使历史中心先展示上次缓存，再由后台索引增量更新。

- 在索引模块提供并发安全的持久化摘要加载方法
- 启动窗口前发起非阻塞预读，history.list 首个请求等待其完成
- 覆盖持久化索引的首次加载回归测试