### PR TITLE
feat(terminal): 增加终端代理继承开关

### DIFF
--- a/electron/pty.test.ts
+++ b/electron/pty.test.ts
@@ -7,6 +7,7 @@ const settingsMock = vi.hoisted(() => ({
   },
   getSettings: vi.fn(),
   getTerminalCapabilitySettings: vi.fn(),
+  getTerminalProxyEnabled: vi.fn(() => true),
 }));
 
 vi.mock('node-pty', () => ({
@@ -30,6 +31,7 @@ vi.mock('./settings.js', () => ({
       settingsMock.getTerminalCapabilitySettings();
       return settingsMock.terminalCapabilities;
     },
+    getTerminalProxyEnabled: () => settingsMock.getTerminalProxyEnabled(),
   },
 }));
 
@@ -50,6 +52,8 @@ describe('PTYManager', () => {
     settingsMock.terminalCapabilities.trueColor = false;
     settingsMock.getSettings.mockClear();
     settingsMock.getTerminalCapabilitySettings.mockClear();
+    settingsMock.getTerminalProxyEnabled.mockReset();
+    settingsMock.getTerminalProxyEnabled.mockReturnValue(true);
   });
 
   /**
@@ -230,6 +234,30 @@ describe('PTYManager', () => {
       if (previousNoColor === undefined) delete process.env.NO_COLOR;
       else process.env.NO_COLOR = previousNoColor;
     }
+  });
+
+  it('关闭终端代理时应清理代理变量并保留显式绕过策略', async () => {
+    const { win } = createWindowStub();
+    const manager = new PTYManager(() => [win as any]);
+    const spawn = vi.mocked(pty.spawn);
+    spawn.mockReset();
+    spawn.mockReturnValue(createPtyStub() as any);
+    settingsMock.getTerminalProxyEnabled.mockReturnValue(false);
+
+    await manager.openWSLConsole({
+      terminal: 'pwsh',
+      env: {
+        HTTP_PROXY: 'http://127.0.0.1:7890',
+        https_proxy: 'http://127.0.0.1:7890',
+        WSLENV: 'HTTP_PROXY/u:CODEXFLOW_PROXY/u:TERM/u',
+      },
+    });
+
+    const env = spawn.mock.calls[0]?.[2]?.env as Record<string, string>;
+    expect(env).not.toHaveProperty('HTTP_PROXY');
+    expect(env).not.toHaveProperty('https_proxy');
+    expect(env).toHaveProperty('NO_PROXY', '*');
+    expect(env.WSLENV).toBe('TERM/u');
   });
 
   it('内置和系统 ConPTY 都失败时才应把 WSL 切换为 PowerShell', async () => {

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -160,6 +160,47 @@ function mergeExtraEnv(base: Record<string, string>, extra?: Record<string, stri
   return next;
 }
 
+const TERMINAL_PROXY_ENV_KEYS = [
+  "CODEXFLOW_PROXY",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+  "npm_config_proxy",
+  "npm_config_https_proxy",
+  "npm_config_noproxy",
+  "GIT_HTTP_PROXY",
+  "GIT_HTTPS_PROXY",
+  "GIT_PROXY_COMMAND",
+  "NO_PROXY",
+  "no_proxy",
+] as const;
+
+/**
+ * 清理终端环境中的代理变量，并让常见网络库默认绕过所有地址。
+ * @param env - 即将传给 PTY 的环境变量
+ */
+export function stripTerminalProxyEnvironment(env: Record<string, string>): Record<string, string> {
+  const next = { ...env };
+  for (const key of TERMINAL_PROXY_ENV_KEYS) delete next[key];
+  next.NO_PROXY = "*";
+  next.no_proxy = "*";
+  if (typeof next.WSLENV === "string") {
+    const blocked = new Set(TERMINAL_PROXY_ENV_KEYS.map((key) => key.toLowerCase()));
+    next.WSLENV = next.WSLENV
+      .split(":")
+      .filter((item) => {
+        const base = String(item || "").split("/")[0].trim().toLowerCase();
+        return base && !blocked.has(base);
+      })
+      .join(":");
+    if (!next.WSLENV) delete next.WSLENV;
+  }
+  return next;
+}
+
 /**
  * 中文说明：将指定环境变量名追加到 WSLENV，确保传递到 WSL。
  */
@@ -470,6 +511,10 @@ export class PTYManager {
       { ...process.env } as Record<string, string>,
     );
     env = mergeExtraEnv(env, opts.env);
+    const terminalProxyEnabled = typeof (settings as any).getTerminalProxyEnabled === "function"
+      ? (settings as any).getTerminalProxyEnabled() !== false
+      : true;
+    if (!terminalProxyEnabled) env = stripTerminalProxyEnvironment(env);
     const terminalCapabilities = normalizeTerminalCapabilitySettings(
       settings.getTerminalCapabilitySettings(),
     );
@@ -523,10 +568,13 @@ export class PTYManager {
         }
       }
       if (os.platform() === 'win32') {
+        const blockedProxyKeys = new Set(TERMINAL_PROXY_ENV_KEYS.map((key) => key.toLowerCase()));
         const keys = [
           ...Object.keys(opts.env || {}),
           ...capabilityEnvKeys,
-        ].map((key) => String(key || "").trim()).filter(Boolean);
+        ].map((key) => String(key || "").trim())
+          .filter(Boolean)
+          .filter((key) => terminalProxyEnabled || !blockedProxyKeys.has(key.toLowerCase()));
         if (keys.length > 0) env.WSLENV = appendWslEnv(env.WSLENV, keys);
       }
       try {

--- a/electron/settings.ts
+++ b/electron/settings.ts
@@ -29,6 +29,8 @@ export type NotificationSettings = {
 export type NetworkSettings = {
   /** 是否启用代理（默认启用） */
   proxyEnabled?: boolean;
+  /** 新打开的终端是否继承代理环境变量（默认启用） */
+  terminalProxyEnabled?: boolean;
   /** 代理模式：跟随系统或自定义 */
   proxyMode?: 'system' | 'custom';
   /** 自定义代理地址（如 http://127.0.0.1:7890） */
@@ -228,6 +230,7 @@ let cachedDistrosAt = 0;
 let cachedTerminalCapabilitySettings: Required<TerminalCapabilitySettings> = {
   ...DEFAULT_TERMINAL_CAPABILITIES,
 };
+let cachedTerminalProxyEnabled = true;
 const DEFAULT_NOTIFICATIONS: NotificationSettings = {
   badge: true,
   system: true,
@@ -236,6 +239,7 @@ const DEFAULT_NOTIFICATIONS: NotificationSettings = {
 };
 const DEFAULT_NETWORK: NetworkSettings = {
   proxyEnabled: true,
+  terminalProxyEnabled: true,
   proxyMode: 'system',
   proxyUrl: '',
   noProxy: '',
@@ -759,10 +763,12 @@ export function getSettings(): AppSettings {
       : {};
     const next = mergeWithDefaults(parsed, distros);
     cachedTerminalCapabilitySettings = normalizeTerminalCapabilitySettings(next.terminalCapabilities);
+    cachedTerminalProxyEnabled = next.network?.terminalProxyEnabled !== false;
     return next;
   } catch (e) {
     const next = defaultSettings();
     cachedTerminalCapabilitySettings = normalizeTerminalCapabilitySettings(next.terminalCapabilities);
+    cachedTerminalProxyEnabled = next.network?.terminalProxyEnabled !== false;
     return next;
   }
 }
@@ -772,6 +778,13 @@ export function getSettings(): AppSettings {
  */
 export function getTerminalCapabilitySettings(): Required<TerminalCapabilitySettings> {
   return { ...cachedTerminalCapabilitySettings };
+}
+
+/**
+ * 返回内存中的终端代理设置，供 PTY 打开热路径使用。
+ */
+export function getTerminalProxyEnabled(): boolean {
+  return cachedTerminalProxyEnabled;
 }
 
 export function updateSettings(partial: Partial<AppSettings>) {
@@ -785,6 +798,12 @@ export function updateSettings(partial: Partial<AppSettings>) {
       const patch = (partial as any)?.terminalCapabilities;
       if (patch && typeof patch === "object")
         (mergedRaw as any).terminalCapabilities = { ...current, ...patch };
+    } catch {}
+    // 对 network 做浅层合并，避免只更新一个代理开关时覆盖其它网络偏好。
+    try {
+      const curNetwork = (cur as any)?.network && typeof (cur as any).network === "object" ? (cur as any).network : {};
+      const nextNetwork = (partial as any)?.network && typeof (partial as any).network === "object" ? (partial as any).network : null;
+      if (nextNetwork) (mergedRaw as any).network = { ...curNetwork, ...nextNetwork };
     } catch {}
     // 对 dragDrop 做浅层合并，避免渲染层只更新单个字段时覆盖其它子字段
     try {
@@ -839,6 +858,7 @@ export function updateSettings(partial: Partial<AppSettings>) {
     const next = mergeWithDefaults(mergedRaw, distros);
     fs.writeFileSync(getStorePath(), JSON.stringify(next, null, 2), 'utf8');
     cachedTerminalCapabilitySettings = normalizeTerminalCapabilitySettings(next.terminalCapabilities);
+    cachedTerminalProxyEnabled = next.network?.terminalProxyEnabled !== false;
     return next;
   } catch (e) {
     return getSettings();
@@ -909,6 +929,7 @@ export async function ensureFirstRunTerminalSelection(): Promise<AppSettings> {
 export default {
   getSettings,
   getTerminalCapabilitySettings,
+  getTerminalProxyEnabled,
   updateSettings,
   hasSettingsStore,
   hasSavedRuntimeEnvSelection,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5726,7 +5726,7 @@ export default function CodexFlowManagerUI() {
   // Claude Code：是否读取 agent-*.jsonl 等不推荐历史（仅影响历史索引/预览）。
   const [claudeCodeReadAgentHistory, setClaudeCodeReadAgentHistory] = useState<boolean>(false);
   // 网络代理设置（用于设置对话框初始值与回显）
-  const [networkPrefs, setNetworkPrefs] = useState<NetworkPrefs>({ proxyEnabled: true, proxyMode: "system", proxyUrl: "", noProxy: "" });
+  const [networkPrefs, setNetworkPrefs] = useState<NetworkPrefs>({ proxyEnabled: true, terminalProxyEnabled: true, proxyMode: "system", proxyUrl: "", noProxy: "" });
   // ChatGPT/Codex：是否启用“记录账号”（用于自动备份与快速切换）
   const [codexAccountRecordEnabled, setCodexAccountRecordEnabled] = useState<boolean>(false);
   // 默认 IDE 打开策略（用于文件“定位打开”链路）。
@@ -7092,6 +7092,7 @@ export default function CodexFlowManagerUI() {
             const net = (s as any).network || {};
             setNetworkPrefs({
               proxyEnabled: net.proxyEnabled !== false,
+              terminalProxyEnabled: net.terminalProxyEnabled !== false,
               proxyMode: net.proxyMode === 'custom' ? 'custom' : 'system',
               proxyUrl: String(net.proxyUrl || ''),
               noProxy: String(net.noProxy || ''),

--- a/web/src/app/app-shared.tsx
+++ b/web/src/app/app-shared.tsx
@@ -1641,6 +1641,7 @@ type CompletionPreferences = {
 // 网络代理偏好（与设置对话框保持一致）
 type NetworkPrefs = {
   proxyEnabled: boolean;
+  terminalProxyEnabled: boolean;
   proxyMode: "system" | "custom";
   proxyUrl: string;
   noProxy: string;

--- a/web/src/features/settings/settings-dialog.tsx
+++ b/web/src/features/settings/settings-dialog.tsx
@@ -106,6 +106,7 @@ type GitWorktreePrefs = {
 };
 type NetworkPrefs = {
   proxyEnabled: boolean;
+  terminalProxyEnabled: boolean;
   proxyMode: "system" | "custom";
   proxyUrl: string;
   noProxy: string;
@@ -629,6 +630,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
   const [codexErrorHandling, setCodexErrorHandling] = useState<CodexErrorHandlingPrefs>(() => normalizeCodexErrorHandlingPrefs(values.codexErrorHandling));
   const [network, setNetwork] = useState<NetworkPrefs>({
     proxyEnabled: values.network?.proxyEnabled ?? true,
+    terminalProxyEnabled: values.network?.terminalProxyEnabled ?? true,
     proxyMode: values.network?.proxyMode ?? "system",
     proxyUrl: values.network?.proxyUrl ?? "",
     noProxy: values.network?.noProxy ?? "",
@@ -790,6 +792,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
     setCodexErrorHandling(normalizeCodexErrorHandlingPrefs(values.codexErrorHandling));
     setNetwork({
       proxyEnabled: values.network?.proxyEnabled ?? true,
+      terminalProxyEnabled: values.network?.terminalProxyEnabled ?? true,
       proxyMode: values.network?.proxyMode ?? "system",
       proxyUrl: values.network?.proxyUrl ?? "",
       noProxy: values.network?.noProxy ?? "",
@@ -2785,6 +2788,18 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                       <div>
                         <div className="text-sm font-medium text-slate-800 dark:text-[var(--cf-text-primary)]">{t("settings:network.enable")}</div>
                         <p className="text-xs text-slate-500 dark:text-[var(--cf-text-secondary)]">{t("settings:network.enableDesc")}</p>
+                      </div>
+                    </label>
+                    <label className="flex items-start gap-3 rounded-lg border border-slate-200/70 bg-white/60 px-3 py-3 shadow-sm dark:border-[var(--cf-border)] dark:bg-[var(--cf-surface-muted)] dark:text-[var(--cf-text-primary)]">
+                      <input
+                        type="checkbox"
+                        className="mt-1 h-4 w-4 rounded border-slate-300 text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-[var(--cf-border)] dark:bg-[var(--cf-surface)] dark:checked:bg-[var(--cf-accent)] dark:focus-visible:ring-[var(--cf-accent)]/40"
+                        checked={network.terminalProxyEnabled}
+                        onChange={(e) => setNetwork((v) => ({ ...v, terminalProxyEnabled: e.target.checked }))}
+                      />
+                      <div>
+                        <div className="text-sm font-medium text-slate-800 dark:text-[var(--cf-text-primary)]">{t("settings:network.terminalEnable")}</div>
+                        <p className="text-xs text-slate-500 dark:text-[var(--cf-text-secondary)]">{t("settings:network.terminalEnableDesc")}</p>
                       </div>
                     </label>
                     <div className="grid gap-3 sm:grid-cols-[180px_1fr] items-center">

--- a/web/src/locales/en/settings.json
+++ b/web/src/locales/en/settings.json
@@ -135,6 +135,8 @@
     "desc": "Make all in-app requests follow your proxy (default: on).",
     "enable": "Enable proxy for network requests",
     "enableDesc": "When enabled, CodexFlow will proxy rate-limit checks and other requests.",
+    "terminalEnable": "Use proxy for new terminals",
+    "terminalEnableDesc": "When disabled, new PowerShell, CMD, and WSL terminals will not inherit common proxy environment variables. Existing terminals are unchanged.",
     "mode": "Proxy mode",
     "modeSystem": "Follow system proxy",
     "modeCustom": "Custom proxy URL",

--- a/web/src/locales/zh/settings.json
+++ b/web/src/locales/zh/settings.json
@@ -135,6 +135,8 @@
     "desc": "让应用内请求走代理（默认开启）以保证海外服务可达。",
     "enable": "启用代理网络",
     "enableDesc": "开启后，用量/更新等网络请求将按下方模式走代理。",
+    "terminalEnable": "让新终端使用代理",
+    "terminalEnableDesc": "关闭后，新打开的 PowerShell、CMD 和 WSL 终端不会继承常见代理环境变量；已运行的终端不受影响。",
     "mode": "代理模式",
     "modeSystem": "跟随系统代理",
     "modeCustom": "自定义代理地址",

--- a/web/src/types/host.d.ts
+++ b/web/src/types/host.d.ts
@@ -114,6 +114,8 @@ export type AppSettings = {
   /** 网络代理设置 */
   network?: {
     proxyEnabled?: boolean;
+    /** 新打开的终端是否继承代理环境变量（默认启用）。 */
+    terminalProxyEnabled?: boolean;
     proxyMode?: 'system' | 'custom';
     proxyUrl?: string;
     noProxy?: string;


### PR DESCRIPTION
产品变化：
- 在网络代理设置中增加“让新终端使用代理”开关，默认开启，兼容既有配置。
- 关闭后，新建的 PowerShell、CMD、WSL 和本地 shell 终端不再继承应用注入的常见代理环境变量；已运行终端保持不变。
- 同步中英文设置文案和前端设置状态，明确说明该选项只影响新终端。

技术变化：
- 在主进程设置模型中持久化 terminalProxyEnabled，并维护 PTY 热路径所需的内存缓存。
- 创建 PTY 前清理 CODEXFLOW_PROXY、HTTP(S)_PROXY、ALL_PROXY、npm、Git 代理变量及 WSLENV 中对应条目，并设置 NO_PROXY/no_proxy 为通配符。
- 在 WSL 环境变量拼装阶段阻止代理变量重新加入 WSLENV，避免绕过清理逻辑。
- 对 network 设置执行浅层合并，更新单个代理开关时保留其它网络偏好。
- 补充关闭终端代理时的 PTY 环境回归测试，并同步 Electron 与 Web 类型定义。

验证：
- npm run test
- npm run i18n:check
- npm run build:electron
- npm run build:web