### PR TITLE
fix(git): 修复 Git 面板刷新闪烁与根提交详情

### DIFF
--- a/electron/git/featureService.commit-details.test.ts
+++ b/electron/git/featureService.commit-details.test.ts
@@ -123,7 +123,7 @@ describe("featureService commit details actions", () => {
     const escapedHash = hash.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const patterns = [
       new RegExp(`\\bshow -s --date=iso-strict\\b.* ${escapedHash}$`),
-      new RegExp(`\\bdiff-tree --no-commit-id --name-status -r -M ${escapedHash}$`),
+      new RegExp(`\\bdiff-tree --root --no-commit-id --name-status -r -M ${escapedHash}$`),
       new RegExp(`\\bshow --numstat --format= ${escapedHash}$`),
       new RegExp(`\\bbranch --contains ${escapedHash}$`),
       new RegExp(`\\btag --contains ${escapedHash}$`),
@@ -165,6 +165,41 @@ describe("featureService commit details actions", () => {
     });
     expect(res.ok).toBe(true);
   }
+
+  it(
+    "log.details 应正确返回根提交的文件列表与行统计",
+    async () => {
+      const repo = await fsp.mkdtemp(path.join(os.tmpdir(), "codexflow-details-root-repo-"));
+      const userDataPath = await fsp.mkdtemp(path.join(os.tmpdir(), "codexflow-details-root-userdata-"));
+      try {
+        await gitAsync(repo, ["init", "-b", "master"]);
+        await gitAsync(repo, ["config", "user.name", "CodexFlow"]);
+        await gitAsync(repo, ["config", "user.email", "codexflow@example.com"]);
+        await writeFileAsync(repo, "README.md", "first line\nsecond line\n");
+        await gitAsync(repo, ["add", "README.md"]);
+        await gitAsync(repo, ["commit", "-m", "root"]);
+        const rootHash = (await gitAsync(repo, ["rev-parse", "HEAD"])).trim();
+
+        const res = await dispatchGitFeatureAction({
+          action: "log.details",
+          payload: { repoPath: repo, hashes: [rootHash] },
+          userDataPath,
+        });
+
+        expect(res.ok).toBe(true);
+        expect(res.data?.mode).toBe("single");
+        expect(res.data?.detail?.parents).toEqual([]);
+        expect(res.data?.detail?.files).toEqual([
+          { status: "A", path: "README.md" },
+        ]);
+        expect(res.data?.detail?.lineStats).toEqual({ additions: 2, deletions: 0 });
+      } finally {
+        try { await fsp.rm(repo, { recursive: true, force: true }); } catch {}
+        try { await fsp.rm(userDataPath, { recursive: true, force: true }); } catch {}
+      }
+    },
+    { timeout: 120_000 },
+  );
 
   it(
     "log.details 对同一提交应复用缓存与在途请求，避免 amend/详情面板重复执行 Git 详情查询",

--- a/electron/git/featureService.operation.test.ts
+++ b/electron/git/featureService.operation.test.ts
@@ -1307,7 +1307,7 @@ describe("featureService dedicated file history", () => {
         .map((entry) => String(entry.command || ""))
         .filter((command) => command.includes(" log ") || command.includes(" diff-tree ") || command.includes(" show "));
       expect(commands.some((command) => command.includes(" log ") && command.includes("--follow"))).toBe(false);
-      expect(commands.some((command) => command.includes(" diff-tree --no-commit-id --name-status -r -M"))).toBe(true);
+      expect(commands.some((command) => command.includes(" diff-tree --root --no-commit-id --name-status -r -M"))).toBe(true);
     } finally {
       await fixture.cleanup();
     }

--- a/electron/git/featureService.ts
+++ b/electron/git/featureService.ts
@@ -3594,7 +3594,7 @@ async function collectDedicatedFileHistoryEntriesAsync(
  * 读取单个提交的变更文件列表，并尽量识别重命名后保留旧路径信息。
  */
 async function getCommitChangedFilesAsync(ctx: GitFeatureContext, repoRoot: string, hash: string): Promise<GitCommitChangedFile[]> {
-  const res = await runGitExecAsync(ctx, repoRoot, ["diff-tree", "--no-commit-id", "--name-status", "-r", "-M", hash], 12_000);
+  const res = await runGitExecAsync(ctx, repoRoot, ["diff-tree", "--root", "--no-commit-id", "--name-status", "-r", "-M", hash], 12_000);
   if (!res.ok) return [];
   return parseCommitChangedFiles(res.stdout);
 }

--- a/web/src/features/git/commit-panel/commit-tree-pane.test.tsx
+++ b/web/src/features/git/commit-panel/commit-tree-pane.test.tsx
@@ -125,6 +125,7 @@ function renderCommitTreePane(input: {
   groupExpanded?: Record<string, boolean>;
   treeExpanded?: Record<string, boolean>;
   activeChangeListId?: string;
+  busy?: boolean;
   localChangesConfig?: { stagingAreaEnabled: boolean; changeListsEnabled: boolean };
   onInvokeEntryAction?: (entry: GitStatusEntry, intent: "doubleClick" | "f4" | "enter" | "singleClick") => void;
   onInvokeHoverAction?: (node: any, action: CommitTreeNodeAction) => void;
@@ -155,6 +156,7 @@ function renderCommitTreePane(input: {
         activeChangeListId={input.activeChangeListId || "default"}
         selectedDiffableEntry={input.selectedDiffableEntry}
         ignoredLoading={false}
+        busy={input.busy}
         containerRef={containerRef}
         onActivate={() => {}}
         onSelectRow={() => {}}
@@ -186,6 +188,53 @@ describe("CommitTreePane", () => {
   afterEach(() => {
     try { cleanup?.(); } catch {}
     cleanup = null;
+  });
+
+  it("刷新期间应保留已有树内容，并只显示加载层", () => {
+    const entry = createEntry({ path: "src/app.ts" });
+    const rendered = renderCommitTreePane({
+      groups: [createGroup({
+        key: "cl:default",
+        label: "默认",
+        entries: [entry],
+        kind: "changelist",
+        changeListId: "default",
+        treeRows: [{
+          node: {
+            key: "node:src/app.ts",
+            name: "app.ts",
+            fullPath: "src/app.ts",
+            isFile: true,
+            filePaths: ["src/app.ts"],
+            fileCount: 1,
+            count: 1,
+            kind: "file",
+            children: [],
+            entry,
+          },
+          depth: 0,
+        }],
+        treeNodes: [{
+          key: "node:src/app.ts",
+          name: "app.ts",
+          fullPath: "src/app.ts",
+          isFile: true,
+          filePaths: ["src/app.ts"],
+          fileCount: 1,
+          count: 1,
+          kind: "file",
+          children: [],
+          entry,
+        }],
+      })],
+      statusEntryByPath: new Map([["src/app.ts", entry]]),
+      busy: true,
+    });
+    cleanup = rendered.cleanup;
+
+    expect(rendered.host.textContent).toContain("app.ts");
+    expect(rendered.host.querySelector('[data-testid="commit-tree-loading-overlay"]')).not.toBeNull();
+    expect(rendered.host.querySelector('[data-testid="commit-node-node:src/app.ts"]')).not.toBeNull();
   });
 
   it("应展示空 changelist，并标记当前活动列表", () => {

--- a/web/src/features/git/commit-panel/commit-tree-pane.tsx
+++ b/web/src/features/git/commit-panel/commit-tree-pane.tsx
@@ -658,7 +658,8 @@ export function CommitTreePane(props: CommitTreePaneProps): React.ReactElement {
       <div
         ref={virtual.containerRef}
         data-testid="commit-tree-scroll"
-        className="min-h-0 h-full overflow-auto cf-scroll-area outline-none"
+        className="relative min-h-0 h-full overflow-auto cf-scroll-area outline-none"
+        aria-busy={busy || undefined}
         tabIndex={0}
         onFocus={onActivate}
         onBlur={(event) => {
@@ -783,7 +784,7 @@ export function CommitTreePane(props: CommitTreePaneProps): React.ReactElement {
           }
         }}
       >
-        {busy ? (
+        {busy && renderRows.length === 0 ? (
           <div className="cf-git-empty-panel flex h-full items-center justify-center gap-2 px-4 text-center text-xs text-[var(--cf-text-secondary)]">
             <Loader2 className="h-4 w-4 animate-spin" />
             {gt("commitTree.loading", "正在刷新变更树")}
@@ -1084,6 +1085,18 @@ export function CommitTreePane(props: CommitTreePaneProps): React.ReactElement {
             <div style={{ height: virtual.windowState.bottom }} />
           </div>
         )}
+        {busy && renderRows.length > 0 ? (
+          <div
+            data-testid="commit-tree-loading-overlay"
+            role="status"
+            className="pointer-events-auto absolute inset-0 z-10 flex cursor-wait items-start justify-center pt-2"
+          >
+            <div className="flex items-center gap-2 rounded-apple-sm border border-[var(--cf-border)] bg-[var(--cf-surface-solid)] px-2 py-1 text-[11px] text-[var(--cf-text-secondary)] shadow-apple-sm">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              {gt("commitTree.loading", "正在刷新变更树")}
+            </div>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/web/src/features/git/log-graph/use-visible-pack.ts
+++ b/web/src/features/git/log-graph/use-visible-pack.ts
@@ -33,18 +33,18 @@ function buildGitLogVisiblePackSignature(
   graphItems: GitLogItem[] | undefined,
   fileHistoryMode: boolean,
 ): string {
-  const visibleHead = items.slice(0, 3).map((item) => item.hash).join(",");
-  const visibleTail = items.slice(-3).map((item) => item.hash).join(",");
-  const graphHead = (graphItems || []).slice(0, 3).map((item) => item.hash).join(",");
-  const graphTail = (graphItems || []).slice(-3).map((item) => item.hash).join(",");
+  /**
+   * 将图谱布局实际依赖的提交字段编码为稳定签名片段。
+   */
+  const serialize = (source: GitLogItem[] | undefined): string => (source || []).map((item) => [
+    String(item.hash || ""),
+    Array.isArray(item.parents) ? item.parents.join(",") : "",
+    String(item.decorations || ""),
+  ].join("\u0001")).join("\u0002");
   return [
     fileHistoryMode ? "file" : "log",
-    items.length,
-    visibleHead,
-    visibleTail,
-    graphItems?.length || 0,
-    graphHead,
-    graphTail,
+    serialize(items),
+    serialize(graphItems),
   ].join("|");
 }
 
@@ -124,7 +124,7 @@ export function useGitLogVisiblePack(args: {
     return () => {
       window.removeEventListener(GIT_LOG_GRAPH_LIGHT_MODE_EVENT, onLightMode as EventListener);
     };
-  }, [items]);
+  }, [signature]);
 
   useEffect(() => {
     const requestId = requestSeqRef.current + 1;
@@ -206,7 +206,7 @@ export function useGitLogVisiblePack(args: {
       try { worker.terminate(); } catch {}
       if (workerRef.current === worker) workerRef.current = null;
     };
-  }, [args.fileHistoryMode, graphItems, items, retrySeq, signature]);
+  }, [args.fileHistoryMode, retrySeq, signature]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
修复 Git 工作台在自动刷新和大日志场景下的视觉抖动，并补齐根提交的变更文件识别。

变更内容：
- 刷新提交树时保留已有内容，仅显示加载覆盖层，避免整棵树在 busy 状态下反复销毁重建。
- 按提交哈希、父提交和引用信息生成稳定的图谱输入签名，避免数组引用变化反复切换占位图谱。
- 为提交文件列表的 git diff-tree 调用增加 --root，使根提交正确显示新增文件。
- 增加刷新期间树内容保留和根提交文件/行统计回归测试。

验证：
- npm run test
- npm run typecheck:web
- npm run i18n:check
- npm run build:web
- npm run build:electron