### PR TITLE
fix(rider): 修复 Windows 更新后无法启动 Rider

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -92,6 +92,7 @@ import { WorktreeRecycleTaskManager } from "./git/worktreeRecycleTasks";
 import { loadDirTreeStore, saveDirTreeStore } from "./stores/dirTreeStore";
 import { getDirBuildRunConfig, setDirBuildRunConfig } from "./stores/buildRunStore";
 import { getWorktreeMeta } from "./stores/worktreeMetaStore";
+import { buildRiderExecutableCandidates, parseRiderRegistryInstallLocations } from "./riderPaths";
 import {
   findProjectPreferredIdeForTargetPath,
   getProjectPreferredIde,
@@ -907,6 +908,9 @@ function logIdeOpenTrace(message: string): void {
 
 type CursorOpenStrategy = "auto" | "protocol" | "command";
 let cursorPreferredStrategy: CursorOpenStrategy = "auto";
+const RIDER_EXECUTABLE_PATHS_CACHE_TTL_MS = 60_000;
+let riderExecutablePathsCache: { paths: string[]; expiresAt: number } | null = null;
+let riderExecutablePathsPromise: Promise<string[]> | null = null;
 
 type RuntimeEnvRepairEntry = {
   providerId?: string;
@@ -4351,7 +4355,14 @@ ipcMain.handle("gitWorktree.openExternalTool", async (_e, args: { dir: string })
       launched = await spawnDetachedShellSafe(cmd, { windowsHide: false });
     } else if (toolId === "rider") {
       if (platform === "darwin") launched = await trySpawn("open", ["-a", "Rider", dir]);
-      else if (platform === "win32") launched = (await trySpawn("rider64.exe", [dir])) || (await trySpawn("rider.exe", [dir])) || (await spawnDetachedShellSafe(`rider \"${dir}\"`, { windowsHide: false }));
+      else if (platform === "win32") {
+        for (const executable of await getRiderExecutablePaths()) {
+          if (await trySpawn(executable, [dir])) {
+            launched = true;
+            break;
+          }
+        }
+      }
       else launched = await trySpawn("rider", [dir]);
     } else if (toolId === "sourcetree") {
       if (platform === "darwin") launched = await trySpawn("open", ["-a", "SourceTree", dir]);
@@ -6016,6 +6027,113 @@ async function tryOpenPathAtPositionWithCustomCommand(
 }
 
 /**
+ * 查询 Windows 卸载注册表中的 Rider 安装目录。
+ * 旧版 Toolbox 脚本可能仍在 PATH 中，但注册表通常保留当前安装位置。
+ */
+async function queryRiderRegistryInstallLocations(): Promise<string[]> {
+  if (process.platform !== "win32") return [];
+  const hives = [
+    "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+    "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+    "HKLM\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+  ];
+  /**
+   * 查询单个卸载注册表根，并在超时或读取失败时返回空结果。
+   */
+  const query = (hive: string): Promise<string> => new Promise((resolve) => {
+    try {
+      (execFile as any)(
+        "reg.exe",
+        ["query", hive, "/s", "/v", "InstallLocation"],
+        {
+          encoding: "buffer",
+          windowsHide: true,
+          maxBuffer: 4 * 1024 * 1024,
+          timeout: 5_000,
+        },
+        (error: any, stdout: Buffer | string) => {
+          if (error) {
+            resolve("");
+            return;
+          }
+          try {
+            resolve(decodeRegOutput(stdout));
+          } catch {
+            resolve(String(stdout || ""));
+          }
+        },
+      );
+    } catch {
+      resolve("");
+    }
+  });
+
+  const rawOutputs = await Promise.all(hives.map((hive) => query(hive)));
+  const locations: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of rawOutputs) {
+    for (const location of parseRiderRegistryInstallLocations(raw)) {
+      const key = location.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      locations.push(location);
+    }
+  }
+  return locations;
+}
+
+/**
+ * 获取当前可用的 Rider 可执行文件，并过滤已卸载版本留下的无效路径。
+ * 结果短期缓存，兼顾重复点击性能与安装、升级 Rider 后自动恢复。
+ */
+async function getRiderExecutablePaths(): Promise<string[]> {
+  if (process.platform !== "win32") return [];
+  const now = Date.now();
+  if (riderExecutablePathsCache && riderExecutablePathsCache.expiresAt > now)
+    return riderExecutablePathsCache.paths;
+  if (riderExecutablePathsPromise) return await riderExecutablePathsPromise;
+
+  riderExecutablePathsPromise = (async () => {
+    const pathValue = String(process.env.Path || process.env.PATH || "");
+    const pathEntries = pathValue.split(";").map((entry) => entry.trim()).filter(Boolean);
+    const registryInstallLocations = await queryRiderRegistryInstallLocations();
+    const candidates = buildRiderExecutableCandidates({
+      platform: process.platform,
+      pathEntries,
+      registryInstallLocations,
+      environment: process.env,
+    });
+    const existing = candidates.filter((candidate) => {
+      try {
+        return fs.statSync(candidate).isFile();
+      } catch {
+        return false;
+      }
+    });
+    logIdeOpenTrace(
+      `rider.discovery candidates=${candidates.length} existing=${existing.length} registry=${registryInstallLocations.length}`,
+    );
+    for (const candidate of existing)
+      logIdeOpenTrace(`rider.discovery.path path="${clampLogValue(candidate)}"`);
+    return existing;
+  })().catch((error) => {
+    logIdeOpenTrace(`rider.discovery.fail error="${clampLogValue(error)}"`);
+    return [];
+  });
+
+  try {
+    const paths = await riderExecutablePathsPromise;
+    riderExecutablePathsCache = {
+      paths,
+      expiresAt: Date.now() + RIDER_EXECUTABLE_PATHS_CACHE_TTL_MS,
+    };
+    return paths;
+  } finally {
+    riderExecutablePathsPromise = null;
+  }
+}
+
+/**
  * 中文说明：判定命令候选是否为绝对路径。
  */
 function isAbsoluteCommandPath(cmd: string): boolean {
@@ -6383,24 +6501,18 @@ async function tryOpenPathAtPositionWithRider(targetPath: string, line: number):
       if (ok) return true;
     } catch {}
   } else if (platform === "win32") {
-    try {
-      const ok = await spawnDetachedSafe("rider64.exe", ["--line", lineArg, p], {
-        windowsHide: false,
-        timeoutMs: 1600,
-        minAliveMs: 0,
-        acceptExit0BeforeMinAliveMs: true,
-      });
-      if (ok) return true;
-    } catch {}
-    try {
-      const ok = await spawnDetachedSafe("rider.exe", ["--line", lineArg, p], {
-        windowsHide: false,
-        timeoutMs: 1600,
-        minAliveMs: 0,
-        acceptExit0BeforeMinAliveMs: true,
-      });
-      if (ok) return true;
-    } catch {}
+    const candidates = await getRiderExecutablePaths();
+    for (const executable of candidates) {
+      try {
+        const ok = await tryLaunchEditorCommand(
+          { file: executable, args: ["--line", lineArg, p] },
+          2200,
+        );
+        if (ok) return true;
+      } catch {}
+    }
+    logIdeOpenTrace(`rider.fail candidates=${candidates.length} path="${clampLogValue(p)}"`);
+    return false;
   } else {
     try {
       const ok = await spawnDetachedSafe("rider", ["--line", lineArg, p], {

--- a/electron/riderPaths.test.ts
+++ b/electron/riderPaths.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { buildRiderExecutableCandidates, parseRiderRegistryInstallLocations } from "./riderPaths";
+
+describe("riderPaths", () => {
+  it("只解析 Rider 注册表项并去掉引号", () => {
+    const raw = [
+      "HKEY_LOCAL_MACHINE\\Software\\...\\JetBrains Rider 2026.1.3",
+      "    InstallLocation    REG_SZ    \"X:\\Apps\\JetBrains\\JetBrains Rider 2026.1.3\"",
+      "",
+      "HKEY_LOCAL_MACHINE\\Software\\...\\Other Editor",
+      "    InstallLocation    REG_SZ    X:\\Apps\\Other Editor",
+      "",
+      "HKEY_CURRENT_USER\\Software\\...\\JetBrains Toolbox (Rider)",
+      "    InstallLocation    REG_SZ    X:\\Apps\\JetBrains Rider (old)",
+      "",
+      "HKEY_CURRENT_USER\\Software\\...\\JetBrains Rider Preview",
+      "    InstallLocation    REG_EXPAND_SZ    %LOCALAPPDATA%\\Programs\\Rider",
+    ].join("\r\n");
+
+    expect(parseRiderRegistryInstallLocations(raw)).toEqual([
+      "X:\\Apps\\JetBrains\\JetBrains Rider 2026.1.3",
+      "X:\\Apps\\JetBrains Rider (old)",
+      "%LOCALAPPDATA%\\Programs\\Rider",
+    ]);
+  });
+
+  it("只生成真实可执行文件候选，不使用 Toolbox 启动脚本", () => {
+    const candidates = buildRiderExecutableCandidates({
+      platform: "win32",
+      pathEntries: ["X:\\Toolbox\\scripts"],
+      registryInstallLocations: ["X:\\Apps\\JetBrains\\JetBrains Rider 2026.1.3"],
+    });
+
+    expect(candidates).toEqual([
+      "X:\\Toolbox\\scripts\\rider64.exe",
+      "X:\\Toolbox\\scripts\\rider.exe",
+      "X:\\Apps\\JetBrains\\JetBrains Rider 2026.1.3\\bin\\rider64.exe",
+      "X:\\Apps\\JetBrains\\JetBrains Rider 2026.1.3\\bin\\rider.exe",
+    ]);
+    expect(candidates.some((candidate) => /Rider\.cmd$/i.test(candidate))).toBe(false);
+  });
+
+  it("规范带引号的 PATH 并展开注册表环境变量", () => {
+    const candidates = buildRiderExecutableCandidates({
+      platform: "win32",
+      pathEntries: ["\"X:\\Tools\\Rider\\bin\""],
+      registryInstallLocations: ["%RIDER_HOME%", "Y:\\Portable\\rider64.exe"],
+      environment: { RIDER_HOME: "Y:\\Apps\\JetBrains Rider" },
+    });
+
+    expect(candidates).toEqual([
+      "X:\\Tools\\Rider\\bin\\rider64.exe",
+      "X:\\Tools\\Rider\\bin\\rider.exe",
+      "Y:\\Apps\\JetBrains Rider\\bin\\rider64.exe",
+      "Y:\\Apps\\JetBrains Rider\\bin\\rider.exe",
+      "Y:\\Portable\\rider64.exe",
+    ]);
+  });
+
+  it("注册表已指向 bin 目录时不重复追加 bin", () => {
+    expect(buildRiderExecutableCandidates({
+      platform: "win32",
+      registryInstallLocations: ["X:\\Apps\\JetBrains Rider\\bin"],
+    })).toEqual([
+      "X:\\Apps\\JetBrains Rider\\bin\\rider64.exe",
+      "X:\\Apps\\JetBrains Rider\\bin\\rider.exe",
+    ]);
+  });
+
+  it("非 Windows 平台不生成 Windows 可执行文件", () => {
+    expect(buildRiderExecutableCandidates({ platform: "linux", registryInstallLocations: ["/opt/rider"] })).toEqual([]);
+  });
+});

--- a/electron/riderPaths.ts
+++ b/electron/riderPaths.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Lulu (GitHub: lulu-sk, https://github.com/lulu-sk/CodexFlow)
+
+import path from "node:path";
+
+const RIDER_EXECUTABLE_NAMES = ["rider64.exe", "rider.exe"] as const;
+
+export type RiderExecutableCandidateOptions = {
+  /** 允许测试时覆盖平台值。 */
+  platform?: NodeJS.Platform;
+  /** PATH 中的目录列表。 */
+  pathEntries?: readonly string[];
+  /** Windows 卸载注册表中的 Rider 安装目录或可执行文件路径。 */
+  registryInstallLocations?: readonly string[];
+  /** 展开注册表路径所使用的环境变量。 */
+  environment?: Readonly<NodeJS.ProcessEnv>;
+};
+
+/**
+ * 清理 Windows 路径两端的空白与成对双引号。
+ */
+function normalizeWindowsPathInput(raw: string): string {
+  let value = String(raw || "").trim();
+  if (value.length >= 2 && value.startsWith("\"") && value.endsWith("\""))
+    value = value.slice(1, -1).trim();
+  return value;
+}
+
+/**
+ * 展开 REG_EXPAND_SZ 等路径中的 Windows 环境变量占位符。
+ * 未定义的变量保持原样，避免把路径静默改成错误位置。
+ */
+function expandWindowsEnvironmentVariables(
+  value: string,
+  environment: Readonly<NodeJS.ProcessEnv>,
+): string {
+  const values = new Map<string, string>();
+  for (const [name, rawValue] of Object.entries(environment)) {
+    if (typeof rawValue !== "string") continue;
+    values.set(name.toLowerCase(), rawValue);
+  }
+  return value.replace(/%([^%]+)%/g, (token, name: string) => values.get(name.toLowerCase()) ?? token);
+}
+
+/**
+ * 解析 Windows `reg query ... /s /v InstallLocation` 输出中的 Rider 安装目录。
+ * 仅接受注册表项名称或安装目录明确包含 Rider 的块，避免把其他软件目录误当成 IDE。
+ */
+export function parseRiderRegistryInstallLocations(raw: string): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  /**
+   * 追加去重后的注册表安装位置。
+   */
+  const append = (value: string) => {
+    const normalized = normalizeWindowsPathInput(value).replace(/[\\/]+$/, "");
+    if (!normalized) return;
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.push(normalized);
+  };
+
+  const blocks = String(raw || "").split(/(?=^HKEY_[^\r\n]*(?:\r?\n|$))/im);
+  for (const block of blocks) {
+    const header = block.match(/^HKEY_[^\r\n]*/im)?.[0] || "";
+    const installLocation = block.match(/^\s*InstallLocation\s+REG_(?:SZ|EXPAND_SZ)\s+(.+?)\s*$/im)?.[1] || "";
+    if (!installLocation) continue;
+    if (!/rider/i.test(header) && !/rider/i.test(installLocation)) continue;
+    append(installLocation);
+  }
+  return result;
+}
+
+/**
+ * 根据 PATH 和注册表安装目录构造 Rider 可执行文件候选列表。
+ * 不生成 `Rider.cmd` 等 Toolbox 启动脚本，避免脚本内部仍指向已卸载版本。
+ */
+export function buildRiderExecutableCandidates(options: RiderExecutableCandidateOptions = {}): string[] {
+  const platform = options.platform || process.platform;
+  if (platform !== "win32") return [];
+
+  const candidates: string[] = [];
+  const seen = new Set<string>();
+  const environment = options.environment || process.env;
+  /**
+   * 追加去重后的可执行文件候选路径。
+   */
+  const append = (value: string) => {
+    const normalized = normalizeWindowsPathInput(value);
+    if (!normalized) return;
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    candidates.push(normalized);
+  };
+  /**
+   * 将安装目录或直接的 exe 路径转换为 Rider 可执行文件候选。
+   */
+  const appendFromLocation = (rawLocation: string) => {
+    const location = expandWindowsEnvironmentVariables(
+      normalizeWindowsPathInput(rawLocation),
+      environment,
+    );
+    if (!location) return;
+    if (/\.exe$/i.test(location)) {
+      append(location);
+      return;
+    }
+    const normalizedLocation = location.replace(/[\\/]+$/, "");
+    const binLocation = /[\\/]bin$/i.test(normalizedLocation)
+      ? normalizedLocation
+      : path.win32.join(normalizedLocation, "bin");
+    for (const executable of RIDER_EXECUTABLE_NAMES)
+      append(path.win32.join(binLocation, executable));
+  };
+
+  for (const entry of options.pathEntries || []) {
+    const directory = expandWindowsEnvironmentVariables(
+      normalizeWindowsPathInput(entry),
+      environment,
+    );
+    if (!directory) continue;
+    for (const executable of RIDER_EXECUTABLE_NAMES)
+      append(path.win32.join(directory, executable));
+  }
+  for (const location of options.registryInstallLocations || []) appendFromLocation(location);
+  return candidates;
+}


### PR DESCRIPTION
JetBrains Toolbox 生成的启动脚本可能仍指向已卸载版本，导致打开项目或按行跳转文件时出现找不到旧版 rider64.exe 的错误。

- 从 PATH 与 Windows 卸载注册表收集真实 Rider 可执行文件候选
- 跳过 Toolbox 批处理脚本，并过滤不存在或不是文件的旧路径
- 兼容带引号路径和 REG_EXPAND_SZ 环境变量，限制注册表查询时间
- 短期缓存发现结果，使 Rider 安装或升级后无需重启应用即可恢复
- 补充注册表解析、候选生成和跨平台行为测试